### PR TITLE
Add support for optional daterange optimization

### DIFF
--- a/Src/grammar/cql.g4
+++ b/Src/grammar/cql.g4
@@ -149,7 +149,7 @@ queryInclusionClause
     ;
 
 retrieve
-    : '[' (occurrence 'of')? topic (',' modality)? (':' (valuesetPathIdentifier 'in')? valueset)? (',' duringPathIdentifier? 'during' expression)? ']'
+    : '[' (occurrence 'of')? topic (',' modality)? (':' (valuesetPathIdentifier 'in')? valueset)? ']'
     ;
 
 occurrence

--- a/Src/java/poc/translator/src/test/java/org/cqframework/cql/poc/translator/TestUtils.java
+++ b/Src/java/poc/translator/src/test/java/org/cqframework/cql/poc/translator/TestUtils.java
@@ -29,6 +29,19 @@ public class TestUtils {
         return createElmTranslatorVisitor(tokens, tree).visit(tree);
     }
 
+    public static Object visitData(String cqlData, boolean enableAnnotations, boolean enableDateRangeOptimization) {
+        TokenStream tokens = parseANTLRInputStream(new ANTLRInputStream(cqlData));
+        ParseTree tree = parseTokenStream(tokens);
+        ElmTranslatorVisitor visitor = createElmTranslatorVisitor(tokens, tree);
+        if (enableAnnotations) {
+            visitor.enableAnnotations();
+        }
+        if (enableDateRangeOptimization) {
+            visitor.enableDateRangeOptimization();
+        }
+        return visitor.visit(tree);
+    }
+
     private static ElmTranslatorVisitor createElmTranslatorVisitor(TokenStream tokens, ParseTree tree) {
         CqlPreprocessorVisitor preprocessor = new CqlPreprocessorVisitor();
         preprocessor.visit(tree);


### PR DESCRIPTION
This pull request adds optional support for detecting "during" clauses that can be refactored from a "where" into the daterange component of a `ClinicalRequest`.  This optimization is turned off by default, but can be enabled via the visitor's `enableDateRangeOptimization` method.  See new unit tests for examples.
