### PR TITLE
LibraryManager now wraps any exception coming from a source provider …

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -55,7 +55,14 @@ public class LibraryManager {
     }
 
     private TranslatedLibrary translateLibrary(VersionedIdentifier libraryIdentifier, List<CqlTranslatorException> errors) {
-        InputStream librarySource = librarySourceLoader.getLibrarySource(libraryIdentifier);
+        InputStream librarySource = null;
+        try {
+            librarySource = librarySourceLoader.getLibrarySource(libraryIdentifier);
+        }
+        catch (Exception e) {
+            throw new CqlTranslatorIncludeException(e.getMessage(), libraryIdentifier.getId(), libraryIdentifier.getVersion(), e);
+        }
+
         if (librarySource == null) {
             throw new CqlTranslatorIncludeException(String.format("Could not load source for library %s, version %s.",
                     libraryIdentifier.getId(), libraryIdentifier.getVersion()), libraryIdentifier.getId(), libraryIdentifier.getVersion());

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 public class LibraryTests {
@@ -54,6 +55,19 @@ public class LibraryTests {
         try {
             translator = CqlTranslator.fromStream(LibraryTests.class.getResourceAsStream("LibraryTests/DuplicateExpressionLibrary.cql"), libraryManager);
             assertThat(translator.getErrors().size(), is(1));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testMissingLibrary() {
+        CqlTranslator translator = null;
+        try {
+            translator = CqlTranslator.fromStream(LibraryTests.class.getResourceAsStream("LibraryTests/MissingLibrary.cql"), libraryManager);
+            assertThat(translator.getErrors().size(), is(1));
+            assertThat(translator.getErrors().get(0), instanceOf(CqlTranslatorException.class));
+            assertThat(translator.getErrors().get(0).getCause(), instanceOf(CqlTranslatorIncludeException.class));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/MissingLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/MissingLibrary.cql
@@ -1,0 +1,4 @@
+library CMS146 version '2'
+
+include CMSAll version '1' called foo
+

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/MissingLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/MissingLibrary.cql
@@ -2,3 +2,4 @@ library CMS146 version '2'
 
 include CMSAll version '1' called foo
 
+define Dummy: 'Dummy'


### PR DESCRIPTION
…implementation as a CqlTranslatorIncludeException.

This behavior was the result of a change to the default library source provider, resulting in the translator not detecting that errors while loading were "include" exceptions.