### PR TITLE
Add Coalesce Execution Test for Arrays

### DIFF
--- a/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/convert/data.coffee
@@ -181,7 +181,7 @@ module.exports['FromString'] = {
                "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10 \\'A\\'",
+                  "value" : "10 'A'",
                   "type" : "Literal"
                }
             }
@@ -193,7 +193,7 @@ module.exports['FromString'] = {
                "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "+10 \\'A\\'",
+                  "value" : "+10 'A'",
                   "type" : "Literal"
                }
             }
@@ -205,7 +205,7 @@ module.exports['FromString'] = {
                "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "-10 \\'A\\'",
+                  "value" : "-10 'A'",
                   "type" : "Literal"
                }
             }
@@ -217,7 +217,7 @@ module.exports['FromString'] = {
                "type" : "ToQuantity",
                "operand" : {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
-                  "value" : "10.0 \\'mA\\'",
+                  "value" : "10.0 'mA'",
                   "type" : "Literal"
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/nullological/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/nullological/data.coffee
@@ -168,9 +168,10 @@ module.exports['IsNull'] = {
 library TestSnippet version '1'
 using QUICK
 context Patient
-define NullNullHelloNullWorld: Coalesce(null as String, null as String, 'Hello', null as String, 'World')
-define FooNullNullBar: Coalesce('Foo', null as String, null as String, 'Bar')
-define AllNull: Coalesce(null as String, null as String, null as String)
+define NullNullHelloNullWorld: Coalesce(null, null, 'Hello', null, 'World')
+define FooNullNullBar: Coalesce('Foo', null, null, 'Bar')
+define AllNull: Coalesce(null, null, null)
+define ListArgStartsWithNull: Coalesce(List{null, null, 'One', null, 'Two'})
 ###
 
 module.exports['Coalesce'] = {
@@ -211,39 +212,15 @@ module.exports['Coalesce'] = {
             "expression" : {
                "type" : "Coalesce",
                "operand" : [ {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
                }, {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "Hello",
                   "type" : "Literal"
                }, {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
                }, {
                   "valueType" : "{urn:hl7-org:elm-types:r1}String",
                   "value" : "World",
@@ -261,7 +238,7 @@ module.exports['Coalesce'] = {
                   "value" : "Foo",
                   "type" : "Literal"
                }, {
-                  "strict" : false,
+                  "asType" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
@@ -271,7 +248,7 @@ module.exports['Coalesce'] = {
                      "type" : "NamedTypeSpecifier"
                   }
                }, {
-                  "strict" : false,
+                  "asType" : "{urn:hl7-org:elm-types:r1}String",
                   "type" : "As",
                   "operand" : {
                      "type" : "Null"
@@ -293,35 +270,60 @@ module.exports['Coalesce'] = {
             "expression" : {
                "type" : "Coalesce",
                "operand" : [ {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
                }, {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
                }, {
-                  "strict" : false,
-                  "type" : "As",
-                  "operand" : {
-                     "type" : "Null"
-                  },
-                  "asTypeSpecifier" : {
-                     "name" : "{urn:hl7-org:elm-types:r1}String",
-                     "type" : "NamedTypeSpecifier"
-                  }
+                  "type" : "Null"
+               } ]
+            }
+         }, {
+            "name" : "ListArgStartsWithNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Coalesce",
+               "operand" : [ {
+                  "type" : "List",
+                  "element" : [ {
+                     "asType" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "As",
+                     "operand" : {
+                        "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "asType" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "As",
+                     "operand" : {
+                        "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "One",
+                     "type" : "Literal"
+                  }, {
+                     "asType" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "As",
+                     "operand" : {
+                        "type" : "Null"
+                     },
+                     "asTypeSpecifier" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "Two",
+                     "type" : "Literal"
+                  } ]
                } ]
             }
          } ]

--- a/Src/coffeescript/cql-execution/test/elm/nullological/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/nullological/data.cql
@@ -10,6 +10,7 @@ define StringIsNull: '' is null
 define NonNullVarIsNull: One is null
 
 // @Test: Coalesce
-define NullNullHelloNullWorld: Coalesce(null as String, null as String, 'Hello', null as String, 'World')
-define FooNullNullBar: Coalesce('Foo', null as String, null as String, 'Bar')
-define AllNull: Coalesce(null as String, null as String, null as String)
+define NullNullHelloNullWorld: Coalesce(null, null, 'Hello', null, 'World')
+define FooNullNullBar: Coalesce('Foo', null, null, 'Bar')
+define AllNull: Coalesce(null, null, null)
+define ListArgStartsWithNull: Coalesce(List{null, null, 'One', null, 'Two'})

--- a/Src/coffeescript/cql-execution/test/elm/nullological/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/nullological/test.coffee
@@ -37,3 +37,6 @@ describe.skip 'Coalesce', ->
 
   it 'should return null when they are all null', ->
     should(@allNull.exec(@ctx)).be.null
+
+  it 'should return first non-null in array', ->
+    @listArgStartsWithNull.exec(@ctx).should.equal 'One'


### PR DESCRIPTION
I *thought* there was a bug in our implementation of Coalesce execution.  It turns out I was wrong, but we might as well keep the test!

This also updated one other test data file based on the recent string escape fixes in the CQL-to-ELM compiler.