### PR TITLE
Fix 110 let scope

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -3,7 +3,7 @@ allprojects {
     apply plugin: 'eclipse'
 
     group = 'info.cqframework'
-    version = '1.1.1-SNAPSHOT'
+    version = '1.1.2-SNAPSHOT'
 }
 
 subprojects {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -2792,9 +2792,6 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
             try {
 
                 List<LetClause> dfcx = ctx.letClause() != null ? (List<LetClause>) visit(ctx.letClause()) : null;
-                if (dfcx != null) {
-                    queryContext.addLetClauses(dfcx);
-                }
 
                 List<RelationshipClause> qicx = new ArrayList<>();
                 if (ctx.queryInclusionClause() != null) {
@@ -3095,6 +3092,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         LetClause letClause = of.createLetClause().withExpression(parseExpression(ctx.expression()))
                 .withIdentifier(parseString(ctx.identifier()));
         letClause.setResultType(letClause.getExpression().getResultType());
+        queries.peek().addLetClause(letClause);
         return letClause;
     }
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TranslationTests.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TranslationTests.cql
@@ -36,3 +36,15 @@ define Empty: Count({ })
 
 define TypedHasNull: Count(List<Integer> { 1, null, null, null, 2 })
 define TypedEmpty: Count(List<Integer> { })
+
+define NestedLet:
+  ({ { id: 1, value: 10 }, { id: 2, value: 20 } }) X
+    let
+      A: (X.value * 10),
+      B: A * 10
+    return {
+      id: X.id,
+      value: X.value,
+      a: A,
+      b: B
+    }


### PR DESCRIPTION
#110 Fixed an issue with let definitions not being accessible in subsequent lets. This issue could be worked around with a nested query, but it's excessive to require that, and the specification is fairly clear that a let clause introduces the definition to the query scope, implying that it should be available anywhere after the definition.