### PR TITLE
#82: Fixed escape sequences in strings and identifiers not being hand…

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -3302,7 +3302,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     }
 
     private String parseString(ParseTree pt) {
-        return pt == null ? null : (String) visit(pt);
+        return StringEscapeUtils.unescapeCql(pt == null ? null : (String) visit(pt));
     }
 
     private Expression parseExpression(ParseTree pt) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/StringEscapeUtils.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/StringEscapeUtils.java
@@ -1,0 +1,76 @@
+package org.cqframework.cql.cql2elm;
+
+import org.apache.commons.lang3.text.translate.*;
+
+/**
+ * Created by Bryn on 3/22/2017.
+ */
+public class StringEscapeUtils {
+
+    /**
+     * Mapping to escape the CQL control characters.
+     *
+     * Namely: {@code \n \t \f \r}
+     * @return the mapping table
+     */
+    public static String[][] CQL_CTRL_CHARS_ESCAPE() { return CQL_CTRL_CHARS_ESCAPE.clone(); }
+    private static final String[][] CQL_CTRL_CHARS_ESCAPE = {
+            {"\n", "\\n"},
+            {"\t", "\\t"},
+            {"\f", "\\f"},
+            {"\r", "\\r"}
+    };
+
+    /**
+     * Reverse of {@link #CQL_CTRL_CHARS_ESCAPE()} for unescaping purposes.
+     * @return the mapping table
+     */
+    public static String[][] CQL_CTRL_CHARS_UNESCAPE() { return CQL_CTRL_CHARS_UNESCAPE.clone(); }
+    private static final String[][] CQL_CTRL_CHARS_UNESCAPE = EntityArrays.invert(CQL_CTRL_CHARS_ESCAPE);
+
+    public static final CharSequenceTranslator ESACPE_CQL =
+            new LookupTranslator(
+                new String[][] {
+                    { "\"", "\\\"" },
+                    { "\\", "\\\\" },
+                    { "'", "\\'" }
+                }).with(
+                    new LookupTranslator(CQL_CTRL_CHARS_ESCAPE())
+            ).with(
+                JavaUnicodeEscaper.outsideOf(32, 0x7f)
+            );
+
+    public static final CharSequenceTranslator UNESCAPE_CQL =
+            new AggregateTranslator(
+                    new UnicodeUnescaper(),
+                    new LookupTranslator(CQL_CTRL_CHARS_UNESCAPE()),
+                    new LookupTranslator(
+                            new String[][] {
+                                    { "\\\\", "\\" },
+                                    { "\\\"", "\"" },
+                                    { "\\'", "\'" },
+                                    { "\\/", "/" },
+                                    { "\\", "" }
+                            }
+                    )
+            );
+
+    public static final String escapeCql(final String input) {
+        return ESACPE_CQL.translate(input);
+    }
+
+    public static final String unescapeCql(final String input) {
+        // CQL supports the following escape characters in both strings and identifiers:
+        // \" - double-quote
+        // \' - single-quote
+        // \\ - backslash
+        // \/ - slash
+        // \f - form feed
+        // \n - newline
+        // \r - carriage return
+        // \t - tab
+        // \\u - unicode hex representation (e.g. \u0020)
+        return UNESCAPE_CQL.translate(input);
+    }
+
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/EscapeSequenceTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/EscapeSequenceTests.java
@@ -1,0 +1,187 @@
+package org.cqframework.cql.cql2elm;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.hl7.elm.r1.*;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import org.cqframework.cql.cql2elm.LibraryManager;
+
+import static org.cqframework.cql.cql2elm.matchers.ConvertsToDecimalFrom.convertsToDecimalFrom;
+import static org.cqframework.cql.cql2elm.matchers.HasTypeAndResult.hasTypeAndResult;
+import static org.cqframework.cql.cql2elm.matchers.LiteralFor.literalFor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EscapeSequenceTests {
+
+    private Map<String, ExpressionDef> defs;
+
+    @BeforeTest
+    public void setup() throws IOException {
+        CqlTranslator translator = CqlTranslator.fromStream(org.cqframework.cql.cql2elm.EscapeSequenceTests.class.getResourceAsStream("EscapeSequenceTests.cql"), new LibraryManager());
+        Library library = translator.toELM();
+        defs = new HashMap<>();
+        for (ExpressionDef def: library.getStatements().getDef()) {
+            defs.put(def.getName(), def);
+        }
+    }
+
+    @Test
+    public void testString() {
+        ExpressionDef def = defs.get("EmptyString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        Literal literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(""));
+
+        def = defs.get("SingleQuoteEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("Hello 'World'"));
+
+        def = defs.get("DoubleQuoteEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("Hello \"World\""));
+
+        def = defs.get("NEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("\n"));
+
+        def = defs.get("FEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("\f"));
+
+        def = defs.get("REscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("\r"));
+
+        def = defs.get("TEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("\t"));
+
+        def = defs.get("SlashEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("/"));
+
+        //Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+        //def = defs.get("BackslashEscapeString");
+        //assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        //literal = (Literal)def.getExpression();
+        //assertThat(literal.getValue(), is("\\"));
+
+        //Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+        //def = defs.get("CharacterEscapesString");
+        //assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        //literal = (Literal)def.getExpression();
+        //assertThat(literal.getValue(), is("\f\n\r\t/\\"));
+
+        def = defs.get("UnicodeEscapeString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("\u0020"));
+
+        def = defs.get("EmbeddedEscapesString");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is("This is a string with 'multiple' embedded \t escapes\u0020\r\nno really, \r\n\f\t/\\lots of them"));
+    }
+
+    @Test
+    public void testIdentifier() {
+        ExpressionDef def = defs.get("");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        Literal literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("Hello 'World'");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("Hello \"World\"");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("\n");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("\f");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("\r");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("\t");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("/");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        //Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+        //def = defs.get("\\");
+        //assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        //literal = (Literal)def.getExpression();
+        //assertThat(literal.getValue(), is(def.getName()));
+
+        //Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+        //def = defs.get("\f\n\r\t/\\");
+        //assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        //literal = (Literal)def.getExpression();
+        //assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("\u0020");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+
+        def = defs.get("This is an identifier with \"multiple\" embedded \t escapes\u0020\r\nno really, \r\n\f\t/\\lots of them");
+        assertThat(def, hasTypeAndResult(Literal.class, "System.String"));
+
+        literal = (Literal)def.getExpression();
+        assertThat(literal.getValue(), is(def.getName()));
+    }
+}

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/EscapeSequenceTests.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/EscapeSequenceTests.cql
@@ -1,0 +1,28 @@
+define EmptyString: ''
+define SingleQuoteEscapeString: 'Hello \'World\''
+define DoubleQuoteEscapeString: 'Hello \"World\"'
+define NEscapeString: '\n'
+define FEscapeString: '\f'
+define REscapeString: '\r'
+define TEscapeString: '\t'
+define SlashEscapeString: '\/'
+//Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+//define BackslashEscapeString: '\\'
+//define CharacterEscapesString: '\f\n\r\t\/\\'
+define UnicodeEscapeString: '\u0020'
+define EmbeddedEscapesString: 'This is a string with \'multiple\' embedded \t escapes\u0020\r\nno really, \r\n\f\t\/\\lots of them'
+
+define "": ''
+define "Hello \'World\'": 'Hello \'World\''
+define "Hello \"World\"": 'Hello \"World\"'
+define "\n": '\n'
+define "\f": '\f'
+define "\r": '\r'
+define "\t": '\t'
+define "\/": '\/'
+//Github #82: The grammar has a bug related to escapes. An STU comment has been submitted to address this in CQL 1.2
+//define "\\": '\\'
+//define "\f\n\r\t\/\\": '\f\n\r\t\/\\'
+define "\u0020": '\u0020'
+define "This is an identifier with \"multiple\" embedded \t escapes\u0020\r\nno really, \r\n\f\t\/\\lots of them":
+  'This is an identifier with \"multiple\" embedded \t escapes\u0020\r\nno really, \r\n\f\t\/\\lots of them'


### PR DESCRIPTION
…led correctly by the translator.

To address issue #82, this adds a StringEscapeUtils class and the visitor then uses it to unescape strings and identifiers in the parser.

There is still an issue with the escape sequence for a backslash, but this requires a grammar change to address, so an STU comment has been submitted against the specification and issue #82 will be addressed once that comment is handled, ideally as part of CQL 1.2.