### PR TITLE
Types operator support

### DIFF
--- a/Src/coffeescript/cql-execution/Cakefile
+++ b/Src/coffeescript/cql-execution/Cakefile
@@ -11,6 +11,8 @@ build = (src, dest, watch = false) ->
     process.stderr.write data.toString()
   coffee.stdout.on 'data', (data) ->
     console.log data.toString()
+  coffee.on 'exit', (code) ->
+    console.log "Completed transpiling #{src} to #{dest}, exit code #{code}"
 
 buildTestData = (watch = false) ->
   args = if watch then [':cql-to-elm:watchTestData'] else [':cql-to-elm:generateTestData']

--- a/Src/coffeescript/cql-execution/src/elm/quantity.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/quantity.coffee
@@ -10,6 +10,10 @@ module.exports.Quantity = class Quantity extends Expression
 
   exec: (ctx) ->
     @
+  
+  toString: () ->
+    "#{@value}#{@unit}"
+  
   sameOrBefore: (other) ->
     if other instanceof Quantity and other.unit == @unit then @value <= other.value else null
 
@@ -29,6 +33,15 @@ clean_unit = (units) ->
 
 module.exports.createQuantity = (value,unit) ->
   new Quantity({value: value, unit: unit})
+  
+module.exports.parseQuantity = (str) ->
+  components = /(\d+\.?\d*)(.+)/.exec str
+  if components? and components[1]? and components[2]
+    value = parseFloat(components[1])
+    unit = components[2].trim()
+    new Quantity({value: value, unit: unit})
+  else
+    null 
 
 module.exports.doAddition = (a,b) ->
   if a instanceof Quantity and b instanceof Quantity

--- a/Src/coffeescript/cql-execution/src/elm/quantity.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/quantity.coffee
@@ -12,7 +12,7 @@ module.exports.Quantity = class Quantity extends Expression
     @
   
   toString: () ->
-    "#{@value}#{@unit}"
+    "#{@value} '#{@unit}'"
   
   sameOrBefore: (other) ->
     if other instanceof Quantity and other.unit == @unit then @value <= other.value else null
@@ -35,7 +35,7 @@ module.exports.createQuantity = (value,unit) ->
   new Quantity({value: value, unit: unit})
   
 module.exports.parseQuantity = (str) ->
-  components = /(\d+\.?\d*)(.+)/.exec str
+  components = /([+|-]?\d+\.?\d*)\s*'(.+)'/.exec str
   if components? and components[1]? and components[2]
     value = parseFloat(components[1])
     unit = components[2].trim()

--- a/Src/coffeescript/cql-execution/src/elm/type.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/type.coffee
@@ -29,7 +29,21 @@ module.exports.Convert = class Convert extends Expression
     @toType = json.toType
     
   exec: (ctx) ->
-    @execArgs(ctx)
+    arg = @execArgs(ctx)
+    if arg? and typeof arg != 'undefined'
+      strArg = String(arg)
+      switch @toType
+        when "{urn:hl7-org:elm-types:r1}Boolean"
+          if strArg=="true"
+            true
+          else
+            false
+        when "{urn:hl7-org:elm-types:r1}Decimal" then parseFloat(strArg)
+        when "{urn:hl7-org:elm-types:r1}Integer" then parseInt(strArg)
+        else
+          arg
+    else
+      arg
 
 module.exports.Is = class Is extends UnimplementedExpression
 

--- a/Src/coffeescript/cql-execution/src/elm/type.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/type.coffee
@@ -15,47 +15,6 @@ module.exports.As = class As extends Expression
     # TODO: Currently just returns the arg (which works for null, but probably not others)
     @execArgs(ctx)
 
-module.exports.ToStringFunctionRef = class ToStringFunctionRef extends FunctionRef
-  constructor: (json) ->
-    super
-
-  exec: (ctx) ->
-    ary = @execArgs ctx
-    if ary.length > 0  and ary[0]? then ary[0].toString() else null
-
-module.exports.ToBooleanFunctionRef = class ToBooleanFunctionRef extends FunctionRef
-  constructor: (json) ->
-    super
-
-  exec: (ctx) ->
-    ary = @execArgs ctx
-    if ary.length > 0 and ary[0]?
-      switch ary[0]
-        when 'true' then true
-        when 'false' then false
-        else null
-    else
-      null
-
-module.exports.ToIntegerFunctionRef = class ToIntegerFunctionRef extends FunctionRef
-  constructor: (json) ->
-    super
-
-  exec: (ctx) ->
-    ary = @execArgs ctx
-    if ary.length > 0  and ary[0]? then parseInt(ary[0]) else null
-
-module.exports.ToDecimalFunctionRef = class ToDecimalFunctionRef extends FunctionRef
-  constructor: (json) ->
-    super
-
-  exec: (ctx) ->
-    ary = @execArgs ctx
-    if ary.length > 0 and ary[0]?
-      if typeof ary[0] is 'number' then ary[0] else parseFloat(ary[0])
-    else
-      null
-
 module.exports.ToDateTime = class ToDateTime extends FunctionRef
   constructor: (json) ->
     super
@@ -64,7 +23,13 @@ module.exports.ToDateTime = class ToDateTime extends FunctionRef
     ary = @execArgs ctx
     if ary.length > 0  and ary[0]? then DateTime.parse(ary[0]) else null
 
-module.exports.Convert = class Convert extends UnimplementedExpression
+module.exports.Convert = class Convert extends Expression
+  constructor: (json) ->
+    super
+    @toType = json.toType
+    
+  exec: (ctx) ->
+    @execArgs(ctx)
 
 module.exports.Is = class Is extends UnimplementedExpression
 

--- a/Src/coffeescript/cql-execution/src/elm/type.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/type.coffee
@@ -1,6 +1,7 @@
 { Expression, UnimplementedExpression } = require './expression'
 { FunctionRef } = require './reusable'
 { DateTime } = require '../datatypes/datetime'
+{ parseQuantity } = require './quantity'
 
 # TODO: Casting and Conversion needs unit tests!
 
@@ -31,7 +32,7 @@ module.exports.Convert = class Convert extends Expression
   exec: (ctx) ->
     arg = @execArgs(ctx)
     if arg? and typeof arg != 'undefined'
-      strArg = String(arg)
+      strArg = arg.toString()
       switch @toType
         when "{urn:hl7-org:elm-types:r1}Boolean"
           if strArg=="true"
@@ -40,6 +41,8 @@ module.exports.Convert = class Convert extends Expression
             false
         when "{urn:hl7-org:elm-types:r1}Decimal" then parseFloat(strArg)
         when "{urn:hl7-org:elm-types:r1}Integer" then parseInt(strArg)
+        when "{urn:hl7-org:elm-types:r1}String" then strArg
+        when "{urn:hl7-org:elm-types:r1}Quantity" then parseQuantity(strArg)
         else
           arg
     else

--- a/Src/coffeescript/cql-execution/src/elm/type.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/type.coffee
@@ -43,6 +43,7 @@ module.exports.Convert = class Convert extends Expression
         when "{urn:hl7-org:elm-types:r1}Integer" then parseInt(strArg)
         when "{urn:hl7-org:elm-types:r1}String" then strArg
         when "{urn:hl7-org:elm-types:r1}Quantity" then parseQuantity(strArg)
+        when "{urn:hl7-org:elm-types:r1}DateTime" then DateTime.parse(strArg)
         else
           arg
     else

--- a/Src/coffeescript/cql-execution/src/util/util.coffee
+++ b/Src/coffeescript/cql-execution/src/util/util.coffee
@@ -7,6 +7,9 @@ module.exports.numerical_sort = (things, direction="asc") ->
     else
       b - a
 
+module.exports.isNull = (value) ->
+  return value==null
+  
 module.exports.typeIsArray  = typeIsArray  = Array.isArray || ( value ) ->
   return {}.toString.call( value ) is '[object Array]'
 

--- a/Src/coffeescript/cql-execution/test/elm/aggregate/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/aggregate/data.coffee
@@ -94,18 +94,30 @@ module.exports['Count'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -220,18 +232,30 @@ module.exports['Sum'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -288,18 +312,30 @@ module.exports['Sum'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "value" : 2,
@@ -452,6 +488,10 @@ module.exports['Min'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "type" : "Negate",
@@ -465,6 +505,10 @@ module.exports['Min'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -535,6 +579,10 @@ module.exports['Min'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "type" : "Negate",
@@ -548,6 +596,10 @@ module.exports['Min'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "value" : 2,
@@ -656,12 +708,20 @@ module.exports['Max'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -722,12 +782,20 @@ module.exports['Max'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "value" : 2,
@@ -831,13 +899,16 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -863,12 +934,20 @@ module.exports['Avg'] = {
                            "type" : "As",
                            "operand" : {
                               "type" : "Null"
+                           },
+                           "asTypeSpecifier" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "type" : "NamedTypeSpecifier"
                            }
                         }, {
                            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "As",
                            "operand" : {
                               "type" : "Null"
+                           },
+                           "asTypeSpecifier" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "type" : "NamedTypeSpecifier"
                            }
                         }, {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -880,13 +959,16 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -939,12 +1021,20 @@ module.exports['Avg'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "value" : 2,
@@ -970,13 +1060,16 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1073,13 +1166,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1126,13 +1222,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1220,13 +1319,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1252,12 +1354,20 @@ module.exports['Median'] = {
                            "type" : "As",
                            "operand" : {
                               "type" : "Null"
+                           },
+                           "asTypeSpecifier" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "type" : "NamedTypeSpecifier"
                            }
                         }, {
                            "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "type" : "As",
                            "operand" : {
                               "type" : "Null"
+                           },
+                           "asTypeSpecifier" : {
+                              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                              "type" : "NamedTypeSpecifier"
                            }
                         }, {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -1269,13 +1379,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1330,13 +1443,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1395,13 +1511,16 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -1423,12 +1542,20 @@ module.exports['Median'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "value" : 2,
@@ -1630,12 +1757,20 @@ module.exports['Mode'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -1787,13 +1922,16 @@ module.exports['Variance'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -2017,13 +2155,16 @@ module.exports['StdDev'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -2141,13 +2282,16 @@ module.exports['PopulationStdDev'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }
                   }
                }
@@ -2278,12 +2422,20 @@ module.exports['AllTrue'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -2344,12 +2496,20 @@ module.exports['AllTrue'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -2457,12 +2617,20 @@ module.exports['AnyTrue'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -2523,12 +2691,20 @@ module.exports['AnyTrue'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",

--- a/Src/coffeescript/cql-execution/test/elm/arithmetic/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/arithmetic/data.coffee
@@ -498,23 +498,29 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          }, {
@@ -524,23 +530,29 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "4",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          }, {
@@ -554,43 +566,55 @@ module.exports['Divide'] = {
                   "operand" : [ {
                      "type" : "Divide",
                      "operand" : [ {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "1000",
                            "type" : "Literal"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      }, {
-                        "name" : "ToDecimal",
-                        "libraryName" : "System",
-                        "type" : "FunctionRef",
-                        "operand" : [ {
+                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "Convert",
+                        "operand" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "4",
                            "type" : "Literal"
-                        } ]
+                        },
+                        "toTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                           "type" : "NamedTypeSpecifier"
+                        }
                      } ]
                   }, {
-                     "name" : "ToDecimal",
-                     "libraryName" : "System",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
+                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "Convert",
+                     "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "10",
                         "type" : "Literal"
-                     } ]
+                     },
+                     "toTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "NamedTypeSpecifier"
+                     }
                   } ]
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "5",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          }, {
@@ -600,21 +624,27 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "name" : "Hundred",
                      "type" : "ExpressionRef"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "name" : "Four",
                      "type" : "ExpressionRef"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          } ]
@@ -723,10 +753,9 @@ module.exports['MathPrecedence'] = {
             "expression" : {
                "type" : "Subtract",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "type" : "Add",
                      "operand" : [ {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -744,27 +773,37 @@ module.exports['MathPrecedence'] = {
                            "type" : "Literal"
                         } ]
                      } ]
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
                   "type" : "Divide",
                   "operand" : [ {
-                     "name" : "ToDecimal",
-                     "libraryName" : "System",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
+                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "Convert",
+                     "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "15",
                         "type" : "Literal"
-                     } ]
+                     },
+                     "toTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "NamedTypeSpecifier"
+                     }
                   }, {
-                     "name" : "ToDecimal",
-                     "libraryName" : "System",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
+                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "Convert",
+                     "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "3",
                         "type" : "Literal"
-                     } ]
+                     },
+                     "toTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "NamedTypeSpecifier"
+                     }
                   } ]
                } ]
             }
@@ -775,10 +814,9 @@ module.exports['MathPrecedence'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "type" : "Multiply",
                      "operand" : [ {
                         "type" : "Add",
@@ -803,16 +841,23 @@ module.exports['MathPrecedence'] = {
                            "type" : "Literal"
                         } ]
                      } ]
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "3",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          } ]
@@ -1072,14 +1117,17 @@ module.exports['Ceiling'] = {
             "expression" : {
                "type" : "Ceiling",
                "operand" : {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }
             }
          } ]
@@ -1145,14 +1193,17 @@ module.exports['Floor'] = {
             "expression" : {
                "type" : "Floor",
                "operand" : {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }
             }
          } ]
@@ -1218,14 +1269,17 @@ module.exports['Truncate'] = {
             "expression" : {
                "type" : "Truncate",
                "operand" : {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }
             }
          } ]
@@ -1466,14 +1520,17 @@ module.exports['Ln'] = {
             "expression" : {
                "type" : "Ln",
                "operand" : {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "4",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }
             }
          } ]
@@ -1526,23 +1583,29 @@ module.exports['Log'] = {
             "expression" : {
                "type" : "Log",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10000",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          } ]
@@ -2310,14 +2373,17 @@ module.exports['Quantity'] = {
                "element" : [ {
                   "name" : "value",
                   "value" : {
-                     "name" : "ToDecimal",
-                     "libraryName" : "System",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
+                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "Convert",
+                     "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "10",
                         "type" : "Literal"
-                     } ]
+                     },
+                     "toTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "NamedTypeSpecifier"
+                     }
                   }
                }, {
                   "name" : "unit",
@@ -2416,14 +2482,17 @@ module.exports['Quantity'] = {
                   "name" : "days_10",
                   "type" : "ExpressionRef"
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          }, {
@@ -2450,14 +2519,17 @@ module.exports['Quantity'] = {
                   "name" : "days_10",
                   "type" : "ExpressionRef"
                }, {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                } ]
             }
          }, {
@@ -2467,14 +2539,17 @@ module.exports['Quantity'] = {
             "expression" : {
                "type" : "Multiply",
                "operand" : [ {
-                  "name" : "ToDecimal",
-                  "libraryName" : "System",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "Convert",
+                  "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  } ]
+                  },
+                  "toTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "NamedTypeSpecifier"
+                  }
                }, {
                   "name" : "QL10Days",
                   "type" : "ExpressionRef"

--- a/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
@@ -20,6 +20,15 @@ Translation Error(s):
 ###
 module.exports['ValueSetDef'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 5,
+         "startChar" : 59,
+         "endLine" : 5,
+         "endChar" : 59,
+         "message" : "no viable alternative at input '<EOF>'",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"

--- a/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
@@ -12,23 +12,12 @@ using QUICK
 valueset "Known": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Unknown One Arg": '1.2.3.4.5.6.7.8.9'
 valueset "Unknown Two Arg": '1.2.3.4.5.6.7.8.9' version '1'
+context Patient
+define Foo: "Bar"
 ###
 
-###
-Translation Error(s):
-[5:59, 5:59] no viable alternative at input '<EOF>'
-###
 module.exports['ValueSetDef'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 5,
-         "startChar" : 59,
-         "endLine" : 5,
-         "endChar" : 59,
-         "message" : "no viable alternative at input '<EOF>'",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -60,6 +49,28 @@ module.exports['ValueSetDef'] = {
             "id" : "1.2.3.4.5.6.7.8.9",
             "version" : "1",
             "accessLevel" : "Public"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "Foo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "Bar",
+               "type" : "IdentifierRef"
+            }
          } ]
       }
    }

--- a/Src/coffeescript/cql-execution/test/elm/clinical/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/data.cql
@@ -2,6 +2,7 @@
 valueset "Known": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Unknown One Arg": '1.2.3.4.5.6.7.8.9'
 valueset "Unknown Two Arg": '1.2.3.4.5.6.7.8.9' version '1'
+define Foo: "Bar"
 
 // @Test: ValueSetRef
 valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -21,6 +21,7 @@ define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
 define quantityStr: convert '10A' to Quantity
 define quantityStrDecimal: convert '10.0mA' to Quantity
+define dateStr: convert '2015-01-02' to DateTime
 ###
 
 module.exports['FromString'] = {
@@ -239,6 +240,23 @@ module.exports['FromString'] = {
                   "type" : "NamedTypeSpecifier"
                }
             }
+         }, {
+            "name" : "dateStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}DateTime",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "2015-01-02",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
          } ]
       }
    }
@@ -361,6 +379,7 @@ library TestSnippet version '1'
 using QUICK
 context Patient
 define quantityStr: convert 10 'A' to String
+define quantityQuantity: convert 10 'A' to Quantity
 ###
 
 module.exports['FromQuantity'] = {
@@ -408,6 +427,241 @@ module.exports['FromQuantity'] = {
                },
                "toTypeSpecifier" : {
                   "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "quantityQuantity",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "As",
+               "operand" : {
+                  "value" : 10,
+                  "unit" : "A",
+                  "type" : "Quantity"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### FromBoolean
+library TestSnippet version '1'
+using QUICK
+context Patient
+define booleanTrueStr: convert true to String
+define booleanFalseStr: convert false to String
+define booleanTrueBool: convert true to Boolean
+define booleanFalseBool: convert false to Boolean
+###
+
+module.exports['FromBoolean'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "booleanTrueStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "booleanFalseStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "false",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "booleanTrueBool",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "As",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "booleanFalseBool",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "As",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "false",
+                  "type" : "Literal"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### FromDateTime
+library TestSnippet version '1'
+using QUICK
+context Patient
+define dateStr: convert @2015-01-02 to String
+define dateDate: convert @2015-01-02 to DateTime
+###
+
+module.exports['FromDateTime'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "dateStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "type" : "DateTime",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2015",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2",
+                     "type" : "Literal"
+                  }
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "dateDate",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+               "type" : "As",
+               "operand" : {
+                  "type" : "DateTime",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2015",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2",
+                     "type" : "Literal"
+                  }
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
                   "type" : "NamedTypeSpecifier"
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -670,3 +670,152 @@ module.exports['FromDateTime'] = {
    }
 }
 
+### FromTime
+library TestSnippet version '1'
+using QUICK
+context Patient
+define timeStr: convert @T11:57 to String
+define timeTime: convert @T11:57 to Time
+###
+
+module.exports['FromTime'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "timeStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "type" : "Time",
+                  "hour" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "11",
+                     "type" : "Literal"
+                  },
+                  "minute" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "57",
+                     "type" : "Literal"
+                  }
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "timeTime",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Time",
+               "type" : "As",
+               "operand" : {
+                  "type" : "Time",
+                  "hour" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "11",
+                     "type" : "Literal"
+                  },
+                  "minute" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "57",
+                     "type" : "Literal"
+                  }
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Time",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### FromCode
+library TestSnippet version '1'
+using QUICK
+// define hepB: Code '66071002' from "SNOMED-CT" display 'Type B viral hepatitis'
+// define codeConcept: convert hepB to Concept
+// define codeCode: convert hepB to Code
+context Patient
+define foo: 'bar'
+###
+
+module.exports['FromCode'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "foo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}String",
+               "value" : "bar",
+               "type" : "Literal"
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -1,0 +1,176 @@
+###
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit data.coffee to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+###
+
+### FromString
+library TestSnippet version '1'
+using QUICK
+context Patient
+define boolTrue: convert 'true' to Boolean
+define boolFalse: convert 'false' to Boolean
+define decimalValid: convert '10.2' to Decimal
+define decimalInvalid: convert 'abc' to Decimal
+define integerValid: convert '10' to Integer
+define integerDropDecimal: convert '10.2' to Integer
+define integerInvalid: convert 'abc' to Integer
+###
+
+module.exports['FromString'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "boolTrue",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "true",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "boolFalse",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "false",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "decimalValid",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "10.2",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "decimalInvalid",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "abc",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "integerValid",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "10",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "integerDropDecimal",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "10.2",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "integerInvalid",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "abc",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -19,8 +19,10 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
-define quantityStr: convert '10A' to Quantity
-define quantityStrDecimal: convert '10.0mA' to Quantity
+define quantityStr: convert '10 ''A''' to Quantity
+define posQuantityStr: convert '+10 ''A''' to Quantity
+define negQuantityStr: convert '-10 ''A''' to Quantity
+define quantityStrDecimal: convert '10.0''mA''' to Quantity
 define dateStr: convert '2015-01-02' to DateTime
 ###
 
@@ -215,7 +217,41 @@ module.exports['FromString'] = {
                "type" : "Convert",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10A",
+                  "value" : "10 'A'",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "posQuantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "+10 'A'",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "negQuantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "-10 'A'",
                   "type" : "Literal"
                },
                "toTypeSpecifier" : {
@@ -232,7 +268,7 @@ module.exports['FromString'] = {
                "type" : "Convert",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10.0mA",
+                  "value" : "10.0'mA'",
                   "type" : "Literal"
                },
                "toTypeSpecifier" : {
@@ -379,6 +415,8 @@ library TestSnippet version '1'
 using QUICK
 context Patient
 define quantityStr: convert 10 'A' to String
+define negQuantityStr: convert -10 'A' to String
+define posQuantityStr: convert +10 'A' to String
 define quantityQuantity: convert 10 'A' to Quantity
 ###
 
@@ -415,6 +453,43 @@ module.exports['FromQuantity'] = {
             }
          }, {
             "name" : "quantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "value" : 10,
+                  "unit" : "A",
+                  "type" : "Quantity"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "negQuantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "type" : "Negate",
+                  "operand" : {
+                     "value" : 10,
+                     "unit" : "A",
+                     "type" : "Quantity"
+                  }
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "posQuantityStr",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -10,6 +10,8 @@
 library TestSnippet version '1'
 using QUICK
 context Patient
+define stringStr: convert 'str' to String
+define stringNull: convert null to String
 define boolTrue: convert 'true' to Boolean
 define boolFalse: convert 'false' to Boolean
 define decimalValid: convert '10.2' to Decimal
@@ -17,6 +19,8 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
+define quantityStr: convert '10A' to Quantity
+define quantityStrDecimal: convert '10.0mA' to Quantity
 ###
 
 module.exports['FromString'] = {
@@ -48,6 +52,38 @@ module.exports['FromString'] = {
                   "dataType" : "{http://hl7.org/fhir}Patient",
                   "templateId" : "patient-qicore-qicore-patient",
                   "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "stringStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "As",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "str",
+                  "type" : "Literal"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "stringNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "As",
+               "operand" : {
+                  "type" : "Null"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -166,6 +202,212 @@ module.exports['FromString'] = {
                },
                "toTypeSpecifier" : {
                   "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "quantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "10A",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "quantityStrDecimal",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                  "value" : "10.0mA",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### FromInteger
+library TestSnippet version '1'
+using QUICK
+context Patient
+define string10: convert 10 to String
+define decimal10: convert 10 to Decimal
+define intNull: convert null to Decimal
+define intInt: convert 10 to Integer
+###
+
+module.exports['FromInteger'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "string10",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "10",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "decimal10",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+               "type" : "Convert",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "10",
+                  "type" : "Literal"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "intNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Decimal",
+               "type" : "As",
+               "operand" : {
+                  "type" : "Null"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         }, {
+            "name" : "intInt",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "asType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "type" : "As",
+               "operand" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "10",
+                  "type" : "Literal"
+               },
+               "asTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### FromQuantity
+library TestSnippet version '1'
+using QUICK
+context Patient
+define quantityStr: convert 10 'A' to String
+###
+
+module.exports['FromQuantity'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "quantityStr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "toType" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Convert",
+               "operand" : {
+                  "value" : 10,
+                  "unit" : "A",
+                  "type" : "Quantity"
+               },
+               "toTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "NamedTypeSpecifier"
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -1,0 +1,8 @@
+// @Test: FromString
+define boolTrue: convert 'true' to Boolean
+define boolFalse: convert 'false' to Boolean
+define decimalValid: convert '10.2' to Decimal
+define decimalInvalid: convert 'abc' to Decimal
+define integerValid: convert '10' to Integer
+define integerDropDecimal: convert '10.2' to Integer
+define integerInvalid: convert 'abc' to Integer

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -1,4 +1,6 @@
 // @Test: FromString
+define stringStr: convert 'str' to String
+define stringNull: convert null to String
 define boolTrue: convert 'true' to Boolean
 define boolFalse: convert 'false' to Boolean
 define decimalValid: convert '10.2' to Decimal
@@ -6,3 +8,14 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
+define quantityStr: convert '10A' to Quantity
+define quantityStrDecimal: convert '10.0mA' to Quantity
+
+// @Test: FromInteger
+define string10: convert 10 to String
+define decimal10: convert 10 to Decimal
+define intNull: convert null to Decimal
+define intInt: convert 10 to Integer
+
+// @Test: FromQuantity
+define quantityStr: convert 10 'A' to String

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -10,6 +10,7 @@ define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
 define quantityStr: convert '10A' to Quantity
 define quantityStrDecimal: convert '10.0mA' to Quantity
+define dateStr: convert '2015-01-02' to DateTime
 
 // @Test: FromInteger
 define string10: convert 10 to String
@@ -19,3 +20,14 @@ define intInt: convert 10 to Integer
 
 // @Test: FromQuantity
 define quantityStr: convert 10 'A' to String
+define quantityQuantity: convert 10 'A' to Quantity
+
+// @Test: FromBoolean
+define booleanTrueStr: convert true to String
+define booleanFalseStr: convert false to String
+define booleanTrueBool: convert true to Boolean
+define booleanFalseBool: convert false to Boolean
+
+// @Test: FromDateTime
+define dateStr: convert @2015-01-02 to String
+define dateDate: convert @2015-01-02 to DateTime

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -31,3 +31,13 @@ define booleanFalseBool: convert false to Boolean
 // @Test: FromDateTime
 define dateStr: convert @2015-01-02 to String
 define dateDate: convert @2015-01-02 to DateTime
+
+// @Test: FromTime
+define timeStr: convert @T11:57 to String
+define timeTime: convert @T11:57 to Time
+
+// @Test: FromCode
+// define hepB: Code '66071002' from "SNOMED-CT" display 'Type B viral hepatitis'
+// define codeConcept: convert hepB to Concept
+// define codeCode: convert hepB to Code
+define foo: 'bar'

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -8,8 +8,10 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
-define quantityStr: convert '10A' to Quantity
-define quantityStrDecimal: convert '10.0mA' to Quantity
+define quantityStr: convert '10 ''A''' to Quantity
+define posQuantityStr: convert '+10 ''A''' to Quantity
+define negQuantityStr: convert '-10 ''A''' to Quantity
+define quantityStrDecimal: convert '10.0''mA''' to Quantity
 define dateStr: convert '2015-01-02' to DateTime
 
 // @Test: FromInteger
@@ -20,6 +22,8 @@ define intInt: convert 10 to Integer
 
 // @Test: FromQuantity
 define quantityStr: convert 10 'A' to String
+define negQuantityStr: convert -10 'A' to String
+define posQuantityStr: convert +10 'A' to String
 define quantityQuantity: convert 10 'A' to Quantity
 
 // @Test: FromBoolean

--- a/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
@@ -107,3 +107,24 @@ describe 'FromDateTime', ->
     date.month.should.equal 1
     date.day.should.equal 2
     
+describe 'FromTime', ->
+  @beforeEach ->
+    setup @, data
+
+  it.skip "should convert @T11:57 to '11:57'", ->
+    @timeStr.exec(@ctx).should.equal "11:57"
+
+  it.skip "should convert @T11:57 to @11:57", ->
+    time = @timeTime.exec(@ctx)
+    time.hour.should.equal 11
+    time.minute.should.equal 57
+    
+describe 'FromCode', ->
+  @beforeEach ->
+    setup @, data
+    
+  it.skip "should convert hepB to a concept", ->
+    concept = @codeConcept.exec(@ctx)
+    
+  it.skip "should convert hepB to a code", ->
+    code = @codeCode.exec(@ctx)

--- a/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
@@ -1,0 +1,28 @@
+should = require 'should'
+setup = require '../../setup'
+data = require './data'
+
+describe 'FromString', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should convert 'true' to true", ->
+    @boolTrue.exec(@ctx).should.equal true
+
+  it "should convert 'false' to false", ->
+    @boolFalse.exec(@ctx).should.equal false
+    
+  it "should convert 10.2 to Decimal", ->
+    @decimalValid.exec(@ctx).should.equal 10.2
+
+  it "should convert abc to Decimal NaN", ->
+    isNaN(@decimalInvalid.exec(@ctx)).should.equal true
+
+  it "should convert 10 to Integer", ->
+    @integerValid.exec(@ctx).should.equal 10
+
+  it "should convert 10.2 to Integer 10", ->
+    @integerDropDecimal.exec(@ctx).should.equal 10
+
+  it "should convert abc to Integer NaN", ->
+    isNaN(@integerInvalid.exec(@ctx)).should.equal true

--- a/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
@@ -1,10 +1,17 @@
 should = require 'should'
 setup = require '../../setup'
 data = require './data'
+{isNull} = require '../../../lib/util/util'
 
 describe 'FromString', ->
   @beforeEach ->
     setup @, data
+
+  it "should convert 'str' to 'str'", ->
+    @stringStr.exec(@ctx).should.equal "str"
+    
+  it "should convert null to null", ->
+    isNull(@stringNull.exec(@ctx)).should.equal true
 
   it "should convert 'true' to true", ->
     @boolTrue.exec(@ctx).should.equal true
@@ -12,17 +19,50 @@ describe 'FromString', ->
   it "should convert 'false' to false", ->
     @boolFalse.exec(@ctx).should.equal false
     
-  it "should convert 10.2 to Decimal", ->
+  it "should convert '10.2' to Decimal", ->
     @decimalValid.exec(@ctx).should.equal 10.2
 
-  it "should convert abc to Decimal NaN", ->
+  it "should convert 'abc' to Decimal NaN", ->
     isNaN(@decimalInvalid.exec(@ctx)).should.equal true
 
-  it "should convert 10 to Integer", ->
+  it "should convert '10' to Integer", ->
     @integerValid.exec(@ctx).should.equal 10
 
-  it "should convert 10.2 to Integer 10", ->
+  it "should convert '10.2' to Integer 10", ->
     @integerDropDecimal.exec(@ctx).should.equal 10
 
-  it "should convert abc to Integer NaN", ->
+  it "should convert 'abc' to Integer NaN", ->
     isNaN(@integerInvalid.exec(@ctx)).should.equal true
+
+  it "should convert '10A' to Quantity", ->
+    quantity = @quantityStr.exec(@ctx)
+    quantity.value.should.equal 10
+    quantity.unit.should.equal 'A'
+
+  it "should convert '10.0mA' to Quantity", ->
+    quantity = @quantityStrDecimal.exec(@ctx)
+    quantity.value.should.equal 10.0
+    quantity.unit.should.equal 'mA'
+
+describe 'FromInteger', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should convert 10 to '10'", ->
+    @string10.exec(@ctx).should.equal "10"
+
+  it "should convert 10 to 10.0", ->
+    @decimal10.exec(@ctx).should.equal 10.0
+    
+  it "should convert null to null", ->
+    isNull(@intNull.exec(@ctx)).should.equal true
+
+  it "should convert 10 to 10", ->
+    @intInt.exec(@ctx).should.equal 10
+
+describe 'FromQuantity', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should convert 10A to '10A'", ->
+    @quantityStr.exec(@ctx).should.equal "10A"

--- a/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
@@ -34,15 +34,25 @@ describe 'FromString', ->
   it "should convert 'abc' to Integer NaN", ->
     isNaN(@integerInvalid.exec(@ctx)).should.equal true
 
-  it "should convert '10A' to Quantity", ->
+  it "should convert \"10 'A'\" to Quantity", ->
     quantity = @quantityStr.exec(@ctx)
     quantity.value.should.equal 10
-    quantity.unit.should.equal 'A'
+    quantity.unit.should.equal "A"
 
-  it "should convert '10.0mA' to Quantity", ->
+  it "should convert \"+10 'A'\" to Quantity", ->
+    quantity = @posQuantityStr.exec(@ctx)
+    quantity.value.should.equal 10
+    quantity.unit.should.equal "A"
+
+  it "should convert \"-10 'A'\" to Quantity", ->
+    quantity = @negQuantityStr.exec(@ctx)
+    quantity.value.should.equal -10
+    quantity.unit.should.equal "A"
+
+  it "should convert \"10.0'mA'\" to Quantity", ->
     quantity = @quantityStrDecimal.exec(@ctx)
     quantity.value.should.equal 10.0
-    quantity.unit.should.equal 'mA'
+    quantity.unit.should.equal "mA"
     
   it "should convert '2015-01-02' to DateTime", ->
     date = @dateStr.exec(@ctx)
@@ -70,10 +80,16 @@ describe 'FromQuantity', ->
   @beforeEach ->
     setup @, data
 
-  it "should convert 10A to '10A'", ->
-    @quantityStr.exec(@ctx).should.equal "10A"
+  it "should convert \"10 'A'\" to \"10 'A'\"", ->
+    @quantityStr.exec(@ctx).should.equal "10 'A'"
 
-  it "should convert 10A to 10A", ->
+  it "should convert \"+10 'A'\" to \"10 'A'\"", ->
+    @posQuantityStr.exec(@ctx).should.equal "10 'A'"
+
+  it "should convert \"-10 'A'\" to \"10 'A'\"", ->
+    @negQuantityStr.exec(@ctx).should.equal "-10 'A'"
+
+  it "should convert \"10 'A'\" to \"10 'A'\"", ->
     quantity = @quantityQuantity.exec(@ctx)
     quantity.value.should.equal 10
     quantity.unit.should.equal 'A'

--- a/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/test.coffee
@@ -43,6 +43,12 @@ describe 'FromString', ->
     quantity = @quantityStrDecimal.exec(@ctx)
     quantity.value.should.equal 10.0
     quantity.unit.should.equal 'mA'
+    
+  it "should convert '2015-01-02' to DateTime", ->
+    date = @dateStr.exec(@ctx)
+    date.year.should.equal 2015
+    date.month.should.equal 1
+    date.day.should.equal 2
 
 describe 'FromInteger', ->
   @beforeEach ->
@@ -66,3 +72,38 @@ describe 'FromQuantity', ->
 
   it "should convert 10A to '10A'", ->
     @quantityStr.exec(@ctx).should.equal "10A"
+
+  it "should convert 10A to 10A", ->
+    quantity = @quantityQuantity.exec(@ctx)
+    quantity.value.should.equal 10
+    quantity.unit.should.equal 'A'
+
+describe 'FromBoolean', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should convert true to 'true'", ->
+    @booleanTrueStr.exec(@ctx).should.equal "true"
+
+  it "should convert false to 'false'", ->
+    @booleanFalseStr.exec(@ctx).should.equal "false"
+
+  it "should convert true to true", ->
+    @booleanTrueBool.exec(@ctx).should.equal true
+
+  it "should convert false to false", ->
+    @booleanFalseBool.exec(@ctx).should.equal false
+
+describe 'FromDateTime', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should convert @2015-01-02 to '2015-01-02'", ->
+    @dateStr.exec(@ctx).should.equal "2015-01-02"
+
+  it "should convert @2015-01-02 to @2015-01-02", ->
+    date = @dateDate.exec(@ctx)
+    date.year.should.equal 2015
+    date.month.should.equal 1
+    date.day.should.equal 2
+    

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
@@ -417,26 +417,11 @@ define ImpreciseComponentTuple: Tuple {
   Second: second from ImpreciseIdesOfMarch,
   Millisecond: millisecond from ImpreciseIdesOfMarch
 }
-define NullDate: year from null
+define NullDate: year from (null as DateTime)
 ###
 
-###
-Translation Error(s):
-[22:18, 22:31] Call to operator DateTimeComponentFrom(System.Any) is ambiguous with: 
-  - DateTimeComponentFrom(System.Time)
-  - DateTimeComponentFrom(System.DateTime)
-###
 module.exports['DateTimeComponentFrom'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 22,
-         "startChar" : 18,
-         "endLine" : 22,
-         "endChar" : 31,
-         "message" : "Call to operator DateTimeComponentFrom(System.Any) is ambiguous with: \n  - DateTimeComponentFrom(System.Time)\n  - DateTimeComponentFrom(System.DateTime)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -702,7 +687,19 @@ module.exports['DateTimeComponentFrom'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "precision" : "Year",
+               "type" : "DateTimeComponentFrom",
+               "operand" : {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
             }
          } ]
       }
@@ -715,7 +712,7 @@ using QUICK
 context Patient
 define Date: date from DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define ImpreciseDate: date from DateTime(2000)
-define NullDate: date from null
+define NullDate: date from (null as DateTime)
 ###
 
 module.exports['DateFrom'] = {
@@ -821,7 +818,7 @@ module.exports['DateFrom'] = {
             "expression" : {
                "type" : "DateFrom",
                "operand" : {
-                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "strict" : false,
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
@@ -982,26 +979,11 @@ context Patient
 define CentralEuropean: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define EasternStandard: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200, -5.0)
 define DefaultTimezone: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200)
-define NullDate: timezone from null
+define NullDate: timezone from (null as DateTime)
 ###
 
-###
-Translation Error(s):
-[7:18, 7:35] Call to operator TimezoneFrom(System.Any) is ambiguous with: 
-  - TimezoneFrom(System.Time)
-  - TimezoneFrom(System.DateTime)
-###
 module.exports['TimezoneFrom'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 7,
-         "startChar" : 18,
-         "endLine" : 7,
-         "endChar" : 35,
-         "message" : "Call to operator TimezoneFrom(System.Any) is ambiguous with: \n  - TimezoneFrom(System.Time)\n  - TimezoneFrom(System.DateTime)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -1184,7 +1166,18 @@ module.exports['TimezoneFrom'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "TimezoneFrom",
+               "operand" : {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }
             }
          } ]
       }
@@ -1222,27 +1215,12 @@ define SameHourWrongTimezone: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same 
 define ImpreciseHour: DateTime(2000, 3, 15, 13, 30, 25, 200) same hour as DateTime(2000, 3, 15)
 define ImpreciseHourWrongDay: DateTime(2000, 3, 15, 13, 30, 25, 200) same hour as DateTime(2000, 3, 16)
 define NullLeft: null same as DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
-define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same as null
-define NullBoth: null same as null
+define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same as (null as DateTime)
+define NullBoth: (null as DateTime) same as null
 ###
 
-###
-Translation Error(s):
-[32:23, 32:29] Call to operator SameAs(System.Any,System.Any) is ambiguous with: 
-  - SameAs(System.DateTime,System.DateTime)
-  - SameAs(System.Time,System.Time)
-###
 module.exports['SameAs'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 32,
-         "startChar" : 23,
-         "endLine" : 32,
-         "endChar" : 29,
-         "message" : "Call to operator SameAs(System.Any,System.Any) is ambiguous with: \n  - SameAs(System.DateTime,System.DateTime)\n  - SameAs(System.Time,System.Time)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -3742,7 +3720,7 @@ module.exports['SameAs'] = {
                      "type" : "Literal"
                   }
                }, {
-                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "strict" : false,
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
@@ -3758,7 +3736,28 @@ module.exports['SameAs'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "SameAs",
+               "operand" : [ {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
             }
          } ]
       }
@@ -3804,26 +3803,11 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) sam
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same hour or after DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null same or after DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same or after null
-define NullBoth: null same or after null
+define NullBoth: (null as DateTime) same or after null
 ###
 
-###
-Translation Error(s):
-[39:23, 39:35] Call to operator SameOrAfter(System.Any,System.Any) is ambiguous with: 
-  - SameOrAfter(System.DateTime,System.DateTime)
-  - SameOrAfter(System.Time,System.Time)
-###
 module.exports['SameOrAfter'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 39,
-         "startChar" : 23,
-         "endLine" : 39,
-         "endChar" : 35,
-         "message" : "Call to operator SameOrAfter(System.Any,System.Any) is ambiguous with: \n  - SameOrAfter(System.DateTime,System.DateTime)\n  - SameOrAfter(System.Time,System.Time)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -6948,7 +6932,28 @@ module.exports['SameOrAfter'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "SameOrAfter",
+               "operand" : [ {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
             }
          } ]
       }
@@ -6994,26 +6999,11 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) sam
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same hour or before DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null same or before DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same or before null
-define NullBoth: null same or before null
+define NullBoth: (null as DateTime) same or before null
 ###
 
-###
-Translation Error(s):
-[39:23, 39:36] Call to operator SameOrBefore(System.Any,System.Any) is ambiguous with: 
-  - SameOrBefore(System.DateTime,System.DateTime)
-  - SameOrBefore(System.Time,System.Time)
-###
 module.exports['SameOrBefore'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 39,
-         "startChar" : 23,
-         "endLine" : 39,
-         "endChar" : 36,
-         "message" : "Call to operator SameOrBefore(System.Any,System.Any) is ambiguous with: \n  - SameOrBefore(System.DateTime,System.DateTime)\n  - SameOrBefore(System.Time,System.Time)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -10138,7 +10128,28 @@ module.exports['SameOrBefore'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "SameOrBefore",
+               "operand" : [ {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
             }
          } ]
       }
@@ -10181,26 +10192,11 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) aft
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) after hour of DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null after DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) after null
-define NullBoth: null after null
+define NullBoth: (null as DateTime) after null
 ###
 
-###
-Translation Error(s):
-[36:23, 36:27] Call to operator After(System.Any,System.Any) is ambiguous with: 
-  - After(System.DateTime,System.DateTime)
-  - After(System.Time,System.Time)
-###
 module.exports['After'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 36,
-         "startChar" : 23,
-         "endLine" : 36,
-         "endChar" : 27,
-         "message" : "Call to operator After(System.Any,System.Any) is ambiguous with: \n  - After(System.DateTime,System.DateTime)\n  - After(System.Time,System.Time)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -13046,7 +13042,28 @@ module.exports['After'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "After",
+               "operand" : [ {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
             }
          } ]
       }
@@ -13089,26 +13106,11 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) bef
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) before hour of DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null before DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) before null
-define NullBoth: null before null
+define NullBoth: (null as DateTime) before null
 ###
 
-###
-Translation Error(s):
-[36:23, 36:28] Call to operator Before(System.Any,System.Any) is ambiguous with: 
-  - Before(System.DateTime,System.DateTime)
-  - Before(System.Time,System.Time)
-###
 module.exports['Before'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 36,
-         "startChar" : 23,
-         "endLine" : 36,
-         "endChar" : 28,
-         "message" : "Call to operator Before(System.Any,System.Any) is ambiguous with: \n  - Before(System.DateTime,System.DateTime)\n  - Before(System.Time,System.Time)",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -15954,7 +15956,28 @@ module.exports['Before'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "Before",
+               "operand" : [ {
+                  "strict" : false,
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "asType" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "As",
+                  "operand" : {
+                     "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
             }
          } ]
       }

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
@@ -816,6 +816,10 @@ module.exports['DateFrom'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -950,6 +954,10 @@ module.exports['TimeFrom'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -3609,6 +3617,10 @@ module.exports['SameAs'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "DateTime",
@@ -3707,6 +3719,10 @@ module.exports['SameAs'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -6782,6 +6798,10 @@ module.exports['SameOrAfter'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "DateTime",
@@ -6880,6 +6900,10 @@ module.exports['SameOrAfter'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -9955,6 +9979,10 @@ module.exports['SameOrBefore'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "DateTime",
@@ -10053,6 +10081,10 @@ module.exports['SameOrBefore'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -12846,6 +12878,10 @@ module.exports['After'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "DateTime",
@@ -12944,6 +12980,10 @@ module.exports['After'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -15737,6 +15777,10 @@ module.exports['Before'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "DateTime",
@@ -15835,6 +15879,10 @@ module.exports['Before'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
@@ -428,6 +428,15 @@ Translation Error(s):
 ###
 module.exports['DateTimeComponentFrom'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 22,
+         "startChar" : 18,
+         "endLine" : 22,
+         "endChar" : 31,
+         "message" : "Call to operator DateTimeComponentFrom(System.Any) is ambiguous with: \n  - DateTimeComponentFrom(System.Time)\n  - DateTimeComponentFrom(System.DateTime)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -984,6 +993,15 @@ Translation Error(s):
 ###
 module.exports['TimezoneFrom'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 7,
+         "startChar" : 18,
+         "endLine" : 7,
+         "endChar" : 35,
+         "message" : "Call to operator TimezoneFrom(System.Any) is ambiguous with: \n  - TimezoneFrom(System.Time)\n  - TimezoneFrom(System.DateTime)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -1216,6 +1234,15 @@ Translation Error(s):
 ###
 module.exports['SameAs'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 32,
+         "startChar" : 23,
+         "endLine" : 32,
+         "endChar" : 29,
+         "message" : "Call to operator SameAs(System.Any,System.Any) is ambiguous with: \n  - SameAs(System.DateTime,System.DateTime)\n  - SameAs(System.Time,System.Time)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -3788,6 +3815,15 @@ Translation Error(s):
 ###
 module.exports['SameOrAfter'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 39,
+         "startChar" : 23,
+         "endLine" : 39,
+         "endChar" : 35,
+         "message" : "Call to operator SameOrAfter(System.Any,System.Any) is ambiguous with: \n  - SameOrAfter(System.DateTime,System.DateTime)\n  - SameOrAfter(System.Time,System.Time)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -6969,6 +7005,15 @@ Translation Error(s):
 ###
 module.exports['SameOrBefore'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 39,
+         "startChar" : 23,
+         "endLine" : 39,
+         "endChar" : 36,
+         "message" : "Call to operator SameOrBefore(System.Any,System.Any) is ambiguous with: \n  - SameOrBefore(System.DateTime,System.DateTime)\n  - SameOrBefore(System.Time,System.Time)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -10147,6 +10192,15 @@ Translation Error(s):
 ###
 module.exports['After'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 36,
+         "startChar" : 23,
+         "endLine" : 36,
+         "endChar" : 27,
+         "message" : "Call to operator After(System.Any,System.Any) is ambiguous with: \n  - After(System.DateTime,System.DateTime)\n  - After(System.Time,System.Time)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -13046,6 +13100,15 @@ Translation Error(s):
 ###
 module.exports['Before'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 36,
+         "startChar" : 23,
+         "endLine" : 36,
+         "endChar" : 28,
+         "message" : "Call to operator Before(System.Any,System.Any) is ambiguous with: \n  - Before(System.DateTime,System.DateTime)\n  - Before(System.Time,System.Time)",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
@@ -33,12 +33,12 @@ define ImpreciseComponentTuple: Tuple {
   Second: second from ImpreciseIdesOfMarch,
   Millisecond: millisecond from ImpreciseIdesOfMarch
 }
-define NullDate: year from null
+define NullDate: year from (null as DateTime)
 
 // @Test: DateFrom
 define Date: date from DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define ImpreciseDate: date from DateTime(2000)
-define NullDate: date from null
+define NullDate: date from (null as DateTime)
 
 // @Test: TimeFrom
 define Time: time from DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
@@ -49,7 +49,7 @@ define NullDate: time from null
 define CentralEuropean: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define EasternStandard: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200, -5.0)
 define DefaultTimezone: timezone from DateTime(2000, 3, 15, 13, 30, 25, 200)
-define NullDate: timezone from null
+define NullDate: timezone from (null as DateTime)
 
 // @Test: SameAs
 define SameYear: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same year as DateTime(2000, 11, 23, 8, 14, 47, 500, +1.0)
@@ -79,8 +79,8 @@ define SameHourWrongTimezone: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same 
 define ImpreciseHour: DateTime(2000, 3, 15, 13, 30, 25, 200) same hour as DateTime(2000, 3, 15)
 define ImpreciseHourWrongDay: DateTime(2000, 3, 15, 13, 30, 25, 200) same hour as DateTime(2000, 3, 16)
 define NullLeft: null same as DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
-define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same as null
-define NullBoth: null same as null
+define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same as (null as DateTime)
+define NullBoth: (null as DateTime) same as null
 
 // @Test: SameOrAfter
 define SameYear: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same year or after DateTime(2000, 11, 23, 8, 14, 47, 500, +1.0)
@@ -118,7 +118,7 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) sam
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same hour or after DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null same or after DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same or after null
-define NullBoth: null same or after null
+define NullBoth: (null as DateTime) same or after null
 
 // @Test: SameOrBefore
 define SameYear: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same year or before DateTime(2000, 11, 23, 8, 14, 47, 500, +1.0)
@@ -156,7 +156,7 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) sam
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same hour or before DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null same or before DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) same or before null
-define NullBoth: null same or before null
+define NullBoth: (null as DateTime) same or before null
 
 // @Test: After
 define SameYear: DateTime(2000, 12, 15, 13, 30, 25, 200, +1.0) after year of DateTime(2000, 11, 23, 8, 14, 47, 500, +1.0)
@@ -191,7 +191,7 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) aft
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) after hour of DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null after DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) after null
-define NullBoth: null after null
+define NullBoth: (null as DateTime) after null
 
 // @Test: Before
 define SameYear: DateTime(2000, 10, 15, 13, 30, 25, 200, +1.0) before year of DateTime(2000, 11, 23, 8, 14, 47, 500, +1.0)
@@ -226,7 +226,7 @@ define HourAfterNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) bef
 define HourBeforeNormalizeZones: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) before hour of DateTime(2000, 3, 15, 8, 30, 25, 200, -5.0)
 define NullLeft: null before DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
 define NullRight: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) before null
-define NullBoth: null before null
+define NullBoth: (null as DateTime) before null
 
 // @Test: DurationBetween
 define NewYear2013: DateTime(2013, 1, 1, 0, 0, 0, 0)

--- a/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
@@ -71,14 +71,17 @@ module.exports['Instance'] = {
                }, {
                   "name" : "value",
                   "value" : {
-                     "name" : "ToDecimal",
-                     "libraryName" : "System",
-                     "type" : "FunctionRef",
-                     "operand" : [ {
+                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                     "type" : "Convert",
+                     "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "12",
                         "type" : "Literal"
-                     } ]
+                     },
+                     "toTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
+                        "type" : "NamedTypeSpecifier"
+                     }
                   }
                } ]
             }

--- a/Src/coffeescript/cql-execution/test/elm/interval/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/interval/data.coffee
@@ -2436,6 +2436,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2467,6 +2471,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2495,6 +2503,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2523,6 +2535,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2554,6 +2570,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2587,6 +2607,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2615,6 +2639,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2646,6 +2674,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2674,6 +2706,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2702,6 +2738,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2728,6 +2768,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2822,6 +2866,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -2916,6 +2964,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -3010,6 +3062,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -3104,6 +3160,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -3236,6 +3296,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -3330,6 +3394,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -3424,6 +3492,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -3518,6 +3590,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -3612,6 +3688,10 @@ module.exports['Contains'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -4279,6 +4359,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4307,6 +4391,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4335,6 +4423,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4366,6 +4458,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4394,6 +4490,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4427,6 +4527,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -4458,6 +4562,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -4486,6 +4594,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -4514,6 +4626,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -4545,6 +4661,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -4601,6 +4721,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4695,6 +4819,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4789,6 +4917,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4883,6 +5015,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -4977,6 +5113,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -5109,6 +5249,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -5203,6 +5347,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -5297,6 +5445,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -5391,6 +5543,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -5485,6 +5641,10 @@ module.exports['In'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -6412,6 +6572,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6453,6 +6617,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6491,6 +6659,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6529,6 +6701,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6570,6 +6746,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6613,6 +6793,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -6651,6 +6835,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -6692,6 +6880,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -6730,6 +6922,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -6768,6 +6964,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -6804,6 +7004,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -6941,6 +7145,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -7078,6 +7286,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -7215,6 +7427,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -7352,6 +7568,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -7527,6 +7747,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -7664,6 +7888,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -7801,6 +8029,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -7938,6 +8170,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -8075,6 +8311,10 @@ module.exports['Includes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -8716,6 +8956,10 @@ module.exports['ProperlyIncludes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -8754,6 +8998,10 @@ module.exports['ProperlyIncludes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -8770,6 +9018,10 @@ module.exports['ProperlyIncludes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -8794,6 +9046,10 @@ module.exports['ProperlyIncludes'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -9735,6 +9991,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9751,6 +10011,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9775,6 +10039,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9816,6 +10084,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9832,6 +10104,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9856,6 +10132,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9897,6 +10177,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -9943,6 +10227,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -9962,6 +10250,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -9986,6 +10278,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -10027,6 +10323,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -10046,6 +10346,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -10070,6 +10374,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -10111,6 +10419,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -10144,6 +10456,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10193,6 +10509,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10250,6 +10570,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10387,6 +10711,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10436,6 +10764,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10493,6 +10825,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10630,6 +10966,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -10805,6 +11145,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -10854,6 +11198,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -10911,6 +11259,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -11048,6 +11400,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -11097,6 +11453,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -11154,6 +11514,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -11291,6 +11655,10 @@ module.exports['IncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -11965,6 +12333,10 @@ module.exports['ProperlyIncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -12014,6 +12386,10 @@ module.exports['ProperlyIncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -12071,6 +12447,10 @@ module.exports['ProperlyIncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -12208,6 +12588,10 @@ module.exports['ProperlyIncludedIn'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -13209,6 +13593,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13250,6 +13638,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13291,6 +13683,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13334,6 +13730,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -13378,6 +13778,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -13419,6 +13823,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -13463,6 +13871,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -13499,6 +13911,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13636,6 +14052,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13773,6 +14193,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -13948,6 +14372,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -14085,6 +14513,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -14222,6 +14654,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -14359,6 +14795,10 @@ module.exports['After'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -15360,6 +15800,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15398,6 +15842,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15436,6 +15884,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15474,6 +15926,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15517,6 +15973,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -15555,6 +16015,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -15593,6 +16057,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -15629,6 +16097,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15766,6 +16238,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -15903,6 +16379,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -16040,6 +16520,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -16215,6 +16699,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -16352,6 +16840,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -16489,6 +16981,10 @@ module.exports['Before'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -17680,6 +18176,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17718,6 +18218,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17770,6 +18274,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17794,6 +18302,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17832,6 +18344,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17870,6 +18386,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17922,6 +18442,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -17951,6 +18475,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -17989,6 +18517,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -18041,6 +18573,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -18065,6 +18601,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -18103,6 +18643,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -18141,6 +18685,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -18196,6 +18744,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -18215,6 +18767,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -18352,6 +18908,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -18569,6 +19129,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -18626,6 +19190,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -18763,6 +19331,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -18900,6 +19472,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -19117,6 +19693,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -19212,6 +19792,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -19349,6 +19933,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -19566,6 +20154,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -19623,6 +20215,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -19760,6 +20356,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -19897,6 +20497,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -20114,6 +20718,10 @@ module.exports['Meets'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -21225,6 +21833,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21263,6 +21875,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21315,6 +21931,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21339,6 +21959,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21377,6 +22001,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21415,6 +22043,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21467,6 +22099,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21496,6 +22132,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -21534,6 +22174,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -21586,6 +22230,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -21610,6 +22258,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -21648,6 +22300,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -21686,6 +22342,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -21741,6 +22401,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -21760,6 +22424,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -21897,6 +22565,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22114,6 +22786,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22171,6 +22847,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22308,6 +22988,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22445,6 +23129,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22662,6 +23350,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -22757,6 +23449,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -22894,6 +23590,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -23111,6 +23811,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -23168,6 +23872,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -23305,6 +24013,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -23442,6 +24154,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -23659,6 +24375,10 @@ module.exports['MeetsAfter'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -24770,6 +25490,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -24808,6 +25532,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -24860,6 +25588,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -24884,6 +25616,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -24922,6 +25658,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -24960,6 +25700,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25012,6 +25756,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25041,6 +25789,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -25079,6 +25831,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -25131,6 +25887,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -25155,6 +25915,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -25193,6 +25957,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -25231,6 +25999,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -25286,6 +26058,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -25305,6 +26081,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25442,6 +26222,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25659,6 +26443,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25716,6 +26504,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25853,6 +26645,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -25990,6 +26786,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -26207,6 +27007,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -26302,6 +27106,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -26439,6 +27247,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -26656,6 +27468,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -26713,6 +27529,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -26850,6 +27670,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -26987,6 +27811,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -27204,6 +28032,10 @@ module.exports['MeetsBefore'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]
@@ -30124,6 +30956,10 @@ module.exports['Width'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }
@@ -30143,6 +30979,10 @@ module.exports['Width'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {
@@ -30172,6 +31012,10 @@ module.exports['Width'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }
@@ -30191,6 +31035,10 @@ module.exports['Width'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "type" : "NamedTypeSpecifier"
                      }
                   },
                   "high" : {

--- a/Src/coffeescript/cql-execution/test/elm/library/COM.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/COM.cql
@@ -5,7 +5,7 @@ parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014
 context Patient
 
 define InDemographic:
-AgeInYearsAt(start of MeasurementPeriod) >= 2 and AgeInYearsAt(start of MeasurementPeriod) < 18
+  AgeInYearsAt(start of MeasurementPeriod) >= 2 and AgeInYearsAt(start of MeasurementPeriod) < 18
 
 define function foo (a Integer, b Integer) :
   a + b

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -356,6 +356,15 @@ Translation Error(s):
 ###
 module.exports['Using CommonLib'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 10,
+         "startChar" : 19,
+         "endLine" : 10,
+         "endChar" : 36,
+         "message" : "Member given not found for type list<QUICK.HumanName>.",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -346,25 +346,12 @@ context Patient
 
 define ID: common.InDemographic
 
-define L : Length(Patient.name.given)
+define L : Length(Patient.name[1].given[1])
 define FuncTest : common.foo(2, 5)
 ###
 
-###
-Translation Error(s):
-[10:19, 10:36] Member given not found for type list<QUICK.HumanName>.
-###
 module.exports['Using CommonLib'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 10,
-         "startChar" : 19,
-         "endLine" : 10,
-         "endChar" : 36,
-         "message" : "Member given not found for type list<QUICK.HumanName>.",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -463,7 +450,30 @@ module.exports['Using CommonLib'] = {
             "expression" : {
                "type" : "Length",
                "operand" : {
-                  "type" : "Null"
+                  "type" : "Indexer",
+                  "operand" : [ {
+                     "path" : "given",
+                     "type" : "Property",
+                     "source" : {
+                        "type" : "Indexer",
+                        "operand" : [ {
+                           "path" : "name",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "Patient",
+                              "type" : "ExpressionRef"
+                           }
+                        }, {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "1",
+                           "type" : "Literal"
+                        } ]
+                     }
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  } ]
                }
             }
          }, {

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -29,7 +29,7 @@ context Patient
 
 define ID: common.InDemographic
 
-define L : Length(Patient.name.given)
+define L : Length(Patient.name[1].given[1])
 define FuncTest : common.foo(2, 5)
 
 

--- a/Src/coffeescript/cql-execution/test/elm/library/patients.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/patients.coffee
@@ -13,7 +13,7 @@ module.exports.p1 = {
         "meta" :{ "profile" : ["patient-qicore-qicore-patient"]},
         "resourceType" : "Patient",
         "identifier": [{ "value": "1" }],
-        "name": {"given":["John"], "family": ["Smith"]},
+        "name": [{"given":["John"], "family": ["Smith"]}],
         "gender": "M",
         "birthDate" : "1980-02-17T06:15"}
         }
@@ -35,7 +35,7 @@ module.exports.p2 = {
       "meta" :{ "profile" : ["patient-qicore-qicore-patient"]},
       "id" : "2",
       "identifier": [{ "value": "2" }],
-      "name": {"given":["Sally"], "family": ["Smith"]},
+      "name": [{"given":["Sally"], "family": ["Smith"]}],
       "gender": "F",
       "birthDate" : "2007-08-02T11:47"
       }]

--- a/Src/coffeescript/cql-execution/test/elm/list/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/list/data.coffee
@@ -2707,6 +2707,10 @@ module.exports['IndexOf'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -2905,6 +2909,10 @@ module.exports['Indexer'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -3179,6 +3187,10 @@ module.exports['In'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "List",
@@ -3532,6 +3544,10 @@ module.exports['Contains'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -4009,6 +4025,10 @@ module.exports['Includes'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -5057,6 +5077,10 @@ module.exports['ProperIncludes'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }

--- a/Src/coffeescript/cql-execution/test/elm/logical/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/logical/data.coffee
@@ -99,6 +99,10 @@ module.exports['And'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -149,6 +153,10 @@ module.exports['And'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -163,12 +171,20 @@ module.exports['And'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -183,6 +199,10 @@ module.exports['And'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -201,6 +221,10 @@ module.exports['And'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -306,6 +330,10 @@ module.exports['Or'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -356,6 +384,10 @@ module.exports['Or'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -370,12 +402,20 @@ module.exports['Or'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -390,6 +430,10 @@ module.exports['Or'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -408,6 +452,10 @@ module.exports['Or'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -513,6 +561,10 @@ module.exports['XOr'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -563,6 +615,10 @@ module.exports['XOr'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -577,12 +633,20 @@ module.exports['XOr'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -597,6 +661,10 @@ module.exports['XOr'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -615,6 +683,10 @@ module.exports['XOr'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
@@ -702,6 +774,10 @@ module.exports['Not'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
@@ -21,6 +21,15 @@ Translation Error(s):
 ###
 module.exports['ParameterDef'] = {
    "library" : {
+      "annotation" : [ {
+         "startLine" : 6,
+         "startChar" : 110,
+         "endLine" : 6,
+         "endChar" : 110,
+         "message" : "no viable alternative at input '<EOF>'",
+         "errorType" : "syntax",
+         "type" : "CqlToElmError"
+      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
@@ -13,23 +13,12 @@ parameter MeasureYear default 2012
 parameter IntParameter Integer
 parameter ListParameter List<String>
 parameter TupleParameter Tuple{a Integer, b String, c Boolean, d List<Integer>, e Tuple{ f String, g Boolean}}
+context Patient
+define foo: "bar"
 ###
 
-###
-Translation Error(s):
-[6:110, 6:110] no viable alternative at input '<EOF>'
-###
 module.exports['ParameterDef'] = {
    "library" : {
-      "annotation" : [ {
-         "startLine" : 6,
-         "startChar" : 110,
-         "endLine" : 6,
-         "endChar" : 110,
-         "message" : "no viable alternative at input '<EOF>'",
-         "errorType" : "syntax",
-         "type" : "CqlToElmError"
-      } ],
       "identifier" : {
          "id" : "TestSnippet",
          "version" : "1"
@@ -124,6 +113,28 @@ module.exports['ParameterDef'] = {
                      } ]
                   }
                } ]
+            }
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "foo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "bar",
+               "type" : "IdentifierRef"
             }
          } ]
       }

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
@@ -3,6 +3,7 @@ parameter MeasureYear default 2012
 parameter IntParameter Integer
 parameter ListParameter List<String>
 parameter TupleParameter Tuple{a Integer, b String, c Boolean, d List<Integer>, e Tuple{ f String, g Boolean}}
+define foo: "bar"
 
 // @Test: ParameterRef
 parameter FooP default 'Bar'

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -326,11 +326,6 @@ where  E.period  included in MeasurementPeriod and C.id = 'http://cqframework.or
 define msQuery: from [Encounter] E, [Condition] C return {E: E, C:C}
 ###
 
-###
-Translation Error(s):
-[5:22, 7:44] type
-[9:23, 10:86] type
-###
 module.exports['MultiSourceQuery'] = {
    "library" : {
       "identifier" : {
@@ -414,14 +409,106 @@ module.exports['MultiSourceQuery'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "dateProperty" : "period",
+                     "type" : "Retrieve",
+                     "dateRange" : {
+                        "name" : "MeasurementPeriod",
+                        "type" : "ParameterRef"
+                     }
+                  }
+               }, {
+                  "alias" : "C",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Condition",
+                     "templateId" : "condition-qicore-qicore-condition",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "distinct" : true,
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "E",
+                        "value" : {
+                           "name" : "E",
+                           "type" : "AliasRef"
+                        }
+                     }, {
+                        "name" : "C",
+                        "value" : {
+                           "name" : "C",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               }
             }
          }, {
             "name" : "msQueryWhere2",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Null"
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "dateProperty" : "period",
+                     "type" : "Retrieve",
+                     "dateRange" : {
+                        "name" : "MeasurementPeriod",
+                        "type" : "ParameterRef"
+                     }
+                  }
+               }, {
+                  "alias" : "C",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Condition",
+                     "templateId" : "condition-qicore-qicore-condition",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "type" : "Equal",
+                  "operand" : [ {
+                     "path" : "id",
+                     "scope" : "C",
+                     "type" : "Property"
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "http://cqframework.org/3/2",
+                     "type" : "Literal"
+                  } ]
+               },
+               "return" : {
+                  "distinct" : true,
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "E",
+                        "value" : {
+                           "name" : "E",
+                           "type" : "AliasRef"
+                        }
+                     }, {
+                        "name" : "C",
+                        "value" : {
+                           "name" : "C",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               }
             }
          }, {
             "name" : "msQuery",

--- a/Src/coffeescript/cql-execution/test/elm/string/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/string/data.coffee
@@ -202,6 +202,10 @@ module.exports['Concat'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -388,6 +392,10 @@ module.exports['Combine'] = {
                      "type" : "As",
                      "operand" : {
                         "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}String",
@@ -492,6 +500,10 @@ module.exports['Split'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                },
                "separator" : {
@@ -516,6 +528,10 @@ module.exports['Split'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -586,6 +602,10 @@ module.exports['Length'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -682,6 +702,10 @@ module.exports['Upper'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -778,6 +802,10 @@ module.exports['Lower'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -887,6 +915,10 @@ module.exports['Indexer'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
@@ -909,6 +941,10 @@ module.exports['Indexer'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -1003,6 +1039,10 @@ module.exports['PositionOf'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                },
                "string" : {
@@ -1027,6 +1067,10 @@ module.exports['PositionOf'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -1216,6 +1260,10 @@ module.exports['Substring'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
                   }
                },
                "startIndex" : {
@@ -1240,6 +1288,10 @@ module.exports['Substring'] = {
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
+                  },
+                  "asTypeSpecifier" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
                   }
                }
             }

--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -3,7 +3,7 @@ allprojects {
     apply plugin: 'eclipse'
 
     group = 'info.cqframework'
-    version = '0.1-SNAPSHOT'
+    version = '0.2-SNAPSHOT'
 }
 
 subprojects {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -3428,11 +3428,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                     .withOperand(expression)
                     .withResultType(conversion.getToType());
 
+            castedOperand.setAsTypeSpecifier(dataTypeToTypeSpecifier(castedOperand.getResultType()));
             if (castedOperand.getResultType() instanceof NamedType) {
                 castedOperand.setAsType(dataTypeToQName(castedOperand.getResultType()));
-            }
-            else {
-                castedOperand.setAsTypeSpecifier(dataTypeToTypeSpecifier(castedOperand.getResultType()));
             }
 
             return castedOperand;
@@ -3448,11 +3446,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                     .withOperand(expression)
                     .withResultType(conversion.getToType());
 
+            convertedOperand.setToTypeSpecifier(dataTypeToTypeSpecifier(convertedOperand.getResultType()));
             if (convertedOperand.getResultType() instanceof NamedType) {
                 convertedOperand.setToType(dataTypeToQName(convertedOperand.getResultType()));
-            }
-            else {
-                convertedOperand.setToTypeSpecifier(dataTypeToTypeSpecifier(convertedOperand.getResultType()));
             }
 
             return convertedOperand;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.java
@@ -401,6 +401,10 @@ public class SystemLibraryHelper {
         Operator codeToConcept = new Operator("ToConcept", new Signature(systemModel.getCode()), systemModel.getConcept());
         system.add(codeToConcept);
         system.add(new Conversion(codeToConcept, true));
+        // ToConcept(list<Code>)
+        Operator codesToConcept = new Operator("ToConcept", new Signature(new ListType(systemModel.getCode())), systemModel.getConcept());
+        system.add(codesToConcept);
+        system.add(new Conversion(codesToConcept, false)); // TODO: Spec does not say if this is implicit (DSTU comment #827)
 
         system.add(new Operator("CalculateAge", new Signature(systemModel.getDateTime()), systemModel.getInteger()));
         system.add(new Operator("CalculateAgeAt", new Signature(systemModel.getDateTime(), systemModel.getDateTime()), systemModel.getInteger()));

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/ConvertInvocation.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/ConvertInvocation.java
@@ -1,0 +1,22 @@
+package org.cqframework.cql.cql2elm.model.invocation;
+
+import org.hl7.elm.r1.Convert;
+import org.hl7.elm.r1.Expression;
+
+import java.util.Collections;
+
+public class ConvertInvocation extends AbstractExpressionInvocation {
+    public ConvertInvocation(Convert expression) {
+        super(expression);
+    }
+
+    @Override
+    public Iterable<Expression> getOperands() {
+        return Collections.singletonList(((Convert) expression).getOperand());
+    }
+
+    @Override
+    public void setOperands(Iterable<Expression> operands) {
+        ((Convert) expression).setOperand(assertAndGetSingleOperand(operands));
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
@@ -26,10 +26,15 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
                 .withValueType(new QName("urn:hl7-org:elm-types:r1", "Integer"))
                 .withValue(String.valueOf(i));
 
+<<<<<<< adeeb4811d63b61ed4945063119d72d1ce2a9fa2
         QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
         expectedValue = of.createConvert()
                 .withToType(expectedTypeName)
                 .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
+=======
+        expectedValue = of.createConvert()
+                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
+>>>>>>> All conversions use Convert ELM operator (instead of 'ToX' functions).  Also add tests for other type operators.  NOTE: This breaks the execution engine because it doesn't currently support Convert.
                 .withOperand(integerLiteral);
     }
 
@@ -37,11 +42,16 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
         super();
 
         expectedArg = a;
+<<<<<<< adeeb4811d63b61ed4945063119d72d1ce2a9fa2
         ObjectFactory of = new ObjectFactory();
         QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
         expectedValue = of.createConvert()
                 .withToType(expectedTypeName)
                 .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
+=======
+        expectedValue = new ObjectFactory().createConvert()
+                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
+>>>>>>> All conversions use Convert ELM operator (instead of 'ToX' functions).  Also add tests for other type operators.  NOTE: This breaks the execution engine because it doesn't currently support Convert.
                 .withOperand(a);
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
@@ -5,8 +5,8 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hl7.elm.r1.AliasRef;
+import org.hl7.elm.r1.Convert;
 import org.hl7.elm.r1.Expression;
-import org.hl7.elm.r1.FunctionRef;
 import org.hl7.elm.r1.Literal;
 import org.hl7.elm.r1.ObjectFactory;
 
@@ -14,7 +14,7 @@ import javax.xml.namespace.QName;
 
 public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression> {
     private Object expectedArg;
-    private FunctionRef expectedValue;
+    private Convert expectedValue;
 
     public ConvertsToDecimalFrom(Integer i) {
         super();
@@ -26,9 +26,8 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
                 .withValueType(new QName("urn:hl7-org:elm-types:r1", "Integer"))
                 .withValue(String.valueOf(i));
 
-        expectedValue = of.createFunctionRef()
-                .withLibraryName("System")
-                .withName("ToDecimal")
+        expectedValue = of.createConvert()
+                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
                 .withOperand(integerLiteral);
     }
 
@@ -36,22 +35,21 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
         super();
 
         expectedArg = a;
-        expectedValue = new ObjectFactory().createFunctionRef()
-                .withLibraryName("System")
-                .withName("ToDecimal")
+        expectedValue = new ObjectFactory().createConvert()
+                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
                 .withOperand(a);
     }
 
     @Override
     protected boolean matchesSafely(Expression item, Description mismatchDescription) {
-        if (! (item instanceof FunctionRef)) {
+        if (! (item instanceof Convert)) {
             mismatchDescription.appendText("had wrong ELM class type: ").appendText(item.getClass().getName());
             return false;
         }
 
-        FunctionRef fun = (FunctionRef) item;
-        if (! expectedValue.equals(fun)) {
-            mismatchDescription.appendText("had wrong function reference: ").appendValue(fun);
+        Convert convert = (Convert) item;
+        if (! expectedValue.equals(convert)) {
+            mismatchDescription.appendText("had wrong conversion: ").appendValue(convert);
             return false;
         }
 
@@ -60,7 +58,7 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
 
     @Override
     public void describeTo(Description description) {
-        description.appendText("FunctionRef for ToDecimal w/ value: <")
+        description.appendText("Conversion to Decimal w/ value: <")
                 .appendValue(expectedArg);
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
@@ -26,8 +26,10 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
                 .withValueType(new QName("urn:hl7-org:elm-types:r1", "Integer"))
                 .withValue(String.valueOf(i));
 
+        QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
         expectedValue = of.createConvert()
-                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
+                .withToType(expectedTypeName)
+                .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
                 .withOperand(integerLiteral);
     }
 
@@ -35,8 +37,11 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
         super();
 
         expectedArg = a;
-        expectedValue = new ObjectFactory().createConvert()
-                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
+        ObjectFactory of = new ObjectFactory();
+        QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
+        expectedValue = of.createConvert()
+                .withToType(expectedTypeName)
+                .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
                 .withOperand(a);
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/matchers/ConvertsToDecimalFrom.java
@@ -26,15 +26,10 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
                 .withValueType(new QName("urn:hl7-org:elm-types:r1", "Integer"))
                 .withValue(String.valueOf(i));
 
-<<<<<<< adeeb4811d63b61ed4945063119d72d1ce2a9fa2
         QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
         expectedValue = of.createConvert()
                 .withToType(expectedTypeName)
                 .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
-=======
-        expectedValue = of.createConvert()
-                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
->>>>>>> All conversions use Convert ELM operator (instead of 'ToX' functions).  Also add tests for other type operators.  NOTE: This breaks the execution engine because it doesn't currently support Convert.
                 .withOperand(integerLiteral);
     }
 
@@ -42,16 +37,11 @@ public class ConvertsToDecimalFrom extends TypeSafeDiagnosingMatcher<Expression>
         super();
 
         expectedArg = a;
-<<<<<<< adeeb4811d63b61ed4945063119d72d1ce2a9fa2
         ObjectFactory of = new ObjectFactory();
         QName expectedTypeName = new QName("urn:hl7-org:elm-types:r1", "Decimal");
         expectedValue = of.createConvert()
                 .withToType(expectedTypeName)
                 .withToTypeSpecifier(of.createNamedTypeSpecifier().withName(expectedTypeName))
-=======
-        expectedValue = new ObjectFactory().createConvert()
-                .withToType(new QName("urn:hl7-org:elm-types:r1", "Decimal"))
->>>>>>> All conversions use Convert ELM operator (instead of 'ToX' functions).  Also add tests for other type operators.  NOTE: This breaks the execution engine because it doesn't currently support Convert.
                 .withOperand(a);
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/AggregateOperatorsTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/AggregateOperatorsTest.java
@@ -240,7 +240,7 @@ public class AggregateOperatorsTest {
         assertThat(aqs.getExpression(), listOfLiterals(1, 2, 3, 4, 5));
         String alias = aqs.getAlias();
         assertThat(q.getReturn().isDistinct(), is(false));
-        assertThat(q.getReturn().getExpression(), instanceOf(FunctionRef.class));
+        assertThat(q.getReturn().getExpression(), instanceOf(Convert.class));
         assertThat(q.getReturn().getExpression(), convertsToDecimalFromAlias(alias));
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
@@ -2,27 +2,18 @@ package org.cqframework.cql.cql2elm.operators;
 
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.hl7.elm.r1.As;
-import org.hl7.elm.r1.Code;
-import org.hl7.elm.r1.Combine;
 import org.hl7.elm.r1.Convert;
 import org.hl7.elm.r1.DateTime;
-import org.hl7.elm.r1.Expression;
 import org.hl7.elm.r1.ExpressionDef;
 import org.hl7.elm.r1.ExpressionRef;
 import org.hl7.elm.r1.Is;
-import org.hl7.elm.r1.Length;
 import org.hl7.elm.r1.Library;
-import org.hl7.elm.r1.Lower;
 import org.hl7.elm.r1.MaxValue;
 import org.hl7.elm.r1.MinValue;
 import org.hl7.elm.r1.NamedTypeSpecifier;
 import org.hl7.elm.r1.Null;
-import org.hl7.elm.r1.PositionOf;
 import org.hl7.elm.r1.Quantity;
-import org.hl7.elm.r1.Split;
-import org.hl7.elm.r1.Substring;
 import org.hl7.elm.r1.Time;
-import org.hl7.elm.r1.Upper;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -32,12 +23,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.cqframework.cql.cql2elm.matchers.HasTypeAndResult.hasTypeAndResult;
-import static org.cqframework.cql.cql2elm.matchers.ListOfLiterals.listOfLiterals;
 import static org.cqframework.cql.cql2elm.matchers.LiteralFor.literalFor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.testng.Assert.assertTrue;
 
 public class TypeOperatorsTest {
 
@@ -91,6 +82,14 @@ public class TypeOperatorsTest {
         assertThat(spec.getResultType().toString(), is("System.Boolean"));
         //assertThat(is.getIsType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
     }
+    
+    private static void validateTyping(Convert convert, QName typeName) {
+        assertThat(convert.getToType(), is(typeName));
+        assertTrue(convert.getToTypeSpecifier() != null);
+        assertTrue(convert.getToTypeSpecifier() instanceof NamedTypeSpecifier);
+        NamedTypeSpecifier nts = (NamedTypeSpecifier)convert.getToTypeSpecifier();
+        assertThat(nts.getName(), is(typeName));
+    }
 
     @Test
     public void testToString() {
@@ -98,22 +97,19 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor(false));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
 
         def = defs.get("IntegerToString");
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
         convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor(3));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
 
         def = defs.get("DecimalToString");
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
         convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor(3.0));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
 
         def = defs.get("QuantityToString");
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
@@ -122,8 +118,7 @@ public class TypeOperatorsTest {
         Quantity q = (Quantity) convert.getOperand();
         assertThat(q.getValue().doubleValue(), is(3.0));
         assertThat(q.getUnit(), is("m"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
 
         def = defs.get("DateTimeToString");
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
@@ -138,8 +133,7 @@ public class TypeOperatorsTest {
         assertThat(dt.getSecond(), literalFor(0));
         assertThat(dt.getMillisecond(), literalFor(0));
         assertThat(dt.getTimezoneOffset(), nullValue());
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
 
         def = defs.get("TimeToString");
         assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
@@ -151,8 +145,7 @@ public class TypeOperatorsTest {
         assertThat(t.getSecond(), literalFor(0));
         assertThat(t.getMillisecond(), literalFor(0));
         assertThat(t.getTimezoneOffset(), nullValue());
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "String"));
     }
 
     @Test
@@ -224,8 +217,7 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.Boolean"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor("false"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Boolean"));
     }
 
     @Test
@@ -244,8 +236,7 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.Integer"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor("1"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Integer")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Integer"));
     }
 
     @Test
@@ -264,15 +255,13 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor("3.0"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Decimal"));
 
         def = defs.get("IntegerToDecimal");
         assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
         convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor(1));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Decimal"));
     }
 
     @Test
@@ -288,8 +277,7 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
         convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor(1));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Decimal"));
     }
 
     @Test
@@ -298,8 +286,7 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.DateTime"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor("2014-01-01T00:00:00:00.0000+0700"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "DateTime")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "DateTime"));
     }
 
     @Test
@@ -318,8 +305,7 @@ public class TypeOperatorsTest {
         assertThat(def, hasTypeAndResult(Convert.class, "System.Time"));
         Convert convert = (Convert) def.getExpression();
         assertThat(convert.getOperand(), literalFor("T00:00:00:00.0000+0700"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Time")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Time"));
     }
 
     @Test
@@ -341,8 +327,7 @@ public class TypeOperatorsTest {
         ExpressionRef ref = (ExpressionRef) convert.getOperand();
         assertThat(ref.getName(), is("MyCode"));
         assertThat(ref.getResultType().toString(), is("System.Code"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Concept"));
 
         def = defs.get("CodesToConcept");
         assertThat(def, hasTypeAndResult(Convert.class, "System.Concept"));
@@ -351,8 +336,7 @@ public class TypeOperatorsTest {
         ref = (ExpressionRef) convert.getOperand();
         assertThat(ref.getName(), is("MyCodes"));
         assertThat(ref.getResultType().toString(), is("list<System.Code>"));
-        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
-        assertThat(convert.getToTypeSpecifier(), nullValue());
+        validateTyping(convert, new QName("urn:hl7-org:elm-types:r1", "Concept"));
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
@@ -1,0 +1,426 @@
+package org.cqframework.cql.cql2elm.operators;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.hl7.elm.r1.As;
+import org.hl7.elm.r1.Code;
+import org.hl7.elm.r1.Combine;
+import org.hl7.elm.r1.Convert;
+import org.hl7.elm.r1.DateTime;
+import org.hl7.elm.r1.Expression;
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.ExpressionRef;
+import org.hl7.elm.r1.Is;
+import org.hl7.elm.r1.Length;
+import org.hl7.elm.r1.Library;
+import org.hl7.elm.r1.Lower;
+import org.hl7.elm.r1.MaxValue;
+import org.hl7.elm.r1.MinValue;
+import org.hl7.elm.r1.NamedTypeSpecifier;
+import org.hl7.elm.r1.Null;
+import org.hl7.elm.r1.PositionOf;
+import org.hl7.elm.r1.Quantity;
+import org.hl7.elm.r1.Split;
+import org.hl7.elm.r1.Substring;
+import org.hl7.elm.r1.Time;
+import org.hl7.elm.r1.Upper;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.xml.namespace.QName;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.cqframework.cql.cql2elm.matchers.HasTypeAndResult.hasTypeAndResult;
+import static org.cqframework.cql.cql2elm.matchers.ListOfLiterals.listOfLiterals;
+import static org.cqframework.cql.cql2elm.matchers.LiteralFor.literalFor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class TypeOperatorsTest {
+
+    private Map<String, ExpressionDef> defs;
+
+    @BeforeTest
+    public void setup() throws IOException {
+        CqlTranslator translator = CqlTranslator.fromStream(TypeOperatorsTest.class.getResourceAsStream("../OperatorTests/TypeOperators.cql"));
+        Library library = translator.toELM();
+        defs = new HashMap<>();
+        for (ExpressionDef def: library.getStatements().getDef()) {
+            defs.put(def.getName(), def);
+        }
+    }
+
+    @Test
+    public void testAs() {
+        ExpressionDef def = defs.get("AsExpression");
+        assertThat(def, hasTypeAndResult(As.class, "System.Boolean"));
+        As as = (As) def.getExpression();
+        assertThat(as.getOperand(), instanceOf(Null.class));
+        assertThat(as.getAsTypeSpecifier(), instanceOf(NamedTypeSpecifier.class));
+        NamedTypeSpecifier spec = (NamedTypeSpecifier) as.getAsTypeSpecifier();
+        assertThat(spec.getName(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+        assertThat(spec.getResultType().toString(), is("System.Boolean"));
+        //assertThat(as.getAsType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+    }
+
+    @Test
+    public void testCast() {
+        ExpressionDef def = defs.get("CastExpression");
+        assertThat(def, hasTypeAndResult(As.class, "System.Boolean"));
+        As as = (As) def.getExpression();
+        assertThat(as.getOperand(), instanceOf(Null.class));
+        assertThat(as.getAsTypeSpecifier(), instanceOf(NamedTypeSpecifier.class));
+        NamedTypeSpecifier spec = (NamedTypeSpecifier) as.getAsTypeSpecifier();
+        assertThat(spec.getName(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+        assertThat(spec.getResultType().toString(), is("System.Boolean"));
+        //assertThat(as.getAsType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+    }
+
+    @Test
+    public void testIs() {
+        ExpressionDef def = defs.get("IsExpression");
+        assertThat(def, hasTypeAndResult(Is.class, "System.Boolean"));
+        Is is = (Is) def.getExpression();
+        assertThat(is.getOperand(), instanceOf(Null.class));
+        assertThat(is.getIsTypeSpecifier(), instanceOf(NamedTypeSpecifier.class));
+        NamedTypeSpecifier spec = (NamedTypeSpecifier) is.getIsTypeSpecifier();
+        assertThat(spec.getName(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+        assertThat(spec.getResultType().toString(), is("System.Boolean"));
+        //assertThat(is.getIsType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+    }
+
+    @Test
+    public void testToString() {
+        ExpressionDef def = defs.get("BooleanToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(false));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("IntegerToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(3));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("DecimalToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(3.0));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("QuantityToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(Quantity.class));
+        Quantity q = (Quantity) convert.getOperand();
+        assertThat(q.getValue().doubleValue(), is(3.0));
+        assertThat(q.getUnit(), is("m"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("DateTimeToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(DateTime.class));
+        DateTime dt = (DateTime) convert.getOperand();
+        assertThat(dt.getYear(), literalFor(2014));
+        assertThat(dt.getMonth(), literalFor(1));
+        assertThat(dt.getDay(), literalFor(1));
+        assertThat(dt.getHour(), literalFor(0));
+        assertThat(dt.getMinute(), literalFor(0));
+        assertThat(dt.getSecond(), literalFor(0));
+        assertThat(dt.getMillisecond(), literalFor(0));
+        assertThat(dt.getTimezoneOffset(), nullValue());
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("TimeToString");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(Time.class));
+        Time t = (Time) convert.getOperand();
+        assertThat(t.getHour(), literalFor(0));
+        assertThat(t.getMinute(), literalFor(0));
+        assertThat(t.getSecond(), literalFor(0));
+        assertThat(t.getMillisecond(), literalFor(0));
+        assertThat(t.getTimezoneOffset(), nullValue());
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToStringFunction() {
+        ExpressionDef def = defs.get("BooleanToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(false));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("IntegerToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(3));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("DecimalToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(3.0));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("QuantityToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(Quantity.class));
+        Quantity q = (Quantity) convert.getOperand();
+        assertThat(q.getValue().doubleValue(), is(3.0));
+        assertThat(q.getUnit(), is("m"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("DateTimeToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(DateTime.class));
+        DateTime dt = (DateTime) convert.getOperand();
+        assertThat(dt.getYear(), literalFor(2014));
+        assertThat(dt.getMonth(), literalFor(1));
+        assertThat(dt.getDay(), literalFor(1));
+        assertThat(dt.getHour(), literalFor(0));
+        assertThat(dt.getMinute(), literalFor(0));
+        assertThat(dt.getSecond(), literalFor(0));
+        assertThat(dt.getMillisecond(), literalFor(0));
+        assertThat(dt.getTimezoneOffset(), nullValue());
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("TimeToStringFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.String"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(Time.class));
+        Time t = (Time) convert.getOperand();
+        assertThat(t.getHour(), literalFor(0));
+        assertThat(t.getMinute(), literalFor(0));
+        assertThat(t.getSecond(), literalFor(0));
+        assertThat(t.getMillisecond(), literalFor(0));
+        assertThat(t.getTimezoneOffset(), nullValue());
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "String")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToBoolean() {
+        ExpressionDef def = defs.get("StringToBoolean");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Boolean"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("false"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToBooleanFunction() {
+        ExpressionDef def = defs.get("StringToBooleanFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Boolean"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("false"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Boolean")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToInteger() {
+        ExpressionDef def = defs.get("StringToInteger");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Integer"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("1"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Integer")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToIntegerFunction() {
+        ExpressionDef def = defs.get("StringToIntegerFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Integer"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("1"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Integer")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToDecimal() {
+        ExpressionDef def = defs.get("StringToDecimal");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("3.0"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("IntegerToDecimal");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(1));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToDecimalFunction() {
+        ExpressionDef def = defs.get("StringToDecimalFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("3.0"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("IntegerToDecimal");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Decimal"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor(1));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToDateTime() {
+        ExpressionDef def = defs.get("StringToDateTime");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.DateTime"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("2014-01-01T00:00:00:00.0000+0700"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "DateTime")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToDateTimeFunction() {
+        ExpressionDef def = defs.get("StringToDateTimeFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.DateTime"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("2014-01-01T00:00:00:00.0000+0700"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "DateTime")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToTime() {
+        ExpressionDef def = defs.get("StringToTime");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Time"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("T00:00:00:00.0000+0700"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Time")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToTimeFunction() {
+        ExpressionDef def = defs.get("StringToTimeFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Time"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), literalFor("T00:00:00:00.0000+0700"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Time")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToConcept() {
+        ExpressionDef def = defs.get("CodeToConcept");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Concept"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(ExpressionRef.class));
+        ExpressionRef ref = (ExpressionRef) convert.getOperand();
+        assertThat(ref.getName(), is("MyCode"));
+        assertThat(ref.getResultType().toString(), is("System.Code"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("CodesToConcept");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Concept"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(ExpressionRef.class));
+        ref = (ExpressionRef) convert.getOperand();
+        assertThat(ref.getName(), is("MyCodes"));
+        assertThat(ref.getResultType().toString(), is("list<System.Code>"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testToConceptFunction() {
+        ExpressionDef def = defs.get("CodeToConceptFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Concept"));
+        Convert convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(ExpressionRef.class));
+        ExpressionRef ref = (ExpressionRef) convert.getOperand();
+        assertThat(ref.getName(), is("MyCode"));
+        assertThat(ref.getResultType().toString(), is("System.Code"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+
+        def = defs.get("CodesToConceptFun");
+        assertThat(def, hasTypeAndResult(Convert.class, "System.Concept"));
+        convert = (Convert) def.getExpression();
+        assertThat(convert.getOperand(), instanceOf(ExpressionRef.class));
+        ref = (ExpressionRef) convert.getOperand();
+        assertThat(ref.getName(), is("MyCodes"));
+        assertThat(ref.getResultType().toString(), is("list<System.Code>"));
+        assertThat(convert.getToType(), is(new QName("urn:hl7-org:elm-types:r1", "Concept")));
+        assertThat(convert.getToTypeSpecifier(), nullValue());
+    }
+
+    @Test
+    public void testMinValue() {
+        ExpressionDef def = defs.get("MinimumInteger");
+        assertThat(def, hasTypeAndResult(MinValue.class, "System.Integer"));
+        MinValue minValue = (MinValue) def.getExpression();
+        assertThat(minValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Integer")));
+
+        def = defs.get("MinimumDecimal");
+        assertThat(def, hasTypeAndResult(MinValue.class, "System.Decimal"));
+        minValue = (MinValue) def.getExpression();
+        assertThat(minValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+
+        def = defs.get("MinimumDateTime");
+        assertThat(def, hasTypeAndResult(MinValue.class, "System.DateTime"));
+        minValue = (MinValue) def.getExpression();
+        assertThat(minValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "DateTime")));
+
+        def = defs.get("MinimumTime");
+        assertThat(def, hasTypeAndResult(MinValue.class, "System.Time"));
+        minValue = (MinValue) def.getExpression();
+        assertThat(minValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Time")));
+    }
+
+    @Test
+    public void testMaxValue() {
+        ExpressionDef def = defs.get("MaximumInteger");
+        assertThat(def, hasTypeAndResult(MaxValue.class, "System.Integer"));
+        MaxValue maxValue = (MaxValue) def.getExpression();
+        assertThat(maxValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Integer")));
+
+        def = defs.get("MaximumDecimal");
+        assertThat(def, hasTypeAndResult(MaxValue.class, "System.Decimal"));
+        maxValue = (MaxValue) def.getExpression();
+        assertThat(maxValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Decimal")));
+
+        def = defs.get("MaximumDateTime");
+        assertThat(def, hasTypeAndResult(MaxValue.class, "System.DateTime"));
+        maxValue = (MaxValue) def.getExpression();
+        assertThat(maxValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "DateTime")));
+
+        def = defs.get("MaximumTime");
+        assertThat(def, hasTypeAndResult(MaxValue.class, "System.Time"));
+        maxValue = (MaxValue) def.getExpression();
+        assertThat(maxValue.getValueType(), is(new QName("urn:hl7-org:elm-types:r1", "Time")));
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/operators/TypeOperatorsTest.java
@@ -21,6 +21,7 @@ import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.cqframework.cql.cql2elm.LibraryManager;
 
 import static org.cqframework.cql.cql2elm.matchers.HasTypeAndResult.hasTypeAndResult;
 import static org.cqframework.cql.cql2elm.matchers.LiteralFor.literalFor;
@@ -36,7 +37,7 @@ public class TypeOperatorsTest {
 
     @BeforeTest
     public void setup() throws IOException {
-        CqlTranslator translator = CqlTranslator.fromStream(TypeOperatorsTest.class.getResourceAsStream("../OperatorTests/TypeOperators.cql"));
+        CqlTranslator translator = CqlTranslator.fromStream(TypeOperatorsTest.class.getResourceAsStream("../OperatorTests/TypeOperators.cql"), new LibraryManager());
         Library library = translator.toELM();
         defs = new HashMap<>();
         for (ExpressionDef def: library.getStatements().getDef()) {

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/OperatorTests/TypeOperators.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/OperatorTests/TypeOperators.cql
@@ -1,25 +1,56 @@
+codesystem "FAKECS": '1.2.3.4.5.6.7.8.9' version '1'
+
 define AsExpression: null as Boolean
 define CastExpression: cast null as Boolean
 define IsExpression: null is Boolean
 
 // ToString(Boolean) : String
 define BooleanToString: convert false to String
+define BooleanToStringFun: ToString(false)
 // ToString(Integer) : String
 define IntegerToString: convert 3 to String
+define IntegerToStringFun: ToString(3)
 // ToString(Decimal) : String
 define DecimalToString: convert 3.0 to String
+define DecimalToStringFun: ToString(3.0)
+// ToString(Quantity) : String
+define QuantityToString: convert 3.0'm' to String
+define QuantityToStringFun: ToString(3.0'm')
 // ToString(DateTime) : String
-define DateTimeToString: convert DateTime(2014, 1, 1, 0, 0, 0, 0) to String
+define DateTimeToString: convert @2014-01-01T00:00:00.0 to String
+define DateTimeToStringFun: ToString(@2014-01-01T00:00:00.0)
+// ToString(Time) : String
+define TimeToString: convert @T00:00:00.0 to String
+define TimeToStringFun: ToString(@T00:00:00.0)
 // ToBoolean(String) : Boolean
 define StringToBoolean: convert 'false' to Boolean
+define StringToBooleanFun: ToBoolean('false')
 // ToInteger(String) : Integer
 define StringToInteger: convert '1' to Integer
+define StringToIntegerFun: ToInteger('1')
 // ToDecimal(String) : Decimal
 define StringToDecimal: convert '3.0' to Decimal
+define StringToDecimalFun: ToDecimal('3.0')
 // ToDecimal(Integer) : Decimal
 define IntegerToDecimal: convert 1 to Decimal
+define IntegerToDecimalFun: ToDecimal(1)
 // ToDateTime(String) : DateTime
 define StringToDateTime: convert '2014-01-01T00:00:00:00.0000+0700' to DateTime
+define StringToDateTimeFun: ToDateTime('2014-01-01T00:00:00:00.0000+0700')
+// ToTime(String) : DateTime
+define StringToTime: convert 'T00:00:00:00.0000+0700' to Time
+define StringToTimeFun: ToTime('T00:00:00:00.0000+0700')
+// ToConcept(Code) : DateTime
+define MyCode: Code 'ABC' from "FAKECS" display 'ABC'
+define CodeToConcept: convert MyCode to Concept
+define CodeToConceptFun: ToConcept(MyCode)
+define MyCodes: {
+  Code 'ABC' from "FAKECS" display 'ABC',
+  Code 'DEF' from "FAKECS" display 'DEF',
+  Code 'GHI' from "FAKECS" display 'GHI'
+}
+define CodesToConcept: convert MyCodes to Concept
+define CodesToConceptFun: ToConcept(MyCodes)
 
 define MinimumInteger: minimum Integer
 define MinimumDecimal: minimum Decimal

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/ClassType.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/ClassType.java
@@ -220,6 +220,9 @@ public class ClassType extends DataType implements NamedType {
         if (other instanceof TupleType) {
             TupleType tupleType = (TupleType)other;
             return getTupleType().equals(tupleType);
+        } else if (other instanceof ClassType) {
+            ClassType classType = (ClassType)other;
+            return getTupleType().equals(classType.getTupleType());            
         }
 
         return false;

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/SimpleType.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/SimpleType.java
@@ -61,7 +61,8 @@ public class SimpleType extends DataType implements NamedType {
     @Override
     public boolean isCompatibleWith(DataType other) {
         // The system type "Any" can be implicitly cast to any other type.
-        return this.equals(DataType.ANY);
+        // Any data type is compatible with itself
+        return this.equals(DataType.ANY) || this.equals(other);
     }
 
     @Override


### PR DESCRIPTION
The convert function is now implemented in CoffeeScript to match the changes to the CQL-to-ELM converter. I also bumped the artifact versions to 0.2-SNAPSHOT to provide a stable target for the cql-to-elm translation service code.