### PR TITLE
Very simplistic implimentation of Instance selectors .  This is only …

### DIFF
--- a/Src/coffeescript/cql-execution/src/elm/expressions.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/expressions.coffee
@@ -7,6 +7,7 @@ conditional = require './conditional',
 datetime = require './datetime',
 declaration = require './declaration',
 external = require './external',
+instance = require './instance',
 interval = require './interval',
 list = require './list',
 literal = require './literal',
@@ -21,7 +22,7 @@ type = require './type',
 overloaded = require './overloaded'
 
 libs = [expression, aggregate, arithmetic, clinical, comparison, conditional, datetime, declaration,
-        external, interval, list, literal, logical, nullological, parameters, query, reusable,
+        external, instance, interval, list, literal, logical, nullological, parameters, query, reusable,
         string, structured, type, overloaded]
 for lib in libs
   for element in Object.keys(lib)

--- a/Src/coffeescript/cql-execution/src/elm/instance.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/instance.coffee
@@ -1,0 +1,22 @@
+{ Expression } = require './expression'
+{ build } = require './builder'
+
+class Element 
+  constructor: (json) ->
+    @name = json.name
+    @value = build json.value
+  exec: (ctx) ->
+    @value?.exec(ctx)
+
+
+module.exports.Instance = class Instance extends Expression
+  constructor: (json) ->
+    super
+    @classType = json.classType
+    @element = ( new Element(child) for child in json.element)
+
+  exec: (ctx) ->
+    obj = {}
+    for el in @element
+      obj[el.name] = el.exec(ctx)
+    obj

--- a/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
@@ -1,0 +1,138 @@
+###
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit data.coffee to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+###
+
+### Instance
+library TestSnippet version '1'
+using QUICK
+context Patient
+define Quantity: Quantity {
+  unit: 'a',
+  value: 12
+}
+
+define Med : Medication {
+  name: 'Best Med Ever',
+  isBrand: false
+}
+
+define C : Crap {}
+
+define val: Quantity.value
+###
+
+###
+Translation Error(s):
+[14:17, 14:17] no viable alternative at input '}'
+[14:12, 14:18] A named type is required in this context.
+###
+module.exports['Instance'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "Quantity",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "Instance",
+               "element" : [ {
+                  "name" : "unit",
+                  "value" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "a",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "name" : "value",
+                  "value" : {
+                     "name" : "ToDecimal",
+                     "libraryName" : "System",
+                     "type" : "FunctionRef",
+                     "operand" : [ {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "12",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ]
+            }
+         }, {
+            "name" : "Med",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "classType" : "{http://hl7.org/fhir}Medication",
+               "type" : "Instance",
+               "element" : [ {
+                  "name" : "name",
+                  "value" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "Best Med Ever",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "name" : "isBrand",
+                  "value" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "value" : "false",
+                     "type" : "Literal"
+                  }
+               } ]
+            }
+         }, {
+            "name" : "C",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Null"
+            }
+         }, {
+            "name" : "val",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "path" : "value",
+               "type" : "Property",
+               "source" : {
+                  "name" : "Quantity",
+                  "type" : "ExpressionRef"
+               }
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/instance/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/instance/data.cql
@@ -1,0 +1,16 @@
+// @Test: Instance
+using QUICK
+define Quantity: Quantity {
+  unit: 'a',
+  value: 12
+}
+
+define Med : Medication {
+  name: 'Best Med Ever',
+  isBrand: false
+}
+
+define val: Quantity.value
+
+
+

--- a/Src/coffeescript/cql-execution/test/elm/instance/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/instance/test.coffee
@@ -1,0 +1,17 @@
+should = require 'should'
+setup = require '../../setup'
+data = require './data'
+{ DateTime } = require '../../../lib/datatypes/datetime'
+
+describe 'Instance', ->
+  @beforeEach ->
+    setup @, data
+
+  it 'should create generic json objects with the correct key values', ->
+    @quantity.exec(@ctx).unit.should.eql 'a'
+    @quantity.exec(@ctx).value.should.eql 12
+    @med.exec(@ctx).isBrand.should.eql false
+    @med.exec(@ctx).name.should.eql "Best Med Ever"
+    @val.exec(@ctx).should.eql 12
+
+


### PR DESCRIPTION
…a stop gap until a more robust impl can be produced.  Instance type must come from either the System types such as Quantity or from types declared in models in the using statements.  The translator enforces this so you cannot just supply any type name.  Chances are that this will only work for a simple subset of property types within the definition.  The translator enforces types to be correct so if you attempt to use this in a nested fashion chances are it will break.