### PR TITLE
DateMath Fixes

### DIFF
--- a/Src/coffeescript/cql-execution/src/datatypes/datetime.coffee
+++ b/Src/coffeescript/cql-execution/src/datatypes/datetime.coffee
@@ -1,7 +1,7 @@
 { Uncertainty } = require './uncertainty'
 
 module.exports.DateTime = class DateTime
-  @Unit: { YEAR: 'year', MONTH: 'month', DAY: 'day', HOUR: 'hour', MINUTE: 'minute', SECOND: 'second', MILLISECOND: 'millisecond' }
+  @Unit: { YEAR: 'year', MONTH: 'month', WEEK: 'week', DAY: 'day', HOUR: 'hour', MINUTE: 'minute', SECOND: 'second', MILLISECOND: 'millisecond' }
   @FIELDS: [@Unit.YEAR, @Unit.MONTH, @Unit.DAY, @Unit.HOUR, @Unit.MINUTE, @Unit.SECOND, @Unit.MILLISECOND]
 
   @parse: (string) ->
@@ -139,6 +139,12 @@ module.exports.DateTime = class DateTime
     # TODO: According to spec, 2/29/2000 + 1 year is 2/28/2001
     # Currently, it evaluates to 3/1/2001.  Doh.
     result = @copy()
+
+    # If weeks, convert to days
+    if field == DateTime.Unit.WEEK
+      offset = offset * 7
+      field = DateTime.Unit.DAY
+
     if result[field]?
       # Increment the field, then round-trip to JS date and back for calendar math
       result[field] = result[field] + offset
@@ -162,6 +168,7 @@ module.exports.DateTime = class DateTime
     # To count boundaries below month, we need to floor units at lower precisions
     [a, b] = [a, b].map (x) ->
       switch unitField
+        when DateTime.Unit.WEEK then new Date(x.getFullYear(), x.getMonth(), x.getDate())
         when DateTime.Unit.DAY then new Date(x.getFullYear(), x.getMonth(), x.getDate())
         when DateTime.Unit.HOUR then new Date(x.getFullYear(), x.getMonth(), x.getDate(), x.getHours())
         when DateTime.Unit.MINUTE then new Date(x.getFullYear(), x.getMonth(), x.getDate(), x.getHours(), x.getMinutes())
@@ -173,6 +180,7 @@ module.exports.DateTime = class DateTime
     switch unitField
       when DateTime.Unit.YEAR then b.getFullYear() - a.getFullYear()
       when DateTime.Unit.MONTH then b.getMonth() - a.getMonth() + (12 * (b.getFullYear() - a.getFullYear()))
+      when DateTime.Unit.WEEK then Math.floor(msDiff / (7 * 24 * 60 * 60 * 1000))
       when DateTime.Unit.DAY then Math.floor(msDiff / (24 * 60 * 60 * 1000))
       when DateTime.Unit.HOUR then Math.floor(msDiff / (60 * 60 * 1000))
       when DateTime.Unit.MINUTE then Math.floor(msDiff / (60 * 1000))

--- a/Src/coffeescript/cql-execution/src/elm/quantity.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/quantity.coffee
@@ -30,7 +30,7 @@ module.exports.Quantity = class Quantity extends Expression
   before: (other) ->
     if other instanceof Quantity and other.unit == @unit then @value < other.value else null
 
-time_units = {'years':'year',  'months': 'month',  'days' :'day', 'minutes': 'minute', 'seconds':'seconds', 'milliseconds' : 'millisecond' }
+time_units = {'years':'year',  'months': 'month',  'days' :'day', 'hours': 'hour', 'minutes': 'minute', 'seconds':'second', 'milliseconds' : 'millisecond' }
 
 clean_unit = (units) ->
   if time_units[units] then time_units[units] else units

--- a/Src/coffeescript/cql-execution/src/elm/quantity.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/quantity.coffee
@@ -30,7 +30,7 @@ module.exports.Quantity = class Quantity extends Expression
   before: (other) ->
     if other instanceof Quantity and other.unit == @unit then @value < other.value else null
 
-time_units = {'years':'year',  'months': 'month',  'days' :'day', 'hours': 'hour', 'minutes': 'minute', 'seconds':'second', 'milliseconds' : 'millisecond' }
+time_units = {'years':'year',  'months': 'month', 'weeks': 'week', 'days' :'day', 'hours': 'hour', 'minutes': 'minute', 'seconds':'second', 'milliseconds' : 'millisecond' }
 
 clean_unit = (units) ->
   if time_units[units] then time_units[units] else units

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
@@ -16203,6 +16203,7 @@ define NewYear2014: DateTime(2014, 1, 1, 0, 0, 0, 0)
 define January2014: DateTime(2014, 1)
 define YearsBetween: years between NewYear2013 and NewYear2014
 define MonthsBetween: months between NewYear2013 and NewYear2014
+define WeeksBetween: weeks between NewYear2013 and NewYear2014
 define DaysBetween: days between NewYear2013 and NewYear2014
 define HoursBetween: hours between NewYear2013 and NewYear2014
 define MinutesBetween: minutes between NewYear2013 and NewYear2014
@@ -16211,6 +16212,7 @@ define MillisecondsBetween: milliseconds between NewYear2013 and NewYear2014
 define MillisecondsBetweenReversed: milliseconds between NewYear2014 and NewYear2013
 define YearsBetweenUncertainty: years between NewYear2014 and January2014
 define MonthsBetweenUncertainty: months between NewYear2014 and January2014
+define WeeksBetweenUncertainty: weeks between NewYear2014 and January2014
 define DaysBetweenUncertainty: days between NewYear2014 and January2014
 define HoursBetweenUncertainty: hours between NewYear2014 and January2014
 define MinutesBetweenUncertainty: minutes between NewYear2014 and January2014
@@ -16382,6 +16384,21 @@ module.exports['DurationBetween'] = {
                } ]
             }
          }, {
+            "name" : "WeeksBetween",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "precision" : "Week",
+               "type" : "DurationBetween",
+               "operand" : [ {
+                  "name" : "NewYear2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "name" : "NewYear2014",
+                  "type" : "ExpressionRef"
+               } ]
+            }
+         }, {
             "name" : "DaysBetween",
             "context" : "Patient",
             "accessLevel" : "Public",
@@ -16492,6 +16509,21 @@ module.exports['DurationBetween'] = {
             "accessLevel" : "Public",
             "expression" : {
                "precision" : "Month",
+               "type" : "DurationBetween",
+               "operand" : [ {
+                  "name" : "NewYear2014",
+                  "type" : "ExpressionRef"
+               }, {
+                  "name" : "January2014",
+                  "type" : "ExpressionRef"
+               } ]
+            }
+         }, {
+            "name" : "WeeksBetweenUncertainty",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "precision" : "Week",
                "type" : "DurationBetween",
                "operand" : [ {
                   "name" : "NewYear2014",

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.coffee
@@ -17113,3 +17113,344 @@ module.exports['DurationBetween Comparisons'] = {
    }
 }
 
+### DateMath
+library TestSnippet version '1'
+using QUICK
+context Patient
+define June15th2013: DateTime(2013, 6, 15, 0, 0, 0, 0)
+define PlusThreeYears: June15th2013 + 3 years
+define MinusThreeYears: June15th2013 - 3 years
+define PlusEightMonths: June15th2013 + 8 months
+define MinusEightMonths: June15th2013 - 8 months
+define PlusThreeWeeks: June15th2013 + 3 weeks
+define MinusThreeWeeks: June15th2013 - 3 weeks
+define PlusTwentyDays: June15th2013 + 20 days
+define MinusTwentyDays: June15th2013 - 20 days
+define PlusThreeHours: June15th2013 + 3 hours
+define MinusThreeHours: June15th2013 - 3 hours
+define PlusThreeMinutes: June15th2013 + 3 minutes
+define MinusThreeMinutes: June15th2013 - 3 minutes
+define PlusThreeSeconds: June15th2013 + 3 seconds
+define MinusThreeSeconds: June15th2013 - 3 seconds
+define PlusThreeMilliseconds: June15th2013 + 3 milliseconds
+define MinusThreeMilliseconds: June15th2013 - 3 milliseconds
+###
+
+module.exports['DateMath'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "June15th2013",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "DateTime",
+               "year" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "2013",
+                  "type" : "Literal"
+               },
+               "month" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "6",
+                  "type" : "Literal"
+               },
+               "day" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "15",
+                  "type" : "Literal"
+               },
+               "hour" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               },
+               "minute" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               },
+               "second" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               },
+               "millisecond" : {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "0",
+                  "type" : "Literal"
+               }
+            }
+         }, {
+            "name" : "PlusThreeYears",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "years",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeYears",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "years",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusEightMonths",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 8,
+                  "unit" : "months",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusEightMonths",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 8,
+                  "unit" : "months",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusThreeWeeks",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "weeks",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeWeeks",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "weeks",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusTwentyDays",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 20,
+                  "unit" : "days",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusTwentyDays",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 20,
+                  "unit" : "days",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusThreeHours",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "hours",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeHours",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "hours",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusThreeMinutes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "minutes",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeMinutes",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "minutes",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusThreeSeconds",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "seconds",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeSeconds",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "seconds",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "PlusThreeMilliseconds",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Add",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "milliseconds",
+                  "type" : "Quantity"
+               } ]
+            }
+         }, {
+            "name" : "MinusThreeMilliseconds",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Subtract",
+               "operand" : [ {
+                  "name" : "June15th2013",
+                  "type" : "ExpressionRef"
+               }, {
+                  "value" : 3,
+                  "unit" : "milliseconds",
+                  "type" : "Quantity"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
@@ -244,6 +244,7 @@ define NewYear2014: DateTime(2014, 1, 1, 0, 0, 0, 0)
 define January2014: DateTime(2014, 1)
 define YearsBetween: years between NewYear2013 and NewYear2014
 define MonthsBetween: months between NewYear2013 and NewYear2014
+define WeeksBetween: weeks between NewYear2013 and NewYear2014
 define DaysBetween: days between NewYear2013 and NewYear2014
 define HoursBetween: hours between NewYear2013 and NewYear2014
 define MinutesBetween: minutes between NewYear2013 and NewYear2014
@@ -252,6 +253,7 @@ define MillisecondsBetween: milliseconds between NewYear2013 and NewYear2014
 define MillisecondsBetweenReversed: milliseconds between NewYear2014 and NewYear2013
 define YearsBetweenUncertainty: years between NewYear2014 and January2014
 define MonthsBetweenUncertainty: months between NewYear2014 and January2014
+define WeeksBetweenUncertainty: weeks between NewYear2014 and January2014
 define DaysBetweenUncertainty: days between NewYear2014 and January2014
 define HoursBetweenUncertainty: hours between NewYear2014 and January2014
 define MinutesBetweenUncertainty: minutes between NewYear2014 and January2014

--- a/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/data.cql
@@ -280,3 +280,22 @@ define LessThan80DaysAfter: days between NewYear2014 and February2014 < 80
 define TwentyFiveDaysLessThanDaysBetween: 25 < days between NewYear2014 and February2014
 define FortyDaysEqualToDaysBetween: 40 = days between NewYear2014 and February2014
 define TwentyFiveDaysGreaterThanDaysBetween: 25 > days between NewYear2014 and February2014
+
+// @Test: DateMath
+define June15th2013: DateTime(2013, 6, 15, 0, 0, 0, 0)
+define PlusThreeYears: June15th2013 + 3 years
+define MinusThreeYears: June15th2013 - 3 years
+define PlusEightMonths: June15th2013 + 8 months
+define MinusEightMonths: June15th2013 - 8 months
+define PlusThreeWeeks: June15th2013 + 3 weeks
+define MinusThreeWeeks: June15th2013 - 3 weeks
+define PlusTwentyDays: June15th2013 + 20 days
+define MinusTwentyDays: June15th2013 - 20 days
+define PlusThreeHours: June15th2013 + 3 hours
+define MinusThreeHours: June15th2013 - 3 hours
+define PlusThreeMinutes: June15th2013 + 3 minutes
+define MinusThreeMinutes: June15th2013 - 3 minutes
+define PlusThreeSeconds: June15th2013 + 3 seconds
+define MinusThreeSeconds: June15th2013 - 3 seconds
+define PlusThreeMilliseconds: June15th2013 + 3 milliseconds
+define MinusThreeMilliseconds: June15th2013 - 3 milliseconds

--- a/Src/coffeescript/cql-execution/test/elm/datetime/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/test.coffee
@@ -620,6 +620,9 @@ describe 'DurationBetween', ->
   it 'should properly execute months between', ->
     @monthsBetween.exec(@ctx).should.equal 12
 
+  it 'should properly execute weeks between', ->
+    @weeksBetween.exec(@ctx).should.equal 52
+
   it 'should properly execute days between', ->
     @daysBetween.exec(@ctx).should.equal 365
 
@@ -643,6 +646,9 @@ describe 'DurationBetween', ->
 
   it 'should properly execute months between with an uncertainty', ->
     @monthsBetweenUncertainty.exec(@ctx).should.equal 0
+
+  it 'should properly execute weeks between with an uncertainty', ->
+    @weeksBetweenUncertainty.exec(@ctx).should.eql new Uncertainty(0, 4)
 
   it 'should properly execute days between with an uncertainty', ->
     @daysBetweenUncertainty.exec(@ctx).should.eql new Uncertainty(0, 30)
@@ -712,7 +718,7 @@ describe 'DateMath', ->
     d = @minusEightMonths.exec(@ctx)
     dateCheck(d, 2012, 10, 15, 0, 0, 0, 0)
 
-  it.skip 'should properly add and subtract weeks', ->
+  it 'should properly add and subtract weeks', ->
     d = @plusThreeWeeks.exec(@ctx)
     dateCheck(d, 2013, 7, 6, 0, 0, 0, 0)
     d = @minusThreeWeeks.exec(@ctx)

--- a/Src/coffeescript/cql-execution/test/elm/datetime/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/datetime/test.coffee
@@ -695,3 +695,64 @@ describe 'DurationBetween Comparisons', ->
     @twentyFiveDaysLessThanDaysBetween.exec(@ctx).should.be.true()
     should(@fortyDaysEqualToDaysBetween.exec(@ctx)).be.null
     @twentyFiveDaysGreaterThanDaysBetween.exec(@ctx).should.be.false()
+
+describe 'DateMath', ->
+  @beforeEach ->
+    setup @, data
+
+  it 'should properly add and subtract years', ->
+    d = @plusThreeYears.exec(@ctx)
+    dateCheck(d, 2016, 6, 15, 0, 0, 0, 0)
+    d = @minusThreeYears.exec(@ctx)
+    dateCheck(d, 2010, 6, 15, 0, 0, 0, 0)
+
+  it 'should properly add and subtract months', ->
+    d = @plusEightMonths.exec(@ctx)
+    dateCheck(d, 2014, 2, 15, 0, 0, 0, 0)
+    d = @minusEightMonths.exec(@ctx)
+    dateCheck(d, 2012, 10, 15, 0, 0, 0, 0)
+
+  it.skip 'should properly add and subtract weeks', ->
+    d = @plusThreeWeeks.exec(@ctx)
+    dateCheck(d, 2013, 7, 6, 0, 0, 0, 0)
+    d = @minusThreeWeeks.exec(@ctx)
+    dateCheck(d, 2013, 5, 25, 0, 0, 0, 0)
+
+  it 'should properly add and subtract days', ->
+    d = @plusTwentyDays.exec(@ctx)
+    dateCheck(d, 2013, 7, 5, 0, 0, 0, 0)
+    d = @minusTwentyDays.exec(@ctx)
+    dateCheck(d, 2013, 5, 26, 0, 0, 0, 0)
+
+  it 'should properly add and subtract hours', ->
+    d = @plusThreeHours.exec(@ctx)
+    dateCheck(d, 2013, 6, 15, 3, 0, 0, 0)
+    d = @minusThreeHours.exec(@ctx)
+    dateCheck(d, 2013, 6, 14, 21, 0, 0, 0)
+
+  it 'should properly add and subtract minutes', ->
+    d = @plusThreeMinutes.exec(@ctx)
+    dateCheck(d, 2013, 6, 15, 0, 3, 0, 0)
+    d = @minusThreeMinutes.exec(@ctx)
+    dateCheck(d, 2013, 6, 14, 23, 57, 0, 0)
+
+  it 'should properly add and subtract seconds', ->
+    d = @plusThreeSeconds.exec(@ctx)
+    dateCheck(d, 2013, 6, 15, 0, 0, 3, 0)
+    d = @minusThreeSeconds.exec(@ctx)
+    dateCheck(d, 2013, 6, 14, 23, 59, 57, 0)
+
+  it 'should properly add and subtract milliseconds', ->
+    d = @plusThreeMilliseconds.exec(@ctx)
+    dateCheck(d, 2013, 6, 15, 0, 0, 0, 3)
+    d = @minusThreeMilliseconds.exec(@ctx)
+    dateCheck(d, 2013, 6, 14, 23, 59, 59, 997)
+
+dateCheck = (date, year, month, day, hour, minute, second, millisecond) ->
+  date.year.should.equal year
+  date.month.should.equal month
+  date.day.should.equal day
+  date.hour.should.equal hour
+  date.minute.should.equal minute
+  date.second.should.equal second
+  date.millisecond.should.equal millisecond


### PR DESCRIPTION
Fixed an issue with date math (e.g., `Today() - 3 months`) for hours and seconds.  Implemented date math and duration for the `weeks` unit (previously unsupported).