### PR TITLE
Avoid Files Named COM2

### DIFF
--- a/Src/coffeescript/cql-execution/test/elm/library/Common.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/Common.coffee
@@ -2,7 +2,7 @@
    WARNING: This is a GENERATED file.  Do not manually edit!
 
    To generate this file:
-       - Edit COM.coffee to add a CQL Snippet
+       - Edit Common.coffee to add a CQL Snippet
        - From java dir: ./gradlew :cql-to-elm:generateTestData
 ###
 

--- a/Src/coffeescript/cql-execution/test/elm/library/Common.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/Common.cql
@@ -1,5 +1,5 @@
 // NOTE: This library must be DUPLICATED in the data.cql file as well!
-library COM
+library Common
 using QUICK
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 

--- a/Src/coffeescript/cql-execution/test/elm/library/Common2.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/Common2.coffee
@@ -2,7 +2,7 @@
    WARNING: This is a GENERATED file.  Do not manually edit!
 
    To generate this file:
-       - Edit COM2.coffee to add a CQL Snippet
+       - Edit Common2.coffee to add a CQL Snippet
        - From java dir: ./gradlew :cql-to-elm:generateTestData
 ###
 

--- a/Src/coffeescript/cql-execution/test/elm/library/Common2.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/Common2.cql
@@ -1,5 +1,5 @@
 // NOTE: This library must be DUPLICATED in the data.cql file as well!
-library COM2
+library Common2
 using QUICK
 parameter SomeNumber default 17
 

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -157,7 +157,7 @@ module.exports['In Age Demographic'] = {
 }
 
 ### CommonLib
-library COM
+library Common
 using QUICK
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
@@ -173,7 +173,7 @@ define function foo (a Integer, b Integer) :
 module.exports['CommonLib'] = {
    "library" : {
       "identifier" : {
-         "id" : "COM"
+         "id" : "Common"
       },
       "schemaIdentifier" : {
          "id" : "urn:hl7-org:elm",
@@ -339,7 +339,7 @@ module.exports['CommonLib'] = {
 ### Using CommonLib
 library TestSnippet version '1'
 using QUICK
-include COM called common
+include Common called common
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
 context Patient
@@ -372,7 +372,7 @@ module.exports['Using CommonLib'] = {
       "includes" : {
          "def" : [ {
             "localIdentifier" : "common",
-            "path" : "COM"
+            "path" : "Common"
          } ]
       },
       "parameters" : {
@@ -500,7 +500,7 @@ module.exports['Using CommonLib'] = {
 }
 
 ### CommonLib2
-library COM2
+library Common2
 using QUICK
 parameter SomeNumber default 17
 
@@ -537,7 +537,7 @@ define SortUsingFunction:
 module.exports['CommonLib2'] = {
    "library" : {
       "identifier" : {
-         "id" : "COM2"
+         "id" : "Common2"
       },
       "schemaIdentifier" : {
          "id" : "urn:hl7-org:elm",
@@ -788,7 +788,7 @@ module.exports['CommonLib2'] = {
 ### Using CommonLib2
 library TestSnippet version '1'
 using QUICK
-include COM2 called common2
+include Common2 called common2
 
 context Patient
 
@@ -823,7 +823,7 @@ module.exports['Using CommonLib2'] = {
       "includes" : {
          "def" : [ {
             "localIdentifier" : "common2",
-            "path" : "COM2"
+            "path" : "Common2"
          } ]
       },
       "statements" : {

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -7,7 +7,7 @@ define InDemographic:
 AgeInYearsAt(start of MeasurementPeriod) >= 2 and AgeInYearsAt(start of MeasurementPeriod) < 18
 
 // @Test: CommonLib
-library COM
+library Common
 using QUICK
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
@@ -22,7 +22,7 @@ define function foo (a Integer, b Integer) :
 
 // @Test: Using CommonLib
 using QUICK
-include COM called common
+include Common called common
 parameter MeasurementPeriod default Interval[DateTime(2013, 1, 1), DateTime(2014, 1, 1))
 
 context Patient
@@ -33,7 +33,7 @@ define L : Length(Patient.name[0].given[0])
 define FuncTest : common.foo(2, 5)
 
 // @Test: CommonLib2
-library COM2
+library Common2
 using QUICK
 parameter SomeNumber default 17
 
@@ -68,7 +68,7 @@ define SortUsingFunction:
 
 // @Test: Using CommonLib2
 using QUICK
-include COM2 called common2
+include Common2 called common2
 
 context Patient
 


### PR DESCRIPTION
Fixes #138.  Apparently Windows does not allow files to have the name COM2.