### PR TITLE
Add Exp to system functions

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
@@ -41,6 +41,7 @@ public class SystemFunctionResolver {
                 case "Ceiling":
                 case "Floor":
                 case "Ln":
+                case "Exp":
                 case "Truncate":
                 case "Negate":
                 case "Predecessor":


### PR DESCRIPTION
Add Exp to system functions so it is properly translated to the ELM Exp operator rather than a user-function.

v12 branch needs the same fix applied, but wasn't sure how you prefer it done (separate PR, merge from master to v12, etc).