### PR TITLE
Exec updates

### DIFF
--- a/Src/coffeescript/cql-execution/package.json
+++ b/Src/coffeescript/cql-execution/package.json
@@ -16,10 +16,10 @@
   , "url" : "https://github.com/cqframework/clinical_quality_language.git"
   },
   "devDependencies": {
-    "coffee-script": "^1.8.0",
-    "mocha": "^1.21.5",
-    "should": "^4.0.4",
-    "coveralls": "^2.11.2"
+    "coffee-script": "^1.12.0",
+    "mocha": "^3.2.0",
+    "should": "^11.1.1",
+    "coveralls": "^2.11.15"
   },
   "main" : "lib/cql",
   "directories" : {

--- a/Src/coffeescript/cql-execution/src/cql.coffee
+++ b/Src/coffeescript/cql-execution/src/cql.coffee
@@ -1,4 +1,5 @@
 library     = require './elm/library'
+repository  = require './runtime/repository'
 context     = require './runtime/context'
 exec        = require './runtime/executor'
 results     = require './runtime/results'
@@ -7,6 +8,7 @@ patient     = require './cql-patient'
 codeservice = require './cql-code-service'
 
 module.exports.Library            = library.Library
+module.exports.Repository         = repository.Repository
 module.exports.Context            = context.Context
 module.exports.PatientContext     = context.PatientContext
 module.exports.PopulationContext  = context.PopulationContext

--- a/Src/coffeescript/cql-execution/src/datatypes/clinical.coffee
+++ b/Src/coffeescript/cql-execution/src/datatypes/clinical.coffee
@@ -3,10 +3,15 @@
 module.exports.Code = class Code
   constructor: (@code, @system, @version, @display) ->
 
+module.exports.Concept = class Concept
+  constructor: (@codes = [], @text) ->
+
 module.exports.ValueSet = class ValueSet
   constructor: (@oid, @version, @codes = []) ->
 
   hasCode: (code, system, version) ->
+    if code? && typeIsArray code.codes
+      code = code.codes
     if typeIsArray code
       matches = for c in code
         @hasCode c
@@ -23,4 +28,5 @@ module.exports.ValueSet = class ValueSet
     if version? then matches = (c for c in matches when c.version is version)
     return matches.length > 0
 
-# TODO: Concept (and support for constructing by literal or instance)
+module.exports.CodeSystem = class CodeSystem
+  constructor: (@id, @version) ->

--- a/Src/coffeescript/cql-execution/src/elm/arithmetic.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/arithmetic.coffee
@@ -133,6 +133,13 @@ module.exports.Ln = class Ln extends  Expression
   exec: (ctx) ->
     Math.log @execArgs(ctx)
 
+module.exports.Exp = class Exp extends  Expression
+  constructor: (json) ->
+    super
+
+  exec: (ctx) ->
+    Math.exp @execArgs(ctx)
+
 module.exports.Log = class Log extends  Expression
   constructor: (json) ->
     super

--- a/Src/coffeescript/cql-execution/src/elm/library.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/library.coffee
@@ -7,6 +7,9 @@ module.exports.Library = class Library
     @parameters = {}
     for param in json.library.parameters?.def ? []
       @parameters[param.name] = new ParameterDef(param)
+    @codesystems = {}
+    for codesystem in json.library.codeSystems?.def ? []
+      @codesystems[codesystem.name] = new CodeSystemDef(codesystem)
     @valuesets = {}
     for valueset in json.library.valueSets?.def ? []
       @valuesets[valueset.name] = new ValueSetDef(valueset)
@@ -15,7 +18,7 @@ module.exports.Library = class Library
       @expressions[expr.name] = if expr.type == "FunctionDef"  then new FunctionDef(expr) else new ExpressionDef(expr)
     @includes = {}
     for expr in json.library.includes?.def ? []
-      if libraryManager then @includes[expr.localIdentifier] =  libraryManager.resolve(expr.path,expr.version) 
+      if libraryManager then @includes[expr.localIdentifier] =  libraryManager.resolve(expr.path,expr.version)
 
   get: (identifier) ->
     @expressions[identifier] || @includes[identifier]
@@ -23,9 +26,12 @@ module.exports.Library = class Library
   getValueSet: (identifier) ->
     @valuesets[identifier]
 
+  getCodeSystem: (identifier) ->
+    @codesystems[identifier]
+
   getParameter: (name) ->
     @parameters[name]
 # These requires are at the end of the file because having them first in the
 # file creates errors due to the order that the libraries are loaded.
-{ ExpressionDef, FunctionDef, ParameterDef, ValueSetDef } = require './expressions'
+{ ExpressionDef, FunctionDef, ParameterDef, ValueSetDef, CodeSystemDef } = require './expressions'
 { Results } = require '../runtime/results'

--- a/Src/coffeescript/cql-execution/src/elm/list.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/list.coffee
@@ -63,7 +63,7 @@ module.exports.IndexOf = class IndexOf extends Expression
     el = @element.exec ctx
     if not src? or not el? then return null
     (index = i; break) for itm, i in src when equals itm, el
-    if index? then return index + 1 else return 0
+    if index? then return index else return -1
 
 # Indexer is completely handled by overloaded#Indexer
 
@@ -83,7 +83,7 @@ module.exports.doProperIncludes = (list, sublist) ->
 # ELM-only, not a product of CQL
 module.exports.ForEach = class ForEach extends UnimplementedExpression
 
-module.exports.Expand = class Expand extends Expression
+module.exports.Flatten = class Flatten extends Expression
   constructor: (json) ->
     super
 

--- a/Src/coffeescript/cql-execution/src/elm/literal.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/literal.coffee
@@ -48,4 +48,5 @@ module.exports.StringLiteral = class StringLiteral extends Literal
     super
 
   exec: (ctx) ->
-    @value
+    # TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82
+    @value.replace(/\\'/g, "'").replace(/\\"/g, "\"")

--- a/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
@@ -17,6 +17,29 @@ module.exports.Equal = class Equal extends Expression
   exec: (ctx) ->
     equals @execArgs(ctx)...
 
+module.exports.Equivalent = class Equivalent extends Expression
+  constructor: (json) ->
+    super
+
+  exec: (ctx) ->
+    # TODO: This is a quick and dirty implementation to get *something* in here.
+    # This needs to be done right (including equivalence for codes/concepts)
+    [a, b] = @execArgs(ctx)
+    if not a? or not b?
+      false
+    else if (a.code or a.codes) and (b.code or b.codes)
+      @matchCodes(a, b)
+    else
+      equals(a,b)
+
+  matchCodes: (code1,code2) ->
+    matches = []
+    if (code1.codes)
+      return (c for c in code1.codes when @matchCodes(c, code2)).length > 0
+    else if (code2.codes)
+      return @matchCodes(code2, code1)
+    return code1.code is code2.code and code1.system is code2.system and code1.version is code2.version
+
 module.exports.NotEqual = class NotEqual extends Expression
   constructor: (json) ->
     super
@@ -69,8 +92,8 @@ module.exports.Indexer = class Indexer extends Expression
   exec: (ctx) ->
     [operand, index] = @execArgs ctx
     if not operand? or not index? then return null
-    if index <= 0 or index > operand.length then throw new ArrayIndexOutOfBoundsException()
-    operand[index-1]
+    if index < 0 or index >= operand.length then throw new ArrayIndexOutOfBoundsException()
+    operand[index]
 
 module.exports.In = class In extends Expression
   constructor: (json) ->

--- a/Src/coffeescript/cql-execution/src/elm/quantity.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/quantity.coffee
@@ -10,10 +10,10 @@ module.exports.Quantity = class Quantity extends Expression
 
   exec: (ctx) ->
     @
-  
+
   toString: () ->
     "#{@value} '#{@unit}'"
-  
+
   sameOrBefore: (other) ->
     if other instanceof Quantity and other.unit == @unit then @value <= other.value else null
 
@@ -33,15 +33,15 @@ clean_unit = (units) ->
 
 module.exports.createQuantity = (value,unit) ->
   new Quantity({value: value, unit: unit})
-  
+
 module.exports.parseQuantity = (str) ->
   components = /([+|-]?\d+\.?\d*)\s*'(.+)'/.exec str
-  if components? and components[1]? and components[2]
+  if components? and components[1]? and components[2]?
     value = parseFloat(components[1])
     unit = components[2].trim()
     new Quantity({value: value, unit: unit})
   else
-    null 
+    null
 
 module.exports.doAddition = (a,b) ->
   if a instanceof Quantity and b instanceof Quantity

--- a/Src/coffeescript/cql-execution/src/elm/string.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/string.coffee
@@ -60,7 +60,7 @@ module.exports.PositionOf = class PositionOf extends Expression
   exec: (ctx) ->
     pattern = @pattern.exec(ctx)
     string = @string.exec(ctx)
-    if not (pattern? and string?) then null else 1 + string.indexOf(pattern)
+    if not (pattern? and string?) then null else string.indexOf(pattern)
 
 module.exports.Substring = class Substring extends Expression
   constructor: (json) ->
@@ -75,11 +75,11 @@ module.exports.Substring = class Substring extends Expression
     length = if @length? then @length.exec(ctx) else null
     if not (stringToSub? and startIndex?)
       null
-    else if startIndex < 1
-      throw new Error "Start index must be at least 1"
+    else if startIndex < 0
+      throw new Error "Start index must be at least zero"
     else if length? and length < 0
       throw new Error "Length must be at least zero"
     else if length?
-      stringToSub.substr(startIndex-1, length)
+      stringToSub.substr(startIndex, length)
     else
-      stringToSub.substr(startIndex-1)
+      stringToSub.substr(startIndex)

--- a/Src/coffeescript/cql-execution/src/example/CMS146v2_CQM.coffee
+++ b/Src/coffeescript/cql-execution/src/example/CMS146v2_CQM.coffee
@@ -498,12 +498,11 @@ module.exports = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "Count",
-               "type" : "FunctionRef",
-               "operand" : [ {
+               "type" : "Count",
+               "source" : {
                   "name" : "PharyngitisEncounters",
                   "type" : "ExpressionRef"
-               } ]
+               }
             }
          }, {
             "name" : "DenominatorCount",
@@ -518,21 +517,19 @@ module.exports = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "Count",
-               "type" : "FunctionRef",
-               "operand" : [ {
+               "type" : "Count",
+               "source" : {
                   "name" : "ExcludedEncounters",
                   "type" : "ExpressionRef"
-               } ]
+               }
             }
          }, {
             "name" : "NumeratorCount",
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "Count",
-               "type" : "FunctionRef",
-               "operand" : [ {
+               "type" : "Count",
+               "source" : {
                   "type" : "Except",
                   "operand" : [ {
                      "name" : "StrepTestEncounters",
@@ -541,7 +538,7 @@ module.exports = {
                      "name" : "ExcludedEncounters",
                      "type" : "ExpressionRef"
                   } ]
-               } ]
+               }
             }
          } ]
       }

--- a/Src/coffeescript/cql-execution/src/example/age.coffee
+++ b/Src/coffeescript/cql-execution/src/example/age.coffee
@@ -26,70 +26,80 @@ module.exports = {
                "highClosed" : false,
                "type" : "Interval",
                "low" : {
-                  "name" : "DateTime",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "type" : "DateTime",
+                  "year" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2013",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "month" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "day" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "hour" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "minute" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "second" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "millisecond" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  } ]
+                  }
                },
                "high" : {
-                  "name" : "DateTime",
-                  "type" : "FunctionRef",
-                  "operand" : [ {
+                  "type" : "DateTime",
+                  "year" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2014",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "month" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "day" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "1",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "hour" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "minute" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "second" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  }, {
+                  },
+                  "millisecond" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "0",
                      "type" : "Literal"
-                  } ]
+                  }
                }
             }
          } ]

--- a/Src/coffeescript/cql-execution/src/example/exec-age.coffee
+++ b/Src/coffeescript/cql-execution/src/example/exec-age.coffee
@@ -2,6 +2,7 @@ cql = require '../cql'
 measure = require './age'
 
 lib = new cql.Library(measure)
+executor = new cql.Executor(lib)
 psource = new cql.PatientSource [ {
     "resourceType": "Bundle",
     "id": "example1",
@@ -42,7 +43,5 @@ psource = new cql.PatientSource [ {
     ]
   } ]
 
-ctx = new cql.Context(lib, psource)
-
-result = lib.exec(ctx)
+result = executor.exec(psource)
 console.log JSON.stringify(result, undefined, 2)

--- a/Src/coffeescript/cql-execution/src/example/exec-cms146v2_CQM.coffee
+++ b/Src/coffeescript/cql-execution/src/example/exec-cms146v2_CQM.coffee
@@ -1,6 +1,6 @@
 cql = require '../cql'
 codes = require '../cql-code-service'
-measure = require './cms146v2_CQM'
+measure = require './CMS146v2_CQM'
 
 cservice = new codes.CodeService {
     "1.2.3.4.5": {
@@ -55,6 +55,10 @@ cservice = new codes.CodeService {
   }
 
 lib = new cql.Library(measure)
+parameters = {
+  MeasurementPeriod: new cql.Interval(cql.DateTime.parse('2013-01-01'), cql.DateTime.parse('2014-01-01'), true, false)
+}
+executor = new cql.Executor(lib, cservice, parameters)
 psource = new cql.PatientSource [ {
     "resourceType": "Bundle",
     "id": "example1",
@@ -95,7 +99,5 @@ psource = new cql.PatientSource [ {
     ]
   } ]
 
-ctx = new cql.Context(lib, psource, cservice)
-
-result = lib.exec(ctx)
+result = executor.exec(psource)
 console.log JSON.stringify(result, undefined, 2)

--- a/Src/coffeescript/cql-execution/src/runtime/context.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/context.coffee
@@ -17,7 +17,7 @@ module.exports.Context = class Context
     get: -> @_codeService || @parent?.codeService
     set: (cs) -> @_codeService = cs
 
-  
+
   withParameters: (params) ->
     @parameters = params ? {}
     @
@@ -25,7 +25,7 @@ module.exports.Context = class Context
   withCodeService: (cs) ->
     @codeService = cs
     @
-  
+
   rootContext:  ->
     if ( @parent ) then @parent.rootContext() else @
 
@@ -36,7 +36,7 @@ module.exports.Context = class Context
     ctx = new Context(@)
     ctx.context_values = context_values
     ctx
-  
+
   getLibraryContext: (library) ->
     @parent?.getLibraryContext(library)
 
@@ -45,6 +45,9 @@ module.exports.Context = class Context
 
   getValueSet: (name) ->
     @parent?.getValueSet(name)
+
+  getCodeSystem: (name) ->
+    @parent?.getCodeSystem(name)
 
   get: (identifier) ->
     @context_values[identifier] ? @parent?.get(identifier)
@@ -60,7 +63,7 @@ module.exports.PatientContext = class PatientContext extends Context
 
   getLibraryContext: (library) ->
     @library_context[library] ||= new PatientContext(@get(library),@patient,@codeService,@parameters)
-  
+
   findRecords: ( profile) ->
     @patient?.findRecords(profile)
 
@@ -70,7 +73,7 @@ module.exports.PopulationContext = class PopulationContext extends Context
 
   constructor: (@library, @results, codeService, parameters) ->
     super(@library,codeService,parameters)
-   
+
   rootContext:  -> @
 
   findRecords: (template) ->
@@ -78,11 +81,11 @@ module.exports.PopulationContext = class PopulationContext extends Context
 
   getLibraryContext: (library) ->
      throw new Exception("Library expressions are not currently supported in Population Context")
-  
+
   get: (identifier) ->
     #First check to see if the identifier is a population context expression that has already been cached
     return @context_values[identifier] if @context_values[identifier]
-    #if not look to see if the library has a population expression of that identifier 
+    #if not look to see if the library has a population expression of that identifier
     return @library.expressions[identifier] if @library[identifier]?.context == "Population"
     #lastley attempt to gather all patient level results that have that identifier
     # should this compact null values before return ?

--- a/Src/coffeescript/cql-execution/src/runtime/repository.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/repository.coffee
@@ -1,4 +1,4 @@
-{ Library } =  require '../../../lib/cql'
+cql = require '../cql'
 module.exports.Repository = class Repository
   constructor: (@data) ->
     @libraries = for k,v of @data
@@ -6,5 +6,5 @@ module.exports.Repository = class Repository
 
   resolve: (library,version) ->
     for lib in @libraries
-      if lib.library.identifier?.id == library && lib.library.identifier?.version == version
-        return new Library(lib,@)
+      if lib.library?.identifier?.id == library && lib.library?.identifier?.version == version
+        return new cql.Library(lib,@)

--- a/Src/coffeescript/cql-execution/test/elm/aggregate/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/aggregate/data.coffee
@@ -899,15 +899,10 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -959,15 +954,10 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1060,15 +1050,10 @@ module.exports['Avg'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1166,15 +1151,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1222,15 +1202,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1319,15 +1294,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1379,15 +1349,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1443,15 +1408,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1511,15 +1471,10 @@ module.exports['Median'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -1922,15 +1877,10 @@ module.exports['Variance'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -2155,15 +2105,10 @@ module.exports['StdDev'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -2282,15 +2227,10 @@ module.exports['PopulationStdDev'] = {
                   "return" : {
                      "distinct" : false,
                      "expression" : {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "name" : "X",
                            "type" : "AliasRef"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }

--- a/Src/coffeescript/cql-execution/test/elm/arithmetic/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/arithmetic/data.coffee
@@ -498,28 +498,18 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -530,28 +520,18 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "4",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -566,54 +546,34 @@ module.exports['Divide'] = {
                   "operand" : [ {
                      "type" : "Divide",
                      "operand" : [ {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "1000",
                            "type" : "Literal"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      }, {
-                        "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "Convert",
+                        "type" : "ToDecimal",
                         "operand" : {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                            "value" : "4",
                            "type" : "Literal"
-                        },
-                        "toTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                           "type" : "NamedTypeSpecifier"
                         }
                      } ]
                   }, {
-                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "Convert",
+                     "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "10",
                         "type" : "Literal"
-                     },
-                     "toTypeSpecifier" : {
-                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "NamedTypeSpecifier"
                      }
                   } ]
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "5",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -624,26 +584,16 @@ module.exports['Divide'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "name" : "Hundred",
                      "type" : "ExpressionRef"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "name" : "Four",
                      "type" : "ExpressionRef"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -753,8 +703,7 @@ module.exports['MathPrecedence'] = {
             "expression" : {
                "type" : "Subtract",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "type" : "Add",
                      "operand" : [ {
@@ -773,36 +722,22 @@ module.exports['MathPrecedence'] = {
                            "type" : "Literal"
                         } ]
                      } ]
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "type" : "Divide",
                   "operand" : [ {
-                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "Convert",
+                     "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "15",
                         "type" : "Literal"
-                     },
-                     "toTypeSpecifier" : {
-                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "NamedTypeSpecifier"
                      }
                   }, {
-                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "Convert",
+                     "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "3",
                         "type" : "Literal"
-                     },
-                     "toTypeSpecifier" : {
-                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "NamedTypeSpecifier"
                      }
                   } ]
                } ]
@@ -814,8 +749,7 @@ module.exports['MathPrecedence'] = {
             "expression" : {
                "type" : "Divide",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "type" : "Multiply",
                      "operand" : [ {
@@ -841,22 +775,13 @@ module.exports['MathPrecedence'] = {
                            "type" : "Literal"
                         } ]
                      } ]
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "3",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -1117,16 +1042,11 @@ module.exports['Ceiling'] = {
             "expression" : {
                "type" : "Ceiling",
                "operand" : {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -1193,16 +1113,11 @@ module.exports['Floor'] = {
             "expression" : {
                "type" : "Floor",
                "operand" : {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -1269,16 +1184,11 @@ module.exports['Truncate'] = {
             "expression" : {
                "type" : "Truncate",
                "operand" : {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -1520,16 +1430,11 @@ module.exports['Ln'] = {
             "expression" : {
                "type" : "Ln",
                "operand" : {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "4",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }
             }
@@ -1583,28 +1488,18 @@ module.exports['Log'] = {
             "expression" : {
                "type" : "Log",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10000",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -2373,16 +2268,11 @@ module.exports['Quantity'] = {
                "element" : [ {
                   "name" : "value",
                   "value" : {
-                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "Convert",
+                     "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "10",
                         "type" : "Literal"
-                     },
-                     "toTypeSpecifier" : {
-                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "NamedTypeSpecifier"
                      }
                   }
                }, {
@@ -2482,16 +2372,11 @@ module.exports['Quantity'] = {
                   "name" : "days_10",
                   "type" : "ExpressionRef"
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -2519,16 +2404,11 @@ module.exports['Quantity'] = {
                   "name" : "days_10",
                   "type" : "ExpressionRef"
                }, {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                } ]
             }
@@ -2539,16 +2419,11 @@ module.exports['Quantity'] = {
             "expression" : {
                "type" : "Multiply",
                "operand" : [ {
-                  "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "Convert",
+                  "type" : "ToDecimal",
                   "operand" : {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "2",
                      "type" : "Literal"
-                  },
-                  "toTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "NamedTypeSpecifier"
                   }
                }, {
                   "name" : "QL10Days",

--- a/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/data.coffee
@@ -13,7 +13,7 @@ valueset "Known": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Unknown One Arg": '1.2.3.4.5.6.7.8.9'
 valueset "Unknown Two Arg": '1.2.3.4.5.6.7.8.9' version '1'
 context Patient
-define Foo: "Bar"
+define Foo: 'Bar'
 ###
 
 module.exports['ValueSetDef'] = {
@@ -68,8 +68,9 @@ module.exports['ValueSetDef'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "Bar",
-               "type" : "IdentifierRef"
+               "valueType" : "{urn:hl7-org:elm-types:r1}String",
+               "value" : "Bar",
+               "type" : "Literal"
             }
          } ]
       }

--- a/Src/coffeescript/cql-execution/test/elm/clinical/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/data.cql
@@ -2,7 +2,7 @@
 valueset "Known": '2.16.840.1.113883.3.464.1003.101.12.1061'
 valueset "Unknown One Arg": '1.2.3.4.5.6.7.8.9'
 valueset "Unknown Two Arg": '1.2.3.4.5.6.7.8.9' version '1'
-define Foo: "Bar"
+define Foo: 'Bar'
 
 // @Test: ValueSetRef
 valueset "Acute Pharyngitis": '2.16.840.1.113883.3.464.1003.101.12.1001'

--- a/Src/coffeescript/cql-execution/test/elm/comparison/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/comparison/data.coffee
@@ -659,17 +659,17 @@ module.exports['Equal'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define AGtB_Int: 5 <> 4
-define AEqB_Int: 5 <> 5
-define ALtB_Int: 5 <> 6
-define EqTuples: Tuple{a: 1, b: Tuple{c: 1}} <> Tuple{a: 1, b: Tuple{c: 1}}
-define UneqTuples: Tuple{a: 1, b: Tuple{c: 1}} <> Tuple{a: 1, b: Tuple{c: -1}}
-define EqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
-define UneqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 201, +1.0)
-define EqDateTimesTZ: DateTime(2000, 3, 15, 23, 30, 25, 200, +1.0) <> DateTime(2000, 3, 16, 2, 30, 25, 200, +4.0)
-define UneqDateTimesTZ: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 200, +2.0)
-define PossiblyEqualDateTimes: DateTime(2000, 3, 15) <> DateTime(2000)
-define ImpossiblyEqualDateTimes: DateTime(2000, 3, 15) <> DateTime(2000, 4)
+define AGtB_Int: 5 != 4
+define AEqB_Int: 5 != 5
+define ALtB_Int: 5 != 6
+define EqTuples: Tuple{a: 1, b: Tuple{c: 1}} != Tuple{a: 1, b: Tuple{c: 1}}
+define UneqTuples: Tuple{a: 1, b: Tuple{c: 1}} != Tuple{a: 1, b: Tuple{c: -1}}
+define EqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
+define UneqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 201, +1.0)
+define EqDateTimesTZ: DateTime(2000, 3, 15, 23, 30, 25, 200, +1.0) != DateTime(2000, 3, 16, 2, 30, 25, 200, +4.0)
+define UneqDateTimesTZ: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 200, +2.0)
+define PossiblyEqualDateTimes: DateTime(2000, 3, 15) != DateTime(2000)
+define ImpossiblyEqualDateTimes: DateTime(2000, 3, 15) != DateTime(2000, 4)
 ###
 
 module.exports['NotEqual'] = {

--- a/Src/coffeescript/cql-execution/test/elm/comparison/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/comparison/data.cql
@@ -12,17 +12,17 @@ define PossiblyEqualDateTimes: DateTime(2000, 3, 15) = DateTime(2000)
 define ImpossiblyEqualDateTimes: DateTime(2000, 3, 15) = DateTime(2000, 4)
 
 // @Test: NotEqual
-define AGtB_Int: 5 <> 4
-define AEqB_Int: 5 <> 5
-define ALtB_Int: 5 <> 6
-define EqTuples: Tuple{a: 1, b: Tuple{c: 1}} <> Tuple{a: 1, b: Tuple{c: 1}}
-define UneqTuples: Tuple{a: 1, b: Tuple{c: 1}} <> Tuple{a: 1, b: Tuple{c: -1}}
-define EqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
-define UneqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 201, +1.0)
-define EqDateTimesTZ: DateTime(2000, 3, 15, 23, 30, 25, 200, +1.0) <> DateTime(2000, 3, 16, 2, 30, 25, 200, +4.0)
-define UneqDateTimesTZ: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) <> DateTime(2000, 3, 15, 13, 30, 25, 200, +2.0)
-define PossiblyEqualDateTimes: DateTime(2000, 3, 15) <> DateTime(2000)
-define ImpossiblyEqualDateTimes: DateTime(2000, 3, 15) <> DateTime(2000, 4)
+define AGtB_Int: 5 != 4
+define AEqB_Int: 5 != 5
+define ALtB_Int: 5 != 6
+define EqTuples: Tuple{a: 1, b: Tuple{c: 1}} != Tuple{a: 1, b: Tuple{c: 1}}
+define UneqTuples: Tuple{a: 1, b: Tuple{c: 1}} != Tuple{a: 1, b: Tuple{c: -1}}
+define EqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0)
+define UneqDateTimes: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 201, +1.0)
+define EqDateTimesTZ: DateTime(2000, 3, 15, 23, 30, 25, 200, +1.0) != DateTime(2000, 3, 16, 2, 30, 25, 200, +4.0)
+define UneqDateTimesTZ: DateTime(2000, 3, 15, 13, 30, 25, 200, +1.0) != DateTime(2000, 3, 15, 13, 30, 25, 200, +2.0)
+define PossiblyEqualDateTimes: DateTime(2000, 3, 15) != DateTime(2000)
+define ImpossiblyEqualDateTimes: DateTime(2000, 3, 15) != DateTime(2000, 4)
 
 // @Test: Less
 define AGtB_Int: 5 < 4

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -19,10 +19,10 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
-define quantityStr: convert '10 ''A''' to Quantity
-define posQuantityStr: convert '+10 ''A''' to Quantity
-define negQuantityStr: convert '-10 ''A''' to Quantity
-define quantityStrDecimal: convert '10.0''mA''' to Quantity
+define quantityStr: convert '10 \'A\'' to Quantity
+define posQuantityStr: convert '+10 \'A\'' to Quantity
+define negQuantityStr: convert '-10 \'A\'' to Quantity
+define quantityStrDecimal: convert '10.0 \'mA\'' to Quantity
 define dateStr: convert '2015-01-02' to DateTime
 ###
 
@@ -94,16 +94,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "Convert",
+               "type" : "ToBoolean",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "true",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -111,16 +106,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Boolean",
-               "type" : "Convert",
+               "type" : "ToBoolean",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "false",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -128,16 +118,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-               "type" : "Convert",
+               "type" : "ToDecimal",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "10.2",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -145,16 +130,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-               "type" : "Convert",
+               "type" : "ToDecimal",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "abc",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -162,16 +142,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
-               "type" : "Convert",
+               "type" : "ToInteger",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "10",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -179,16 +154,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
-               "type" : "Convert",
+               "type" : "ToInteger",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "10.2",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -196,16 +166,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Integer",
-               "type" : "Convert",
+               "type" : "ToInteger",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "abc",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -213,16 +178,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
-               "type" : "Convert",
+               "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10 'A'",
+                  "value" : "10 \\'A\\'",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -230,16 +190,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
-               "type" : "Convert",
+               "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "+10 'A'",
+                  "value" : "+10 \\'A\\'",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -247,16 +202,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
-               "type" : "Convert",
+               "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "-10 'A'",
+                  "value" : "-10 \\'A\\'",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -264,16 +214,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Quantity",
-               "type" : "Convert",
+               "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10.0'mA'",
+                  "value" : "10.0 \\'mA\\'",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -281,16 +226,11 @@ module.exports['FromString'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}DateTime",
-               "type" : "Convert",
+               "type" : "ToDateTime",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "2015-01-02",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          } ]
@@ -344,16 +284,11 @@ module.exports['FromInteger'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "10",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -361,16 +296,11 @@ module.exports['FromInteger'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-               "type" : "Convert",
+               "type" : "ToDecimal",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                   "value" : "10",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -456,16 +386,11 @@ module.exports['FromQuantity'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "value" : 10,
                   "unit" : "A",
                   "type" : "Quantity"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -473,8 +398,7 @@ module.exports['FromQuantity'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "type" : "Negate",
                   "operand" : {
@@ -482,10 +406,6 @@ module.exports['FromQuantity'] = {
                      "unit" : "A",
                      "type" : "Quantity"
                   }
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -493,16 +413,11 @@ module.exports['FromQuantity'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "value" : 10,
                   "unit" : "A",
                   "type" : "Quantity"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -573,16 +488,11 @@ module.exports['FromBoolean'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "value" : "true",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -590,16 +500,11 @@ module.exports['FromBoolean'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
                   "value" : "false",
                   "type" : "Literal"
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -685,8 +590,7 @@ module.exports['FromDateTime'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "type" : "DateTime",
                   "year" : {
@@ -704,10 +608,6 @@ module.exports['FromDateTime'] = {
                      "value" : "2",
                      "type" : "Literal"
                   }
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {
@@ -789,8 +689,7 @@ module.exports['FromTime'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "toType" : "{urn:hl7-org:elm-types:r1}String",
-               "type" : "Convert",
+               "type" : "ToString",
                "operand" : {
                   "type" : "Time",
                   "hour" : {
@@ -803,10 +702,6 @@ module.exports['FromTime'] = {
                      "value" : "57",
                      "type" : "Literal"
                   }
-               },
-               "toTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}String",
-                  "type" : "NamedTypeSpecifier"
                }
             }
          }, {

--- a/Src/coffeescript/cql-execution/test/elm/convert/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.cql
@@ -8,10 +8,10 @@ define decimalInvalid: convert 'abc' to Decimal
 define integerValid: convert '10' to Integer
 define integerDropDecimal: convert '10.2' to Integer
 define integerInvalid: convert 'abc' to Integer
-define quantityStr: convert '10 ''A''' to Quantity
-define posQuantityStr: convert '+10 ''A''' to Quantity
-define negQuantityStr: convert '-10 ''A''' to Quantity
-define quantityStrDecimal: convert '10.0''mA''' to Quantity
+define quantityStr: convert '10 \'A\'' to Quantity
+define posQuantityStr: convert '+10 \'A\'' to Quantity
+define negQuantityStr: convert '-10 \'A\'' to Quantity
+define quantityStrDecimal: convert '10.0 \'mA\'' to Quantity
 define dateStr: convert '2015-01-02' to DateTime
 
 // @Test: FromInteger

--- a/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/instance/data.coffee
@@ -71,16 +71,11 @@ module.exports['Instance'] = {
                }, {
                   "name" : "value",
                   "value" : {
-                     "toType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                     "type" : "Convert",
+                     "type" : "ToDecimal",
                      "operand" : {
                         "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                         "value" : "12",
                         "type" : "Literal"
-                     },
-                     "toTypeSpecifier" : {
-                        "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                        "type" : "NamedTypeSpecifier"
                      }
                   }
                } ]

--- a/Src/coffeescript/cql-execution/test/elm/interval/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/interval/data.coffee
@@ -1016,16 +1016,16 @@ module.exports['Equal'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define EqualClosed: Interval[1, 5] <> Interval[1, 5]
-define EqualOpen: Interval(1, 5) <> Interval(1, 5)
-define EqualOpenClosed: Interval(1, 5) <> Interval[2, 4]
-define UnequalClosed: Interval[1, 5] <> Interval[2, 4]
-define UnequalOpen: Interval(1, 5) <> Interval(2, 4)
-define UnequalClosedOpen: Interval[1, 5] <> Interval(2, 4)
-define EqualDates: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) <> Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0))
-define EqualDatesOpenClosed: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) <> Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 12, 31, 23, 59, 59, 999)]
-define SameDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) <> Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1))
-define DifferentDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) <> Interval[DateTime(2012, 1, 1), DateTime(2012, 7, 1))
+define EqualClosed: Interval[1, 5] != Interval[1, 5]
+define EqualOpen: Interval(1, 5) != Interval(1, 5)
+define EqualOpenClosed: Interval(1, 5) != Interval[2, 4]
+define UnequalClosed: Interval[1, 5] != Interval[2, 4]
+define UnequalOpen: Interval(1, 5) != Interval(2, 4)
+define UnequalClosedOpen: Interval[1, 5] != Interval(2, 4)
+define EqualDates: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) != Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0))
+define EqualDatesOpenClosed: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) != Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 12, 31, 23, 59, 59, 999)]
+define SameDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) != Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1))
+define DifferentDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) != Interval[DateTime(2012, 1, 1), DateTime(2012, 7, 1))
 ###
 
 module.exports['NotEqual'] = {

--- a/Src/coffeescript/cql-execution/test/elm/interval/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/interval/data.cql
@@ -17,16 +17,16 @@ define SameDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) = Interval
 define DifferentDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) = Interval[DateTime(2012, 1, 1), DateTime(2012, 7, 1))
 
 // @Test: NotEqual
-define EqualClosed: Interval[1, 5] <> Interval[1, 5]
-define EqualOpen: Interval(1, 5) <> Interval(1, 5)
-define EqualOpenClosed: Interval(1, 5) <> Interval[2, 4]
-define UnequalClosed: Interval[1, 5] <> Interval[2, 4]
-define UnequalOpen: Interval(1, 5) <> Interval(2, 4)
-define UnequalClosedOpen: Interval[1, 5] <> Interval(2, 4)
-define EqualDates: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) <> Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0))
-define EqualDatesOpenClosed: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) <> Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 12, 31, 23, 59, 59, 999)]
-define SameDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) <> Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1))
-define DifferentDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) <> Interval[DateTime(2012, 1, 1), DateTime(2012, 7, 1))
+define EqualClosed: Interval[1, 5] != Interval[1, 5]
+define EqualOpen: Interval(1, 5) != Interval(1, 5)
+define EqualOpenClosed: Interval(1, 5) != Interval[2, 4]
+define UnequalClosed: Interval[1, 5] != Interval[2, 4]
+define UnequalOpen: Interval(1, 5) != Interval(2, 4)
+define UnequalClosedOpen: Interval[1, 5] != Interval(2, 4)
+define EqualDates: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) != Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0))
+define EqualDatesOpenClosed: Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2013, 1, 1, 0, 0, 0, 0)) != Interval[DateTime(2012, 1, 1, 0, 0, 0, 0), DateTime(2012, 12, 31, 23, 59, 59, 999)]
+define SameDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) != Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1))
+define DifferentDays: Interval[DateTime(2012, 1, 1), DateTime(2013, 1, 1)) != Interval[DateTime(2012, 1, 1), DateTime(2012, 7, 1))
 
 // @Test: Contains
 define ContainsInt: Interval[1, 5] contains 3

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -346,7 +346,7 @@ context Patient
 
 define ID: common.InDemographic
 
-define L : Length(Patient.name[1].given[1])
+define L : Length(Patient.name[0].given[0])
 define FuncTest : common.foo(2, 5)
 ###
 
@@ -465,13 +465,13 @@ module.exports['Using CommonLib'] = {
                            }
                         }, {
                            "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                           "value" : "1",
+                           "value" : "0",
                            "type" : "Literal"
                         } ]
                      }
                   }, {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                     "value" : "1",
+                     "value" : "0",
                      "type" : "Literal"
                   } ]
                }

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -29,7 +29,7 @@ context Patient
 
 define ID: common.InDemographic
 
-define L : Length(Patient.name[1].given[1])
+define L : Length(Patient.name[0].given[0])
 define FuncTest : common.foo(2, 5)
 
 

--- a/Src/coffeescript/cql-execution/test/elm/library/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/test.coffee
@@ -1,7 +1,7 @@
 should = require 'should'
 setup = require '../../setup'
 data = require './data'
-{Repository} = require './repository'
+{Repository} = require '../../../lib/cql'
 
 { p1, p2 } = require './patients'
 
@@ -21,11 +21,11 @@ describe 'In Age Demographic', ->
 describe 'Using CommonLib', ->
   @beforeEach ->
     setup @, data, [ p1, p2 ], {}, {}, new Repository(data)
-    
+
   it "should have using models defined", ->
     @lib.usings.should.not.be.empty
     @lib.usings.length.should.equal 1
-    @lib.usings[0].name.should.equal "QUICK" 
+    @lib.usings[0].name.should.equal "QUICK"
 
   it 'Should have included a library', ->
     @lib.includes.should.not.be.empty

--- a/Src/coffeescript/cql-execution/test/elm/list/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/list/data.coffee
@@ -626,13 +626,13 @@ module.exports['Equal'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define EqualIntList: {1, 2, 3} <> {1, 2, 3}
-define UnequalIntList: {1, 2, 3} <> {1, 2}
-define ReverseIntList: {1, 2, 3} <> {3, 2, 1}
-define EqualStringList: {'hello', 'world'} <> {'hello', 'world'}
-define UnequalStringList: {'hello', 'world'} <> {'foo', 'bar'}
-define EqualTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } <> List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} }
-define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } <> List<Any>{ Tuple{a: 1, b: Tuple{c: -1}}, Tuple{x: 'y', z: 2} }
+define EqualIntList: {1, 2, 3} != {1, 2, 3}
+define UnequalIntList: {1, 2, 3} != {1, 2}
+define ReverseIntList: {1, 2, 3} != {3, 2, 1}
+define EqualStringList: {'hello', 'world'} != {'hello', 'world'}
+define UnequalStringList: {'hello', 'world'} != {'foo', 'bar'}
+define EqualTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } != List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} }
+define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } != List<Any>{ Tuple{a: 1, b: Tuple{c: -1}}, Tuple{x: 'y', z: 2} }
 ###
 
 module.exports['NotEqual'] = {
@@ -2723,7 +2723,7 @@ module.exports['IndexOf'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define SecondItem: {'a', 'b', 'c', 'd'}[2]
+define SecondItem: {'a', 'b', 'c', 'd'}[1]
 define ZeroIndex: {'a', 'b', 'c', 'd'}[0]
 define OutOfBounds: {'a', 'b', 'c', 'd'}[100]
 define NullList: (null as List<String>)[1]
@@ -2788,7 +2788,7 @@ module.exports['Indexer'] = {
                   } ]
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "value" : "2",
+                  "value" : "1",
                   "type" : "Literal"
                } ]
             }
@@ -5659,15 +5659,15 @@ module.exports['ProperIncludedIn'] = {
    }
 }
 
-### Expand
+### Flatten
 library TestSnippet version '1'
 using QUICK
 context Patient
-define ListOfLists: expand { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {9, 8, 7, 6, 5}, {4}, {3, 2, 1} }
-define NullValue: expand null
+define ListOfLists: flatten { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {9, 8, 7, 6, 5}, {4}, {3, 2, 1} }
+define NullValue: flatten null
 ###
 
-module.exports['Expand'] = {
+module.exports['Flatten'] = {
    "library" : {
       "identifier" : {
          "id" : "TestSnippet",
@@ -5703,7 +5703,7 @@ module.exports['Expand'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Expand",
+               "type" : "Flatten",
                "operand" : {
                   "type" : "List",
                   "element" : [ {
@@ -5804,7 +5804,7 @@ module.exports['Expand'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "type" : "Expand",
+               "type" : "Flatten",
                "operand" : {
                   "type" : "As",
                   "operand" : {

--- a/Src/coffeescript/cql-execution/test/elm/list/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/list/data.cql
@@ -20,13 +20,13 @@ define EqualTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 
 define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } = List<Any>{ Tuple{a: 1, b: Tuple{c: -1}}, Tuple{x: 'y', z: 2} }
 
 // @Test: NotEqual
-define EqualIntList: {1, 2, 3} <> {1, 2, 3}
-define UnequalIntList: {1, 2, 3} <> {1, 2}
-define ReverseIntList: {1, 2, 3} <> {3, 2, 1}
-define EqualStringList: {'hello', 'world'} <> {'hello', 'world'}
-define UnequalStringList: {'hello', 'world'} <> {'foo', 'bar'}
-define EqualTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } <> List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} }
-define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } <> List<Any>{ Tuple{a: 1, b: Tuple{c: -1}}, Tuple{x: 'y', z: 2} }
+define EqualIntList: {1, 2, 3} != {1, 2, 3}
+define UnequalIntList: {1, 2, 3} != {1, 2}
+define ReverseIntList: {1, 2, 3} != {3, 2, 1}
+define EqualStringList: {'hello', 'world'} != {'hello', 'world'}
+define UnequalStringList: {'hello', 'world'} != {'foo', 'bar'}
+define EqualTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } != List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} }
+define UnequalTupleList: List<Any>{ Tuple{a: 1, b: Tuple{c: 1}}, Tuple{x: 'y', z: 2} } != List<Any>{ Tuple{a: 1, b: Tuple{c: -1}}, Tuple{x: 'y', z: 2} }
 
 // @Test: Union
 define OneToTen: {1, 2, 3, 4, 5} union {6, 7, 8, 9, 10}
@@ -67,7 +67,7 @@ define NullList: IndexOf(null, 'a')
 define NullItem: IndexOf({'a', 'b', 'c'}, null)
 
 // @Test: Indexer
-define SecondItem: {'a', 'b', 'c', 'd'}[2]
+define SecondItem: {'a', 'b', 'c', 'd'}[1]
 define ZeroIndex: {'a', 'b', 'c', 'd'}[0]
 define OutOfBounds: {'a', 'b', 'c', 'd'}[100]
 define NullList: (null as List<String>)[1]
@@ -129,9 +129,9 @@ define TuplesNotIncluded: {Tuple{a:2, b:'d'}, Tuple{a:3, b:'c'}} properly includ
 define NullIncludes: {1, 2, 3, 4, 5} properly included in null
 define NullIncluded: (null as List<Integer>) properly included in {1, 2, 3, 4, 5}
 
-// @Test: Expand
-define ListOfLists: expand { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {9, 8, 7, 6, 5}, {4}, {3, 2, 1} }
-define NullValue: expand null
+// @Test: Flatten
+define ListOfLists: flatten { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {9, 8, 7, 6, 5}, {4}, {3, 2, 1} }
+define NullValue: flatten null
 
 // @Test: Distinct
 define LotsOfDups: distinct {1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 3, 2, 1}

--- a/Src/coffeescript/cql-execution/test/elm/list/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/list/test.coffee
@@ -161,17 +161,17 @@ describe 'IndexOf', ->
   @beforeEach ->
     setup @, data
 
-  it 'should return the correct 1-based index when an item is in the list', ->
-    @indexOfSecond.exec(@ctx).should.equal 2
+  it 'should return the correct 0-based index when an item is in the list', ->
+    @indexOfSecond.exec(@ctx).should.equal 1
 
   it 'should work with complex types like tuples', ->
-    @indexOfThirdTuple.exec(@ctx).should.equal 3
+    @indexOfThirdTuple.exec(@ctx).should.equal 2
 
   it 'should return the first index when there are multiple matches', ->
-    @multipleMatches.exec(@ctx).should.equal 4
+    @multipleMatches.exec(@ctx).should.equal 3
 
-  it 'should return 0 when the item is not in the list', ->
-    @itemNotFound.exec(@ctx).should.equal 0
+  it 'should return -1 when the item is not in the list', ->
+    @itemNotFound.exec(@ctx).should.equal -1
 
   it 'should return null if either arg is null', ->
     should(@nullList.exec(@ctx)).be.null
@@ -181,15 +181,14 @@ describe 'Indexer', ->
   @beforeEach ->
     setup @, data
 
-  it 'should return the correct item based on the 1-based index', ->
+  it 'should return the correct item based on the 0-based index', ->
     @secondItem.exec(@ctx).should.equal 'b'
 
-  it 'should throw ArrayIndexOutOfBoundsException when accessing index 0', ->
+  it 'should NOT throw ArrayIndexOutOfBoundsException when accessing index 0', ->
     try
       @zeroIndex.exec(@ctx)
-      should.fail("Accessing index zero should throw ArrayIndexOutOfBoundsException")
     catch e
-      e.should.be.instanceof ArrayIndexOutOfBoundsException
+      should.fail("Accessing index zero should not throw ArrayIndexOutOfBoundsException")
 
   it 'should throw ArrayIndexOutOfBoundsException when accessing out of bounds index', ->
     try
@@ -347,11 +346,11 @@ describe 'ProperIncludedIn', ->
     should(@nullIncluded.exec(@ctx)).be.null
     should(@nullIncludes.exec(@ctx)).be.null
 
-describe 'Expand', ->
+describe 'Flatten', ->
   @beforeEach ->
     setup @, data
 
-  it 'should expand a list of lists', ->
+  it 'should flatten a list of lists', ->
     @listOfLists.exec(@ctx).should.eql [1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 
   it 'should return null for a null list', ->

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
@@ -14,7 +14,7 @@ parameter IntParameter Integer
 parameter ListParameter List<String>
 parameter TupleParameter Tuple{a Integer, b String, c Boolean, d List<Integer>, e Tuple{ f String, g Boolean}}
 context Patient
-define foo: "bar"
+define foo: 'bar'
 ###
 
 module.exports['ParameterDef'] = {
@@ -133,8 +133,9 @@ module.exports['ParameterDef'] = {
             "context" : "Patient",
             "accessLevel" : "Public",
             "expression" : {
-               "name" : "bar",
-               "type" : "IdentifierRef"
+               "valueType" : "{urn:hl7-org:elm-types:r1}String",
+               "value" : "bar",
+               "type" : "Literal"
             }
          } ]
       }

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
@@ -3,7 +3,7 @@ parameter MeasureYear default 2012
 parameter IntParameter Integer
 parameter ListParameter List<String>
 parameter TupleParameter Tuple{a Integer, b String, c Boolean, d List<Integer>, e Tuple{ f String, g Boolean}}
-define foo: "bar"
+define foo: 'bar'
 
 // @Test: ParameterRef
 parameter FooP default 'Bar'

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -753,16 +753,16 @@ module.exports['QueryRelationship'] = {
    }
 }
 
-### QueryDefine
+### QueryLet
 library TestSnippet version '1'
 using QUICK
 context Patient
 define query:  [Encounter] E
-define a: E
+let a: E
 return {E: E, a:a}
 ###
 
-module.exports['QueryDefine'] = {
+module.exports['QueryLet'] = {
    "library" : {
       "identifier" : {
          "id" : "TestSnippet",
@@ -807,7 +807,7 @@ module.exports['QueryDefine'] = {
                      "type" : "Retrieve"
                   }
                } ],
-               "define" : [ {
+               "let" : [ {
                   "identifier" : "a",
                   "expression" : {
                      "name" : "E",
@@ -828,7 +828,7 @@ module.exports['QueryDefine'] = {
                         "name" : "a",
                         "value" : {
                            "name" : "a",
-                           "type" : "QueryDefineRef"
+                           "type" : "QueryLetRef"
                         }
                      } ]
                   }
@@ -987,11 +987,8 @@ module.exports['Sorting'] = {
                "sort" : {
                   "by" : [ {
                      "direction" : "asc",
-                     "type" : "ByExpression",
-                     "expression" : {
-                        "name" : "id",
-                        "type" : "IdentifierRef"
-                     }
+                     "path" : "id",
+                     "type" : "ByColumn"
                   } ]
                }
             }
@@ -1019,11 +1016,8 @@ module.exports['Sorting'] = {
                "sort" : {
                   "by" : [ {
                      "direction" : "asc",
-                     "type" : "ByExpression",
-                     "expression" : {
-                        "name" : "id",
-                        "type" : "IdentifierRef"
-                     }
+                     "path" : "id",
+                     "type" : "ByColumn"
                   } ]
                }
             }
@@ -1060,8 +1054,11 @@ module.exports['Sorting'] = {
                      "type" : "ByExpression",
                      "expression" : {
                         "path" : "id",
-                        "scope" : "E",
-                        "type" : "Property"
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "E",
+                           "type" : "IdentifierRef"
+                        }
                      }
                   } ]
                }
@@ -1084,11 +1081,8 @@ module.exports['Sorting'] = {
                "sort" : {
                   "by" : [ {
                      "direction" : "desc",
-                     "type" : "ByExpression",
-                     "expression" : {
-                        "name" : "id",
-                        "type" : "IdentifierRef"
-                     }
+                     "path" : "id",
+                     "type" : "ByColumn"
                   } ]
                }
             }
@@ -1116,11 +1110,8 @@ module.exports['Sorting'] = {
                "sort" : {
                   "by" : [ {
                      "direction" : "desc",
-                     "type" : "ByExpression",
-                     "expression" : {
-                        "name" : "id",
-                        "type" : "IdentifierRef"
-                     }
+                     "path" : "id",
+                     "type" : "ByColumn"
                   } ]
                }
             }
@@ -1157,8 +1148,11 @@ module.exports['Sorting'] = {
                      "type" : "ByExpression",
                      "expression" : {
                         "path" : "id",
-                        "scope" : "E",
-                        "type" : "Property"
+                        "type" : "Property",
+                        "source" : {
+                           "name" : "E",
+                           "type" : "IdentifierRef"
+                        }
                      }
                   } ]
                }

--- a/Src/coffeescript/cql-execution/test/elm/query/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.cql
@@ -34,9 +34,9 @@ without [Condition] C such that C.id = 'http://cqframework.org/3/'
 define withOutQuery2:  [Encounter] E
 without [Condition] C such that C.id = 'http://cqframework.org/3/2'
 
-// @Test: QueryDefine
+// @Test: QueryLet
 define query:  [Encounter] E
-define a: E
+let a: E
 return {E: E, a:a}
 
 // @Test: Tuple

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -68,7 +68,7 @@ describe.skip 'QueryRelationship', ->
     e = @withOutQuery2.exec(@ctx)
     e.should.have.length(0)
 
-describe 'QueryDefine', ->
+describe 'QueryLet', ->
   @beforeEach ->
     setup @, data, [ p1 ]
 

--- a/Src/coffeescript/cql-execution/test/elm/string/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/string/data.coffee
@@ -1083,7 +1083,7 @@ module.exports['PositionOf'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define World: Substring('HelloWorld', 6)
+define World: Substring('HelloWorld', 5)
 define Or: Substring('HelloWorld', 7, 2)
 define ZeroLength: Substring('HelloWorld', 7, 0)
 define StartTooLow: Substring('HelloWorld', 0)
@@ -1137,7 +1137,7 @@ module.exports['Substring'] = {
                },
                "startIndex" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                  "value" : "6",
+                  "value" : "5",
                   "type" : "Literal"
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/string/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/string/data.cql
@@ -49,7 +49,7 @@ define nullPattern: PositionOf(null, 'abcdefg')
 define nullString: PositionOf('cde', null)
 
 // @Test: Substring
-define World: Substring('HelloWorld', 6)
+define World: Substring('HelloWorld', 5)
 define Or: Substring('HelloWorld', 7, 2)
 define ZeroLength: Substring('HelloWorld', 7, 0)
 define StartTooLow: Substring('HelloWorld', 0)

--- a/Src/coffeescript/cql-execution/test/elm/string/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/string/test.coffee
@@ -120,14 +120,13 @@ describe 'Indexer', ->
     setup @, data
 
   it 'should get letter at index', ->
-    @helloWorldSix.exec(@ctx).should.equal 'W'
+    @helloWorldSix.exec(@ctx).should.equal 'o'
 
   it 'should error on index 0 (out of bounds)', ->
     try
       @helloWorldZero.exec(@ctx)
-      should.fail()
     catch e
-      e.should.be.instanceof ArrayIndexOutOfBoundsException
+      should.fail("index 0 should NOT throw OutOfBoundsException")
 
   it 'should error on index 20 (out of bounds)', ->
     try
@@ -149,11 +148,11 @@ describe 'PositionOf', ->
   it.skip 'should be a PositionOf', ->
     @found.should.be.an.instanceOf(str.Pos)
 
-  it 'should return 1-based position', ->
-    @found.exec(@ctx).should.equal 3
+  it 'should return 0-based position', ->
+    @found.exec(@ctx).should.equal 2
 
-  it 'should return 0 when not found', ->
-    @notFound.exec(@ctx).should.equal 0
+  it 'should return -1 when not found', ->
+    @notFound.exec(@ctx).should.equal -1
 
   it 'should return null when pattern is null', ->
     should(@nullPattern.exec(@ctx)).be.null
@@ -172,7 +171,7 @@ describe 'Substring', ->
     @world.exec(@ctx).should.equal 'World'
 
   it 'should get substring with length', ->
-    @or.exec(@ctx).should.equal 'or'
+    @or.exec(@ctx).should.equal 'rl'
 
   it 'should get substring with zero length', ->
     @zeroLength.exec(@ctx).should.equal ''


### PR DESCRIPTION
Finally tidying up some changes I had hanging around for a while (many based on a previous canceled Pull Request) and adding some additional changes to bring execution up to date with what CQL-to-ELM produces.

Included changes:
- Bumped NPM dependencies up to later versions
- Added support for CodeSystem definitions and the Concept datatype
- Added conversion operators: ToBoolean, To Concept, ToDateTime, ToDecimal, ToInteger, ToQuantity, ToString, ToTime
- Added other operators: Exp, ByColumn, Equivalent (incomplete implementation)
- R1.1 changes: 0-based indexes, !=, backslash escape, rename Expand to Flatten, rename QueryDefineRef to QueryLetRef
- Moved repository.coffee from test src to production src (since it is useful)
- Updated examples and tests based on changes  