### PR TITLE
- Added 'maven' plugin to java projects

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'idea'
+apply plugin: 'maven'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.1'

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'idea'
 apply plugin:'application'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'

--- a/Src/java/cql-to-js/build.gradle
+++ b/Src/java/cql-to-js/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'findbugs'
 apply plugin: 'pmd'
 apply plugin: 'idea'
 apply plugin: 'application'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'

--- a/Src/java/cql/build.gradle
+++ b/Src/java/cql/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin:'application'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'

--- a/Src/java/elm/build.gradle
+++ b/Src/java/elm/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'

--- a/Src/java/quick/build.gradle
+++ b/Src/java/quick/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'

--- a/Src/java/tools/cql-parsetree/build.gradle
+++ b/Src/java/tools/cql-parsetree/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin:'application'
+apply plugin: 'maven'
 
 group = 'org.cqframework'
 version = '0.1'


### PR DESCRIPTION
'maven' plugin added to all the java projects.
The idea is to enable 'gradle build install' so the generated artifacts can be installed in a maven repository. This allow regular maven projects to make use of these artifacts.
