### PR TITLE
Adding using definitions to Library object.  This information can be …

### DIFF
--- a/Src/coffeescript/cql-execution/package.json
+++ b/Src/coffeescript/cql-execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-execution",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An execution framework for the Clinical Quality Language (CQL)",
   "devDependencies": {
     "coffee-script": "^1.8.0",

--- a/Src/coffeescript/cql-execution/src/elm/library.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/library.coffee
@@ -1,5 +1,9 @@
 module.exports.Library = class Library
   constructor: (json, libraryManager) ->
+    @source = json
+    @usings = []
+    for u in json.library.usings?.def ? []
+      @usings.push {"name" : u.localIdentifier, "version" : u.version} if u.localIdentifier != "System"
     @parameters = {}
     for param in json.library.parameters?.def ? []
       @parameters[param.name] = new ParameterDef(param)

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -21,6 +21,7 @@ define function foo (a Integer, b Integer) :
 
 
 // @Test: Using CommonLib
+using QUICK
 include COM called common
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 

--- a/Src/coffeescript/cql-execution/test/elm/library/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/test.coffee
@@ -22,6 +22,10 @@ describe 'Using CommonLib', ->
   @beforeEach ->
     setup @, data, [ p1, p2 ], {}, {}, new Repository(data)
     
+  it "should have using models defined", ->
+    @lib.usings.should.not.be.empty
+    @lib.usings.length.should.equal 1
+    @lib.usings[0].name.should.equal "QUICK" 
 
   it 'Should have included a library', ->
     @lib.includes.should.not.be.empty


### PR DESCRIPTION
…helpful to match an arbitray json document to a PatientSource provider that supports a given model.  For instance if the library in question is using QUICK then the included FHIR based patient source can be used , if a library is using model FOO then a PatientSource that knows how to deal with those types of records can be used.