### PR TITLE
#68: Fixed the translator allowing duplicate expression definitions.

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -48,7 +48,7 @@ public class LibraryTests {
         }
     }
 
-    //@Test
+    @Test
     public void testDuplicateExpressionLibrary() {
         CqlTranslator translator = null;
         try {


### PR DESCRIPTION
This fix addresses issue #68, that the translator was silently ignoring duplicate expression definitions.