### PR TITLE
Returns an object containing each library name and the list of localI…

### DIFF
--- a/Src/coffeescript/cql-execution/src/elm/expression.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/expression.coffee
@@ -11,8 +11,9 @@ module.exports.Expression = class Expression
   
   execute: (ctx) ->
     if @localId?
-      ctx.localId_context[@localId] = @exec(ctx)
-      ctx.localId_context[@localId]
+      # Store the localId and result on the root context of this library
+      ctx.rootContext().setLocalIdWithResult @localId, @exec(ctx)
+      ctx.rootContext().getLocalIdResult @localId
     else 
       @exec(ctx)
 

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -3426,8 +3426,8 @@
 
     Expression.prototype.execute = function(ctx) {
       if (this.localId != null) {
-        ctx.localId_context[this.localId] = this.exec(ctx);
-        return ctx.localId_context[this.localId];
+        ctx.rootContext().setLocalIdWithResult(this.localId, this.exec(ctx));
+        return ctx.rootContext().getLocalIdResult(this.localId);
       } else {
         return this.exec(ctx);
       }
@@ -42895,6 +42895,43 @@
       return this.context_values[identifier] = value;
     };
 
+    Context.prototype.setLocalIdWithResult = function(localId, value) {
+      return this.localId_context[localId] = value;
+    };
+
+    Context.prototype.getLocalIdResult = function(localId) {
+      return this.localId_context[localId];
+    };
+
+    Context.prototype.getAllLocalIds = function() {
+      var lib, libName, localId, localIdResults, ref, ref1, value;
+      localIdResults = {};
+      localIdResults[this.parent.source.library.identifier.id] = {};
+      ref = this.localId_context;
+      for (localId in ref) {
+        value = ref[localId];
+        localIdResults[this.parent.source.library.identifier.id][localId] = value;
+      }
+      ref1 = this.library_context;
+      for (libName in ref1) {
+        lib = ref1[libName];
+        this.supportLibraryLocalIds(lib, localIdResults);
+      }
+      return localIdResults;
+    };
+
+    Context.prototype.supportLibraryLocalIds = function(lib, localIdResults) {
+      var ref, results, supportLib, supportLibName;
+      localIdResults[lib.library.source.library.identifier.id] = lib.localId_context;
+      ref = lib.library_context;
+      results = [];
+      for (supportLibName in ref) {
+        supportLib = ref[supportLibName];
+        results.push(this.supportLibraryLocalIds(supportLib, localIdResults));
+      }
+      return results;
+    };
+
     Context.prototype.checkParameters = function(params) {
       var pDef, pName, pVal;
       for (pName in params) {
@@ -43141,7 +43178,7 @@
       expr = this.library.expressions[expression];
       while (expr && (p = patientSource.currentPatient())) {
         patient_ctx = new PatientContext(this.library, p, this.codeService, this.parameters);
-        r.recordPatientResult(patient_ctx.patient.id(), expression, expr.exec(patient_ctx));
+        r.recordPatientResult(patient_ctx, expression, expr.execute(patient_ctx));
         patientSource.nextPatient();
       }
       return r;
@@ -43170,7 +43207,7 @@
         for (key in ref) {
           expr = ref[key];
           if (expr.context === "Patient") {
-            r.recordPatientResult(patient_ctx.patient.id(), key, patient_ctx.localId_context, expr.execute(patient_ctx));
+            r.recordPatientResult(patient_ctx, key, expr.execute(patient_ctx));
           }
         }
         patientSource.nextPatient();
@@ -43244,21 +43281,17 @@
       this.localIdPatientResultsMap = {};
     }
 
-    Results.prototype.recordPatientResult = function(patientId, resultName, localId_hash, result) {
-      var base, base1, localId, results, value;
+    Results.prototype.recordPatientResult = function(patient_ctx, resultName, result) {
+      var base, base1, patientId;
+      patientId = patient_ctx.patient.id();
       if ((base = this.patientResults)[patientId] == null) {
         base[patientId] = {};
       }
+      this.patientResults[patientId][resultName] = result;
       if ((base1 = this.localIdPatientResultsMap)[patientId] == null) {
         base1[patientId] = {};
       }
-      this.patientResults[patientId][resultName] = result;
-      results = [];
-      for (localId in localId_hash) {
-        value = localId_hash[localId];
-        results.push(this.localIdPatientResultsMap[patientId][localId] = value);
-      }
-      return results;
+      return this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds();
     };
 
     Results.prototype.recordPopulationResult = function(resultName, result) {

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -42904,17 +42904,13 @@
     };
 
     Context.prototype.getAllLocalIds = function() {
-      var lib, libName, localId, localIdResults, ref, ref1, value;
+      var lib, libName, localIdResults, ref;
       localIdResults = {};
       localIdResults[this.parent.source.library.identifier.id] = {};
-      ref = this.localId_context;
-      for (localId in ref) {
-        value = ref[localId];
-        localIdResults[this.parent.source.library.identifier.id][localId] = value;
-      }
-      ref1 = this.library_context;
-      for (libName in ref1) {
-        lib = ref1[libName];
+      localIdResults[this.parent.source.library.identifier.id] = this.localId_context;
+      ref = this.library_context;
+      for (libName in ref) {
+        lib = ref[libName];
         this.supportLibraryLocalIds(lib, localIdResults);
       }
       return localIdResults;
@@ -43282,15 +43278,12 @@
     }
 
     Results.prototype.recordPatientResult = function(patient_ctx, resultName, result) {
-      var base, base1, patientId;
+      var base, patientId;
       patientId = patient_ctx.patient.id();
       if ((base = this.patientResults)[patientId] == null) {
         base[patientId] = {};
       }
       this.patientResults[patientId][resultName] = result;
-      if ((base1 = this.localIdPatientResultsMap)[patientId] == null) {
-        base1[patientId] = {};
-      }
       return this.localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds();
     };
 

--- a/Src/coffeescript/cql-execution/src/runtime/context.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/context.coffee
@@ -84,6 +84,33 @@ module.exports.Context = class Context
   set: (identifier, value) ->
     @context_values[identifier] = value
 
+  setLocalIdWithResult: (localId, value) ->
+    @localId_context[localId] = value
+
+  getLocalIdResult: (localId) ->
+    @localId_context[localId]
+
+  # Returns an object of objects containing each library name
+  # with the localIds and result values
+  getAllLocalIds: ->
+    localIdResults = {}
+    # Add the localIds and result values from the main library
+    localIdResults[@parent.source.library.identifier.id] = {}
+    for localId, value of @localId_context
+      localIdResults[@parent.source.library.identifier.id][localId] = value
+    # Iterate over support libraries and store localIds
+    for libName, lib of @library_context
+      @supportLibraryLocalIds lib, localIdResults
+    localIdResults
+
+  # Recursive function that will grab nested support library localId results
+  supportLibraryLocalIds: (lib, localIdResults) ->
+    # Set library identifier name as the key and the object of localIds with their results as the value
+    localIdResults[lib.library.source.library.identifier.id] = lib.localId_context
+    # Iterate over any support libraries in the current support library
+    for supportLibName, supportLib of lib.library_context
+      @supportLibraryLocalIds supportLib, localIdResults
+
   checkParameters: (params) ->
     for pName, pVal of params
       pDef = @getParameter(pName)

--- a/Src/coffeescript/cql-execution/src/runtime/context.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/context.coffee
@@ -96,8 +96,8 @@ module.exports.Context = class Context
     localIdResults = {}
     # Add the localIds and result values from the main library
     localIdResults[@parent.source.library.identifier.id] = {}
-    for localId, value of @localId_context
-      localIdResults[@parent.source.library.identifier.id][localId] = value
+    localIdResults[@parent.source.library.identifier.id] = @localId_context
+
     # Iterate over support libraries and store localIds
     for libName, lib of @library_context
       @supportLibraryLocalIds lib, localIdResults

--- a/Src/coffeescript/cql-execution/src/runtime/executor.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/executor.coffee
@@ -19,7 +19,7 @@ module.exports.Executor = class Executor
     expr = @library.expressions[expression]
     while expr && p = patientSource.currentPatient()
       patient_ctx = new PatientContext(@library,p,@codeService,@parameters)
-      r.recordPatientResult(patient_ctx.patient.id(), expression, expr.exec(patient_ctx))
+      r.recordPatientResult(patient_ctx, expression, expr.execute(patient_ctx))
       patientSource.nextPatient()
     r
 
@@ -35,7 +35,7 @@ module.exports.Executor = class Executor
     while p = patientSource.currentPatient()
       patient_ctx = new PatientContext(@library,p,@codeService,@parameters)
       for key,expr of @library.expressions when expr.context is "Patient"
-        r.recordPatientResult(patient_ctx.patient.id(), key, patient_ctx.localId_context, expr.execute(patient_ctx))
+        r.recordPatientResult(patient_ctx, key, expr.execute(patient_ctx))
       patientSource.nextPatient()
     r
 

--- a/Src/coffeescript/cql-execution/src/runtime/results.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/results.coffee
@@ -8,7 +8,6 @@ module.exports.Results = class Results
     patientId = patient_ctx.patient.id()
     @patientResults[patientId] ?= {}
     @patientResults[patientId][resultName] = result
-    @localIdPatientResultsMap[patientId] ?= {}
     @localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds()
 
   recordPopulationResult: (resultName, result) ->

--- a/Src/coffeescript/cql-execution/src/runtime/results.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/results.coffee
@@ -4,12 +4,12 @@ module.exports.Results = class Results
     @populationResults = {}
     @localIdPatientResultsMap = {}
 
-  recordPatientResult: (patientId, resultName, localId_hash, result) ->
+  recordPatientResult: (patient_ctx, resultName, result) ->
+    patientId = patient_ctx.patient.id()
     @patientResults[patientId] ?= {}
-    @localIdPatientResultsMap[patientId] ?= {}
     @patientResults[patientId][resultName] = result
-    for localId, value of localId_hash
-      @localIdPatientResultsMap[patientId][localId] = value
+    @localIdPatientResultsMap[patientId] ?= {}
+    @localIdPatientResultsMap[patientId] = patient_ctx.getAllLocalIds()
 
   recordPopulationResult: (resultName, result) ->
     @populationResults[resultName] = result


### PR DESCRIPTION

[bonnienesting01_fixed.zip](https://github.com/cqframework/clinical_quality_language/files/1139951/bonnienesting01_fixed.zip)
…ds with results

In order to test this, copy the cql4browsers.js into a local copy of cql_qdm_patientapi. Have bonnie point to that local copy. Place a debugger in the cql_calculator.js.coffee (in Bonnie repo), under the line: 
 "results = executeSimpleELM(elm, patientSource, @valueSetsForCodeService(), population.collection.parent.get('main_cql_library'), main_library_version, params)"

Go to a measure and either add a patient or edit a patient.  Open developer tools and wait for the debugger to hit. In the console type "results".

"**localIdPatientResultsMap**" should exist. 
- Click the structure open. 
- Open the first patient_id object. 
- A list of library name objects should appear, each containing a map of localIds and result values.

If you can see the library name and that object contains localids and result values, then this is working as expected. 
