### PR TITLE
#149: Removed exists keyword from the identifier parser rule as a tem…

### DIFF
--- a/Src/grammar/cql.g4
+++ b/Src/grammar/cql.g4
@@ -438,8 +438,8 @@ conceptSelector
     ;
 
 identifier
-    : IDENTIFIER | QUOTEDIDENTIFIER
-    // Include here any keyword that should not be a reserved word
+    : IDENTIFIER
+    | QUOTEDIDENTIFIER
     | 'all'
     | 'Code'
     | 'code'
@@ -450,7 +450,7 @@ identifier
     | 'display'
     | 'distinct'
     | 'end'
-    | 'exists'
+    // | 'exists'
     | 'not'
     | 'start'
     | 'time'


### PR DESCRIPTION
…porary work around for the reported parser performance issue. A subsequent pull request will address the issue for the long term.

I realize this isn't a long-term fix, and it introduces an issue with FHIRPath support (namely `.exists(...` will no longer work in CQL), but I'd still like to request that this workaround be merged with master as quickly as possible to support the ongoing CQL testing effort, which does not make use of FHIRPath functionality.