### PR TITLE
#93: Fixed sort clause types not being verified.

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -2694,6 +2694,13 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         return sources;
     }
 
+    private void verifyComparable(DataType dataType) {
+        Expression left = (Expression)of.createLiteral().withResultType(dataType);
+        Expression right = (Expression)of.createLiteral().withResultType(dataType);
+        BinaryExpression comparison = of.createLess().withOperand(left, right);
+        resolveBinaryCall("System", "Less", comparison);
+    }
+
     @Override
     public Object visitQuery(@NotNull cqlParser.QueryContext ctx) {
         QueryContext queryContext = new QueryContext();
@@ -2767,9 +2774,24 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 queryContext.setResultElementType(queryContext.isSingular() ? null : ((ListType)queryResultType).getElementType());
                 SortClause sort = null;
                 if (ctx.sortClause() != null) {
+                    if (queryContext.isSingular()) {
+                        throw new IllegalArgumentException("Sort clause cannot be used in a singular query.");
+                    }
+
                     queryContext.enterSortClause();
                     try {
                         sort = (SortClause)visit(ctx.sortClause());
+
+                        // Validate that the sort can be performed based on the existence of comparison operators for all types involved
+                        for (SortByItem sortByItem : sort.getBy()) {
+                            if (sortByItem instanceof ByDirection) {
+                                // validate that there is a comparison operator defined for the result element type of the query context
+                                verifyComparable(queryContext.getResultElementType());
+                            }
+                            else {
+                                verifyComparable(sortByItem.getResultType());
+                            }
+                        }
                     }
                     finally {
                         queryContext.exitSortClause();
@@ -2784,13 +2806,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                         .withReturn(ret)
                         .withSort(sort);
 
-                if (ret == null) {
-                    query.setResultType(sources.get(0).getResultType());
-                }
-                else {
-                    query.setResultType(ret.getResultType());
-                }
-
+                query.setResultType(queryResultType);
                 return query;
             }
             finally {
@@ -3111,14 +3127,16 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     public SortByItem visitSortByItem(@NotNull cqlParser.SortByItemContext ctx) {
         Expression sortExpression = parseExpression(ctx.expressionTerm());
         if (sortExpression instanceof IdentifierRef) {
-            return of.createByColumn()
+            return (SortByItem)of.createByColumn()
                     .withPath(((IdentifierRef)sortExpression).getName())
-                    .withDirection(parseSortDirection(ctx.sortDirection()));
+                    .withDirection(parseSortDirection(ctx.sortDirection()))
+                    .withResultType(sortExpression.getResultType());
         }
 
-        return of.createByExpression()
+        return (SortByItem)of.createByExpression()
                 .withExpression(sortExpression)
-                .withDirection(parseSortDirection(ctx.sortDirection()));
+                .withDirection(parseSortDirection(ctx.sortDirection()))
+                .withResultType(sortExpression.getResultType());
     }
 
     @Override

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -135,6 +135,11 @@ public class SemanticTests {
         runSemanticTest("OperatorTests/ForwardReferences.cql", 0);
     }
 
+    @Test
+    public void testInvalidSortClauses() throws IOException {
+        runSemanticTest("OperatorTests/InvalidSortClauses.cql", 3);
+    }
+
     private void runSemanticTest(String testFileName) throws IOException {
         runSemanticTest(testFileName, 0);
     }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/OperatorTests/InvalidSortClauses.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/OperatorTests/InvalidSortClauses.cql
@@ -1,0 +1,18 @@
+library Test93
+
+define "Invalid Sort": ({ Interval[1, 3], Interval[3, 5] }) S sort asc
+define "Invalid Column Sort":
+  (
+    {
+      { id: 1, relevantPeriod: Interval[Today(), Today() + 1 day] },
+      { id: 2, relevantPeriod: Interval[Today(), Today() + 2 days] }
+    }
+  ) S sort by relevantPeriod desc
+
+define "Invalid Expression Sort":
+  (
+    {
+      { id: 1, relevantPeriod: Interval[Today(), Today() + 1 day] },
+      { id: 2, relevantPeriod: Interval[Today(), Today() + 2 days] }
+    }
+  ) S sort by Interval[start of relevantPeriod, end of relevantPeriod]


### PR DESCRIPTION
Sort clause translation was not verifying the type of sort clause expressions. It validated that path references were correct, but did not verify that the resulting type could be ordered. The translator now verifies that a "Less" operator is defined for the type of the column, expression, or the type of the elements in the list in the case of a list-based sort. In addition, the sort clause will now correctly throw if it appears on a singular query.