### PR TITLE
Execution: Sort By w/ Expressions or Functions

### DIFF
--- a/Src/coffeescript/cql-execution/.vscode/launch.json
+++ b/Src/coffeescript/cql-execution/.vscode/launch.json
@@ -15,7 +15,8 @@
             "--timeout",
             "999999",
             "--colors",
-            "${workspaceRoot}/lib-test/elm/interval"
+            "--recursive",
+            "${workspaceRoot}/lib-test/"
         ],
         "internalConsoleOptions": "openOnSessionStart"
     },

--- a/Src/coffeescript/cql-execution/test/elm/clinical/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/test.coffee
@@ -161,16 +161,16 @@ describe 'CalculateAge', ->
 
     # this is getting the possible number of months in years with the addtion of an offset
     # to get the correct number of months
-    @full_months = ((@today.getFullYear() - 1980) * 12) + (@today.getMonth() - 6)
+    month_offset = if @today.getMonth() == 5 && @today.getDate() < 17 then 6 else 5
+    @full_months = ((@today.getFullYear() - 1980) * 12) + (@today.getMonth() - month_offset)
+
     @timediff = @today - @bday # diff in milliseconds
 
   it 'should execute age in years', ->
     @years.exec(@ctx).should.equal @full_months // 12
 
   it 'should execute age in months', ->
-    # what is returned will depend on whether the day in the current month has
-    # made it to the 17th day of the month as declared in the birthday
-    [@full_months, @full_months-1].indexOf(@months.exec(@ctx)).should.not.equal -1
+    @months.exec(@ctx).should.equal @full_months
 
   it 'should execute age in days', ->
     @days.exec(@ctx).should.equal @timediff // 1000 // 60 // 60 // 24

--- a/Src/coffeescript/cql-execution/test/elm/library/COM.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/COM.cql
@@ -1,3 +1,4 @@
+// NOTE: This library must be DUPLICATED in the data.cql file as well!
 library COM
 using QUICK
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))

--- a/Src/coffeescript/cql-execution/test/elm/library/COM2.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/COM2.coffee
@@ -1,0 +1,8 @@
+###
+   WARNING: This is a GENERATED file.  Do not manually edit!
+
+   To generate this file:
+       - Edit COM2.coffee to add a CQL Snippet
+       - From java dir: ./gradlew :cql-to-elm:generateTestData
+###
+

--- a/Src/coffeescript/cql-execution/test/elm/library/COM2.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/COM2.cql
@@ -1,0 +1,33 @@
+// NOTE: This library must be DUPLICATED in the data.cql file as well!
+library COM2
+using QUICK
+parameter SomeNumber default 17
+
+context Patient
+
+define TheParameter:
+  SomeNumber
+
+define function addToParameter(a Integer):
+  SomeNumber + a
+
+define function multiply(a Integer, b Integer) :
+  a * b
+
+define function square(a Integer):
+  multiply(a, a)
+
+define TwoTimesThree:
+  multiply(2, 3)
+
+define Two:
+  2
+
+define function addTwo(a Integer):
+  a + Two
+
+define TwoPlusOne:
+  Two + 1
+
+define SortUsingFunction:
+  ({1, 3, 2, 5, 4}) N return Tuple{N: N} sort by square(N)

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -499,3 +499,425 @@ module.exports['Using CommonLib'] = {
    }
 }
 
+### CommonLib2
+library COM2
+using QUICK
+parameter SomeNumber default 17
+
+context Patient
+
+define TheParameter:
+  SomeNumber
+
+define function addToParameter(a Integer):
+  SomeNumber + a
+
+define function multiply(a Integer, b Integer) :
+  a * b
+
+define function square(a Integer):
+  multiply(a, a)
+
+define TwoTimesThree:
+  multiply(2, 3)
+
+define Two:
+  2
+
+define function addTwo(a Integer):
+  a + Two
+
+define TwoPlusOne:
+  Two + 1
+
+define SortUsingFunction:
+  ({1, 3, 2, 5, 4}) N return Tuple{N: N} sort by square(N)
+###
+
+module.exports['CommonLib2'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "COM2"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "name" : "SomeNumber",
+            "accessLevel" : "Public",
+            "default" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "value" : "17",
+               "type" : "Literal"
+            }
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "TheParameter",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "SomeNumber",
+               "type" : "ParameterRef"
+            }
+         }, {
+            "name" : "addToParameter",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "SomeNumber",
+                  "type" : "ParameterRef"
+               }, {
+                  "name" : "a",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "multiply",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "type" : "Multiply",
+               "operand" : [ {
+                  "name" : "a",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "b",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "b",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "square",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "name" : "multiply",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "name" : "a",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "a",
+                  "type" : "OperandRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "TwoTimesThree",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "multiply",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2",
+                  "type" : "Literal"
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "3",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "Two",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "value" : "2",
+               "type" : "Literal"
+            }
+         }, {
+            "name" : "addTwo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "a",
+                  "type" : "OperandRef"
+               }, {
+                  "name" : "Two",
+                  "type" : "ExpressionRef"
+               } ]
+            },
+            "operand" : [ {
+               "name" : "a",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "TwoPlusOne",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "Two",
+                  "type" : "ExpressionRef"
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "1",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "SortUsingFunction",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "N",
+                  "expression" : {
+                     "type" : "List",
+                     "element" : [ {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "3",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "2",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "5",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "4",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "N",
+                        "value" : {
+                           "name" : "N",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               },
+               "sort" : {
+                  "by" : [ {
+                     "direction" : "asc",
+                     "type" : "ByExpression",
+                     "expression" : {
+                        "name" : "square",
+                        "type" : "FunctionRef",
+                        "operand" : [ {
+                           "name" : "N",
+                           "type" : "IdentifierRef"
+                        } ]
+                     }
+                  } ]
+               }
+            }
+         } ]
+      }
+   }
+}
+
+### Using CommonLib2
+library TestSnippet version '1'
+using QUICK
+include COM2 called common2
+
+context Patient
+
+define ExprUsesParam: common2.TheParameter
+define FuncUsesParam: common2.addToParameter(5)
+define ExprCallsFunc: common2.TwoTimesThree
+define FuncCallsFunc: common2.square(5)
+define ExprUsesExpr: common2.TwoPlusOne
+define FuncUsesExpr: common2.addTwo(5)
+define ExprSortsOnFunc: common2.SortUsingFunction
+###
+
+module.exports['Using CommonLib2'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "localIdentifier" : "common2",
+            "path" : "COM2"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "ExprUsesParam",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "TheParameter",
+               "libraryName" : "common2",
+               "type" : "ExpressionRef"
+            }
+         }, {
+            "name" : "FuncUsesParam",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "addToParameter",
+               "libraryName" : "common2",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "ExprCallsFunc",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "TwoTimesThree",
+               "libraryName" : "common2",
+               "type" : "ExpressionRef"
+            }
+         }, {
+            "name" : "FuncCallsFunc",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "square",
+               "libraryName" : "common2",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "ExprUsesExpr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "TwoPlusOne",
+               "libraryName" : "common2",
+               "type" : "ExpressionRef"
+            }
+         }, {
+            "name" : "FuncUsesExpr",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "addTwo",
+               "libraryName" : "common2",
+               "type" : "FunctionRef",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "ExprSortsOnFunc",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "SortUsingFunction",
+               "libraryName" : "common2",
+               "type" : "ExpressionRef"
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -32,4 +32,50 @@ define ID: common.InDemographic
 define L : Length(Patient.name[0].given[0])
 define FuncTest : common.foo(2, 5)
 
+// @Test: CommonLib2
+library COM2
+using QUICK
+parameter SomeNumber default 17
 
+context Patient
+
+define TheParameter:
+  SomeNumber
+
+define function addToParameter(a Integer):
+  SomeNumber + a
+
+define function multiply(a Integer, b Integer) :
+  a * b
+
+define function square(a Integer):
+  multiply(a, a)
+
+define TwoTimesThree:
+  multiply(2, 3)
+
+define Two:
+  2
+
+define function addTwo(a Integer):
+  a + Two
+
+define TwoPlusOne:
+  Two + 1
+
+define SortUsingFunction:
+  ({1, 3, 2, 5, 4}) N return Tuple{N: N} sort by square(N)
+
+// @Test: Using CommonLib2
+using QUICK
+include COM2 called common2
+
+context Patient
+
+define ExprUsesParam: common2.TheParameter
+define FuncUsesParam: common2.addToParameter(5)
+define ExprCallsFunc: common2.TwoTimesThree
+define FuncCallsFunc: common2.square(5)
+define ExprUsesExpr: common2.TwoPlusOne
+define FuncUsesExpr: common2.addTwo(5)
+define ExprSortsOnFunc: common2.SortUsingFunction

--- a/Src/coffeescript/cql-execution/test/elm/library/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/test.coffee
@@ -17,7 +17,6 @@ describe 'In Age Demographic', ->
   it 'should have empty population results', ->
     @results.populationResults.should.be.empty
 
-
 describe 'Using CommonLib', ->
   @beforeEach ->
     setup @, data, [ p1, p2 ], {}, {}, new Repository(data)
@@ -36,3 +35,28 @@ describe 'Using CommonLib', ->
     @results.patientResults['2'].ID.should.equal true
     @results.patientResults['2'].FuncTest.should.equal 7
     @results.patientResults['1'].FuncTest.should.equal 7
+
+describe 'Using CommonLib2', ->
+  @beforeEach ->
+    setup @, data, [], {}, {}, new Repository(data)
+
+  it "should execute expression from included library that uses parameter", ->
+    @exprUsesParam.exec(@ctx).should.equal 17
+
+  it "should execute function from included library that uses parameter", ->
+    @funcUsesParam.exec(@ctx).should.equal 22
+
+  it "should execute expression from included library that calls function", ->
+    @exprCallsFunc.exec(@ctx).should.equal 6
+
+  it "should execute function from included library that calls function", ->
+    @funcCallsFunc.exec(@ctx).should.equal 25
+
+  it "should execute expression from included library that uses expression", ->
+    @exprUsesExpr.exec(@ctx).should.equal 3
+
+  it "should execute function from included library that uses expression", ->
+    @funcUsesExpr.exec(@ctx).should.equal 7
+
+  it "should execute function from included library that uses expression", ->
+    @exprSortsOnFunc.exec(@ctx).should.eql [{N: 1}, {N: 2}, {N: 3}, {N: 4}, {N: 5}]

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -1059,6 +1059,8 @@ define stringAsc: ({'jenny', 'dont', 'change', 'your', 'number'}) S sort asc
 define stringReturnAsc: ({'jenny', 'dont', 'change', 'your', 'number'}) S return S sort asc
 define stringDesc: ({'jenny', 'dont', 'change', 'your', 'number'}) S sort desc
 define stringReturnDesc: ({'jenny', 'dont', 'change', 'your', 'number'}) S return S sort desc
+define five: 5
+define sortByExpression: ({8, 6, 7, 5, 3, 0, 9}) N return Tuple{N: N} sort by (five + N)
 ###
 
 module.exports['Sorting'] = {
@@ -1661,6 +1663,86 @@ module.exports['Sorting'] = {
                   "by" : [ {
                      "direction" : "desc",
                      "type" : "ByDirection"
+                  } ]
+               }
+            }
+         }, {
+            "name" : "five",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "value" : "5",
+               "type" : "Literal"
+            }
+         }, {
+            "name" : "sortByExpression",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "N",
+                  "expression" : {
+                     "type" : "List",
+                     "element" : [ {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "8",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "6",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "7",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "5",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "3",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "0",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "9",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "N",
+                        "value" : {
+                           "name" : "N",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               },
+               "sort" : {
+                  "by" : [ {
+                     "direction" : "asc",
+                     "type" : "ByExpression",
+                     "expression" : {
+                        "type" : "Add",
+                        "operand" : [ {
+                           "name" : "five",
+                           "type" : "ExpressionRef"
+                        }, {
+                           "name" : "N",
+                           "type" : "IdentifierRef"
+                        } ]
+                     }
                   } ]
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/query/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.cql
@@ -60,6 +60,8 @@ define stringAsc: ({'jenny', 'dont', 'change', 'your', 'number'}) S sort asc
 define stringReturnAsc: ({'jenny', 'dont', 'change', 'your', 'number'}) S return S sort asc
 define stringDesc: ({'jenny', 'dont', 'change', 'your', 'number'}) S sort desc
 define stringReturnDesc: ({'jenny', 'dont', 'change', 'your', 'number'}) S return S sort desc
+define five: 5
+define sortByExpression: ({8, 6, 7, 5, 3, 0, 9}) N return Tuple{N: N} sort by (five + N)
 
 // @Test: Distinct
 define defaultNumbers: ({1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1}) N return N

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -154,6 +154,9 @@ describe 'Sorting', ->
     @stringDesc.exec(@ctx).should.eql ['your', 'number', 'jenny', 'dont', 'change']
     @stringReturnDesc.exec(@ctx).should.eql ['your', 'number', 'jenny', 'dont', 'change']
 
+  it 'should be able to sort by an expression that uses another expression in the library', ->
+    @sortByExpression.exec(@ctx).should.eql [{N: 0}, {N: 3}, {N: 5}, {N: 6}, {N: 7}, {N: 8}, {N: 9}]
+
 describe 'Distinct', ->
   @beforeEach ->
     setup @, data


### PR DESCRIPTION
Previously the execution engine did not properly handle query sorting when the sort clause referenced an expression or function from the library (or one of its included libraries).  This PR fixes that issue by passing along the context to the sort functions.

This PR also fixes a minor issue with one of the tests that caused the tests to fail during some days in June -- due to bad logic trying to determine number of months passed.  That is also fixed.

Lastly, updated the special VSCode config for debugging unit tests.