### PR TITLE
CQL Exec: Fix Distinct on lists of objects

### DIFF
--- a/Src/coffeescript/cql-execution/src/elm/list.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/list.coffee
@@ -100,9 +100,11 @@ module.exports.Distinct = class Distinct extends Expression
 
   exec: (ctx) ->
     arg = @execArgs ctx
-    container = {}
-    container[itm] = itm for itm in arg
-    value for key, value of container
+    seen = []
+    arg.filter (item) ->
+      isNew = seen.every (seenItem) -> !equals(item, seenItem)
+      seen.push item if isNew
+      isNew
 
 # ELM-only, not a product of CQL
 module.exports.Current = class Current extends UnimplementedExpression

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -4266,19 +4266,19 @@
     }
 
     Distinct.prototype.exec = function(ctx) {
-      var arg, container, itm, j, key, len, results, value;
+      var arg, seen;
       arg = this.execArgs(ctx);
-      container = {};
-      for (j = 0, len = arg.length; j < len; j++) {
-        itm = arg[j];
-        container[itm] = itm;
-      }
-      results = [];
-      for (key in container) {
-        value = container[key];
-        results.push(value);
-      }
-      return results;
+      seen = [];
+      return arg.filter(function(item) {
+        var isNew;
+        isNew = seen.every(function(seenItem) {
+          return !equals(item, seenItem);
+        });
+        if (isNew) {
+          seen.push(item);
+        }
+        return isNew;
+      });
     };
 
     return Distinct;
@@ -6860,7 +6860,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class AllergyIntoleranceEventComponent
   @exports  AllergyIntoleranceEventComponent as AllergyIntoleranceEventComponent
@@ -7218,7 +7218,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class AppointmentParticipantComponent
   @exports  AppointmentParticipantComponent as AppointmentParticipantComponent
@@ -8209,7 +8209,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class BundleLinkComponent
   @exports  BundleLinkComponent as BundleLinkComponent
@@ -8248,7 +8248,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class BundleEntryDeletedComponent
   @exports  BundleEntryDeletedComponent as BundleEntryDeletedComponent
@@ -8309,7 +8309,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class BundleEntryComponent
   @exports  BundleEntryComponent as BundleEntryComponent
@@ -8557,7 +8557,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class CarePlanParticipantComponent
   @exports  CarePlanParticipantComponent as CarePlanParticipantComponent
@@ -8600,7 +8600,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class CarePlanGoalComponent
   @exports  CarePlanGoalComponent as CarePlanGoalComponent
@@ -8668,7 +8668,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class CarePlanActivitySimpleComponent
   @exports  CarePlanActivitySimpleComponent as CarePlanActivitySimpleComponent
@@ -8820,7 +8820,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class CarePlanActivityComponent
   @exports  CarePlanActivityComponent as CarePlanActivityComponent
@@ -9157,7 +9157,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ItemAdjudicationComponent
   @exports  ItemAdjudicationComponent as ItemAdjudicationComponent
@@ -9210,7 +9210,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DetailAdjudicationComponent
   @exports  DetailAdjudicationComponent as DetailAdjudicationComponent
@@ -9263,7 +9263,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SubdetailAdjudicationComponent
   @exports  SubdetailAdjudicationComponent as SubdetailAdjudicationComponent
@@ -9316,7 +9316,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ItemSubdetailComponent
   @exports  ItemSubdetailComponent as ItemSubdetailComponent
@@ -9364,7 +9364,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ItemDetailComponent
   @exports  ItemDetailComponent as ItemDetailComponent
@@ -9431,7 +9431,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ItemsComponent
   @exports  ItemsComponent as ItemsComponent
@@ -9508,7 +9508,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class AddedItemAdjudicationComponent
   @exports  AddedItemAdjudicationComponent as AddedItemAdjudicationComponent
@@ -9561,7 +9561,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class AddedItemDetailAdjudicationComponent
   @exports  AddedItemDetailAdjudicationComponent as AddedItemDetailAdjudicationComponent
@@ -9614,7 +9614,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class AddedItemsDetailComponent
   @exports  AddedItemsDetailComponent as AddedItemsDetailComponent
@@ -9676,7 +9676,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class AddedItemComponent
   @exports  AddedItemComponent as AddedItemComponent
@@ -9777,7 +9777,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ErrorsComponent
   @exports  ErrorsComponent as ErrorsComponent
@@ -9838,7 +9838,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NotesComponent
   @exports  NotesComponent as NotesComponent
@@ -10304,7 +10304,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class CommunicationRequestMessagePartComponent
   @exports  CommunicationRequestMessagePartComponent as CommunicationRequestMessagePartComponent
@@ -10652,7 +10652,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class CompositionAttesterComponent
   @exports  CompositionAttesterComponent as CompositionAttesterComponent
@@ -10705,7 +10705,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class CompositionEventComponent
   @exports  CompositionEventComponent as CompositionEventComponent
@@ -10774,7 +10774,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SectionComponent
   @exports  SectionComponent as SectionComponent
@@ -11122,7 +11122,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class OtherElementComponent
   @exports  OtherElementComponent as OtherElementComponent
@@ -11171,7 +11171,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptMapElementMapComponent
   @exports  ConceptMapElementMapComponent as ConceptMapElementMapComponent
@@ -11249,7 +11249,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptMapElementComponent
   @exports  ConceptMapElementComponent as ConceptMapElementComponent
@@ -11584,7 +11584,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ConditionStageComponent
   @exports  ConditionStageComponent as ConditionStageComponent
@@ -11634,7 +11634,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConditionEvidenceComponent
   @exports  ConditionEvidenceComponent as ConditionEvidenceComponent
@@ -11684,7 +11684,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConditionLocationComponent
   @exports  ConditionLocationComponent as ConditionLocationComponent
@@ -11725,7 +11725,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConditionDueToComponent
   @exports  ConditionDueToComponent as ConditionDueToComponent
@@ -11768,7 +11768,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConditionOccurredFollowingComponent
   @exports  ConditionOccurredFollowingComponent as ConditionOccurredFollowingComponent
@@ -12160,7 +12160,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceSoftwareComponent
   @exports  ConformanceSoftwareComponent as ConformanceSoftwareComponent
@@ -12211,7 +12211,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceImplementationComponent
   @exports  ConformanceImplementationComponent as ConformanceImplementationComponent
@@ -12250,7 +12250,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestSecurityCertificateComponent
   @exports  ConformanceRestSecurityCertificateComponent as ConformanceRestSecurityCertificateComponent
@@ -12289,7 +12289,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestSecurityComponent
   @exports  ConformanceRestSecurityComponent as ConformanceRestSecurityComponent
@@ -12366,7 +12366,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ResourceInteractionComponent
   @exports  ResourceInteractionComponent as ResourceInteractionComponent
@@ -12405,7 +12405,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestResourceSearchParamComponent
   @exports  ConformanceRestResourceSearchParamComponent as ConformanceRestResourceSearchParamComponent
@@ -12484,7 +12484,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestResourceComponent
   @exports  ConformanceRestResourceComponent as ConformanceRestResourceComponent
@@ -12603,7 +12603,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SystemInteractionComponent
   @exports  SystemInteractionComponent as SystemInteractionComponent
@@ -12642,7 +12642,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestOperationComponent
   @exports  ConformanceRestOperationComponent as ConformanceRestOperationComponent
@@ -12683,7 +12683,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceRestComponent
   @exports  ConformanceRestComponent as ConformanceRestComponent
@@ -12801,7 +12801,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceMessagingEventComponent
   @exports  ConformanceMessagingEventComponent as ConformanceMessagingEventComponent
@@ -12915,7 +12915,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceMessagingComponent
   @exports  ConformanceMessagingComponent as ConformanceMessagingComponent
@@ -12983,7 +12983,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConformanceDocumentComponent
   @exports  ConformanceDocumentComponent as ConformanceDocumentComponent
@@ -13349,7 +13349,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ContractSignerComponent
   @exports  ContractSignerComponent as ContractSignerComponent
@@ -13390,7 +13390,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ContractTermComponent
   @exports  ContractTermComponent as ContractTermComponent
@@ -13888,7 +13888,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ContraindicationMitigationComponent
   @exports  ContraindicationMitigationComponent as ContraindicationMitigationComponent
@@ -14939,7 +14939,7 @@
   module.exports.Identifier = Identifier;
 
 
-  /** 
+  /**
   Embedded class
   @class ElementDefinitionSlicingComponent
   @exports  ElementDefinitionSlicingComponent as ElementDefinitionSlicingComponent
@@ -14998,7 +14998,7 @@
   })(Element);
 
 
-  /** 
+  /**
   Embedded class
   @class TypeRefComponent
   @exports  TypeRefComponent as TypeRefComponent
@@ -15047,7 +15047,7 @@
   })(Element);
 
 
-  /** 
+  /**
   Embedded class
   @class ElementDefinitionConstraintComponent
   @exports  ElementDefinitionConstraintComponent as ElementDefinitionConstraintComponent
@@ -15116,7 +15116,7 @@
   })(Element);
 
 
-  /** 
+  /**
   Embedded class
   @class ElementDefinitionBindingComponent
   @exports  ElementDefinitionBindingComponent as ElementDefinitionBindingComponent
@@ -15197,7 +15197,7 @@
   })(Element);
 
 
-  /** 
+  /**
   Embedded class
   @class ElementDefinitionMappingComponent
   @exports  ElementDefinitionMappingComponent as ElementDefinitionMappingComponent
@@ -15548,7 +15548,7 @@
   module.exports.ElementDefinition = ElementDefinition;
 
 
-  /** 
+  /**
   Embedded class
   @class TimingRepeatComponent
   @exports  TimingRepeatComponent as TimingRepeatComponent
@@ -15717,7 +15717,7 @@
 
 
     /**
-    This component contains the house number, apartment number, street name, street direction, 
+    This component contains the house number, apartment number, street name, street direction,
     P.O. Box number, delivery hints, and similar address information.
     @returns {Array} an array of {@link String} objects
      */
@@ -15941,7 +15941,7 @@
   module.exports.ContactPoint = ContactPoint;
 
 
-  /** 
+  /**
   Embedded class
   @class ResourceMetaComponent
   @exports  ResourceMetaComponent as ResourceMetaComponent
@@ -16094,7 +16094,7 @@
 
 
   /**
-  
+
   @class DomainResource
   @exports DomainResource as DomainResource
    */
@@ -16185,7 +16185,7 @@
   module.exports.DomainResource = DomainResource;
 
 
-  /** 
+  /**
   Embedded class
   @class ParametersParameterComponent
   @exports  ParametersParameterComponent as ParametersParameterComponent
@@ -16574,7 +16574,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DataElementBindingComponent
   @exports  DataElementBindingComponent as DataElementBindingComponent
@@ -16635,7 +16635,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DataElementMappingComponent
   @exports  DataElementMappingComponent as DataElementMappingComponent
@@ -17274,7 +17274,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DeviceComponentProductionSpecificationComponent
   @exports  DeviceComponentProductionSpecificationComponent as DeviceComponentProductionSpecificationComponent
@@ -18074,7 +18074,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DiagnosticOrderEventComponent
   @exports  DiagnosticOrderEventComponent as DiagnosticOrderEventComponent
@@ -18139,7 +18139,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DiagnosticOrderItemComponent
   @exports  DiagnosticOrderItemComponent as DiagnosticOrderItemComponent
@@ -18475,7 +18475,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DiagnosticReportImageComponent
   @exports  DiagnosticReportImageComponent as DiagnosticReportImageComponent
@@ -19118,7 +19118,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DocumentReferenceRelatesToComponent
   @exports  DocumentReferenceRelatesToComponent as DocumentReferenceRelatesToComponent
@@ -19159,7 +19159,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DocumentReferenceServiceParameterComponent
   @exports  DocumentReferenceServiceParameterComponent as DocumentReferenceServiceParameterComponent
@@ -19198,7 +19198,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DocumentReferenceServiceComponent
   @exports  DocumentReferenceServiceComponent as DocumentReferenceServiceComponent
@@ -19258,7 +19258,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DocumentReferenceContextComponent
   @exports  DocumentReferenceContextComponent as DocumentReferenceContextComponent
@@ -20084,7 +20084,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class EncounterParticipantComponent
   @exports  EncounterParticipantComponent as EncounterParticipantComponent
@@ -20134,7 +20134,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class EncounterHospitalizationAccomodationComponent
   @exports  EncounterHospitalizationAccomodationComponent as EncounterHospitalizationAccomodationComponent
@@ -20177,7 +20177,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class EncounterHospitalizationComponent
   @exports  EncounterHospitalizationComponent as EncounterHospitalizationComponent
@@ -20359,7 +20359,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class EncounterLocationComponent
   @exports  EncounterLocationComponent as EncounterLocationComponent
@@ -21327,7 +21327,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ExtensionDefinitionMappingComponent
   @exports  ExtensionDefinitionMappingComponent as ExtensionDefinitionMappingComponent
@@ -21677,7 +21677,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class FamilyHistoryRelationConditionComponent
   @exports  FamilyHistoryRelationConditionComponent as FamilyHistoryRelationConditionComponent
@@ -21756,7 +21756,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class FamilyHistoryRelationComponent
   @exports  FamilyHistoryRelationComponent as FamilyHistoryRelationComponent
@@ -22090,7 +22090,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class GroupCharacteristicComponent
   @exports  GroupCharacteristicComponent as GroupCharacteristicComponent
@@ -22363,7 +22363,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ServiceTypeComponent
   @exports  ServiceTypeComponent as ServiceTypeComponent
@@ -22413,7 +22413,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class HealthcareServiceAvailableTimeComponent
   @exports  HealthcareServiceAvailableTimeComponent as HealthcareServiceAvailableTimeComponent
@@ -22485,7 +22485,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class HealthcareServiceNotAvailableTimeComponent
   @exports  HealthcareServiceNotAvailableTimeComponent as HealthcareServiceNotAvailableTimeComponent
@@ -22990,7 +22990,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class InstanceComponent
   @exports  InstanceComponent as InstanceComponent
@@ -23053,7 +23053,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SeriesComponent
   @exports  SeriesComponent as SeriesComponent
@@ -23124,7 +23124,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class StudyComponent
   @exports  StudyComponent as StudyComponent
@@ -23368,7 +23368,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ImagingStudySeriesInstanceComponent
   @exports  ImagingStudySeriesInstanceComponent as ImagingStudySeriesInstanceComponent
@@ -23463,7 +23463,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ImagingStudySeriesComponent
   @exports  ImagingStudySeriesComponent as ImagingStudySeriesComponent
@@ -23899,7 +23899,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationExplanationComponent
   @exports  ImmunizationExplanationComponent as ImmunizationExplanationComponent
@@ -23956,7 +23956,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationReactionComponent
   @exports  ImmunizationReactionComponent as ImmunizationReactionComponent
@@ -24009,7 +24009,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationVaccinationProtocolComponent
   @exports  ImmunizationVaccinationProtocolComponent as ImmunizationVaccinationProtocolComponent
@@ -24431,7 +24431,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationRecommendationRecommendationDateCriterionComponent
   @exports  ImmunizationRecommendationRecommendationDateCriterionComponent as ImmunizationRecommendationRecommendationDateCriterionComponent
@@ -24474,7 +24474,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationRecommendationRecommendationProtocolComponent
   @exports  ImmunizationRecommendationRecommendationProtocolComponent as ImmunizationRecommendationRecommendationProtocolComponent
@@ -24535,7 +24535,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ImmunizationRecommendationRecommendationComponent
   @exports  ImmunizationRecommendationRecommendationComponent as ImmunizationRecommendationRecommendationComponent
@@ -24803,7 +24803,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ListEntryComponent
   @exports  ListEntryComponent as ListEntryComponent
@@ -25077,7 +25077,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class LocationPositionComponent
   @exports  LocationPositionComponent as LocationPositionComponent
@@ -25595,7 +25595,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationProductIngredientComponent
   @exports  MedicationProductIngredientComponent as MedicationProductIngredientComponent
@@ -25638,7 +25638,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationProductComponent
   @exports  MedicationProductComponent as MedicationProductComponent
@@ -25688,7 +25688,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationPackageContentComponent
   @exports  MedicationPackageContentComponent as MedicationPackageContentComponent
@@ -25731,7 +25731,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationPackageComponent
   @exports  MedicationPackageComponent as MedicationPackageComponent
@@ -25943,7 +25943,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationAdministrationDosageComponent
   @exports  MedicationAdministrationDosageComponent as MedicationAdministrationDosageComponent
@@ -26030,7 +26030,7 @@
 
     /**
     A coded value indicating the method by which the medication was introduced into or onto the body. Most commonly used for injections.  Examples:  Slow Push; Deep IV.
-    
+
     Terminologies used often pre-coordinate this term with the route and or form of administration.
     @returns {CodeableConcept}
      */
@@ -26084,7 +26084,7 @@
 
   /**
   Describes the event of a patient being given a dose of a medication.  This may be as simple as swallowing a tablet or it may be a long running infusion.
-  
+
   Related resources tie this event to the authorizing prescription, and the specific encounter between patient and health care practitioner.
   @class MedicationAdministration
   @exports MedicationAdministration as MedicationAdministration
@@ -26348,7 +26348,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationDispenseDispenseDosageComponent
   @exports  MedicationDispenseDispenseDosageComponent as MedicationDispenseDispenseDosageComponent
@@ -26459,7 +26459,7 @@
 
     /**
     A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  Examples:  Slow Push; Deep IV.
-    
+
     Terminologies used often pre-coordinate this term with the route and or form of administration.
     @returns {CodeableConcept}
      */
@@ -26511,7 +26511,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationDispenseDispenseComponent
   @exports  MedicationDispenseDispenseComponent as MedicationDispenseDispenseComponent
@@ -26662,7 +26662,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationDispenseSubstitutionComponent
   @exports  MedicationDispenseSubstitutionComponent as MedicationDispenseSubstitutionComponent
@@ -26911,7 +26911,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationPrescriptionDosageInstructionComponent
   @exports  MedicationPrescriptionDosageInstructionComponent as MedicationPrescriptionDosageInstructionComponent
@@ -27032,7 +27032,7 @@
 
     /**
     A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  Examples:  Slow Push; Deep IV.
-    
+
     Terminologies used often pre-coordinate this term with the route and or form of administration.
     @returns {CodeableConcept}
      */
@@ -27084,7 +27084,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationPrescriptionDispenseComponent
   @exports  MedicationPrescriptionDispenseComponent as MedicationPrescriptionDispenseComponent
@@ -27112,8 +27112,8 @@
 
 
     /**
-    Design Comments: This indicates the validity period of a prescription (stale dating the Prescription) 
-    It reflects the prescriber perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations. 
+    Design Comments: This indicates the validity period of a prescription (stale dating the Prescription)
+    It reflects the prescriber perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations.
     Rationale: Indicates when the Prescription becomes valid, and when it ceases to be a dispensable Prescription.
     @returns {Period}
      */
@@ -27126,7 +27126,7 @@
 
 
     /**
-    An integer indicating the number of repeats of the Dispense. 
+    An integer indicating the number of repeats of the Dispense.
     UsageNotes: For example, the number of times the prescribed quantity is to be supplied including the initial standard fill.
     @returns {Array} an array of {@link Number} objects
      */
@@ -27149,7 +27149,7 @@
 
 
     /**
-    Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last. 
+    Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.
     In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage) When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors.
     @returns {Duration}
      */
@@ -27165,7 +27165,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationPrescriptionSubstitutionComponent
   @exports  MedicationPrescriptionSubstitutionComponent as MedicationPrescriptionSubstitutionComponent
@@ -27448,7 +27448,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MedicationStatementDosageComponent
   @exports  MedicationStatementDosageComponent as MedicationStatementDosageComponent
@@ -27523,7 +27523,7 @@
 
     /**
     A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  Examples:  Slow Push; Deep IV.
-    
+
     Terminologies used often pre-coordinate this term with the route and or form of administration.
     @returns {CodeableConcept}
      */
@@ -27781,7 +27781,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class MessageHeaderResponseComponent
   @exports  MessageHeaderResponseComponent as MessageHeaderResponseComponent
@@ -27832,7 +27832,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MessageSourceComponent
   @exports  MessageSourceComponent as MessageSourceComponent
@@ -27903,7 +27903,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MessageDestinationComponent
   @exports  MessageDestinationComponent as MessageDestinationComponent
@@ -28379,7 +28379,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class NamingSystemUniqueIdComponent
   @exports  NamingSystemUniqueIdComponent as NamingSystemUniqueIdComponent
@@ -28440,7 +28440,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NamingSystemContactComponent
   @exports  NamingSystemContactComponent as NamingSystemContactComponent
@@ -28699,7 +28699,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemOralDietNutrientsComponent
   @exports  NutritionOrderItemOralDietNutrientsComponent as NutritionOrderItemOralDietNutrientsComponent
@@ -28754,7 +28754,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemOralDietTextureComponent
   @exports  NutritionOrderItemOralDietTextureComponent as NutritionOrderItemOralDietTextureComponent
@@ -28797,7 +28797,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemOralDietComponent
   @exports  NutritionOrderItemOralDietComponent as NutritionOrderItemOralDietComponent
@@ -28902,7 +28902,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemSupplementComponent
   @exports  NutritionOrderItemSupplementComponent as NutritionOrderItemSupplementComponent
@@ -28962,7 +28962,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemEnteralFormulaComponent
   @exports  NutritionOrderItemEnteralFormulaComponent as NutritionOrderItemEnteralFormulaComponent
@@ -29079,7 +29079,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NutritionOrderItemComponent
   @exports  NutritionOrderItemComponent as NutritionOrderItemComponent
@@ -29405,7 +29405,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ObservationReferenceRangeComponent
   @exports  ObservationReferenceRangeComponent as ObservationReferenceRangeComponent
@@ -29482,7 +29482,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ObservationRelatedComponent
   @exports  ObservationRelatedComponent as ObservationRelatedComponent
@@ -29942,7 +29942,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class OperationDefinitionParameterComponent
   @exports  OperationDefinitionParameterComponent as OperationDefinitionParameterComponent
@@ -30330,7 +30330,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class OperationOutcomeIssueComponent
   @exports  OperationOutcomeIssueComponent as OperationOutcomeIssueComponent
@@ -30494,7 +30494,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class PayeeComponent
   @exports  PayeeComponent as PayeeComponent
@@ -30561,7 +30561,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DiagnosisComponent
   @exports  DiagnosisComponent as DiagnosisComponent
@@ -30602,7 +30602,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class CoverageComponent
   @exports  CoverageComponent as CoverageComponent
@@ -30709,7 +30709,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class MissingTeethComponent
   @exports  MissingTeethComponent as MissingTeethComponent
@@ -30764,7 +30764,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class OrthodonticPlanComponent
   @exports  OrthodonticPlanComponent as OrthodonticPlanComponent
@@ -30863,7 +30863,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SubDetailComponent
   @exports  SubDetailComponent as SubDetailComponent
@@ -30984,7 +30984,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class DetailComponent
   @exports  DetailComponent as DetailComponent
@@ -31124,7 +31124,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ProsthesisComponent
   @exports  ProsthesisComponent as ProsthesisComponent
@@ -31177,7 +31177,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ItemsComponent
   @exports  ItemsComponent as ItemsComponent
@@ -31870,7 +31870,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class OrderWhenComponent
   @exports  OrderWhenComponent as OrderWhenComponent
@@ -32333,7 +32333,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class OrganizationContactComponent
   @exports  OrganizationContactComponent as OrganizationContactComponent
@@ -32791,7 +32791,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ContactComponent
   @exports  ContactComponent as ContactComponent
@@ -32906,7 +32906,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class AnimalComponent
   @exports  AnimalComponent as AnimalComponent
@@ -32961,7 +32961,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class PatientLinkComponent
   @exports  PatientLinkComponent as PatientLinkComponent
@@ -33578,7 +33578,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class DetailsComponent
   @exports  DetailsComponent as DetailsComponent
@@ -33681,7 +33681,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class NotesComponent
   @exports  NotesComponent as NotesComponent
@@ -34229,7 +34229,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class PractitionerQualificationComponent
   @exports  PractitionerQualificationComponent as PractitionerQualificationComponent
@@ -34616,7 +34616,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ProcedurePerformerComponent
   @exports  ProcedurePerformerComponent as ProcedurePerformerComponent
@@ -34659,7 +34659,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ProcedureRelatedItemComponent
   @exports  ProcedureRelatedItemComponent as ProcedureRelatedItemComponent
@@ -35306,7 +35306,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ProfileMappingComponent
   @exports  ProfileMappingComponent as ProfileMappingComponent
@@ -35365,7 +35365,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConstraintComponent
   @exports  ConstraintComponent as ConstraintComponent
@@ -35709,7 +35709,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ProvenanceAgentComponent
   @exports  ProvenanceAgentComponent as ProvenanceAgentComponent
@@ -35772,7 +35772,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ProvenanceEntityComponent
   @exports  ProvenanceEntityComponent as ProvenanceEntityComponent
@@ -36054,7 +36054,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class QueryResponseComponent
   @exports  QueryResponseComponent as QueryResponseComponent
@@ -36342,7 +36342,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class QuestionComponent
   @exports  QuestionComponent as QuestionComponent
@@ -36461,7 +36461,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class GroupComponent
   @exports  GroupComponent as GroupComponent
@@ -36744,7 +36744,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class QuestionAnswerComponent
   @exports  QuestionAnswerComponent as QuestionAnswerComponent
@@ -36899,7 +36899,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class QuestionComponent
   @exports  QuestionComponent as QuestionComponent
@@ -36976,7 +36976,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class GroupComponent
   @exports  GroupComponent as GroupComponent
@@ -37265,7 +37265,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ItemsComponent
   @exports  ItemsComponent as ItemsComponent
@@ -38009,7 +38009,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class PayeeComponent
   @exports  PayeeComponent as PayeeComponent
@@ -38076,7 +38076,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ReversalCoverageComponent
   @exports  ReversalCoverageComponent as ReversalCoverageComponent
@@ -38382,7 +38382,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class RiskAssessmentPredictionComponent
   @exports  RiskAssessmentPredictionComponent as RiskAssessmentPredictionComponent
@@ -38888,7 +38888,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventEventComponent
   @exports  SecurityEventEventComponent as SecurityEventEventComponent
@@ -38980,7 +38980,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventParticipantNetworkComponent
   @exports  SecurityEventParticipantNetworkComponent as SecurityEventParticipantNetworkComponent
@@ -39019,7 +39019,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventParticipantComponent
   @exports  SecurityEventParticipantComponent as SecurityEventParticipantComponent
@@ -39133,7 +39133,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventSourceComponent
   @exports  SecurityEventSourceComponent as SecurityEventSourceComponent
@@ -39191,7 +39191,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventObjectDetailComponent
   @exports  SecurityEventObjectDetailComponent as SecurityEventObjectDetailComponent
@@ -39230,7 +39230,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SecurityEventObjectComponent
   @exports  SecurityEventObjectComponent as SecurityEventObjectComponent
@@ -39703,7 +39703,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SpecimenSourceComponent
   @exports  SpecimenSourceComponent as SpecimenSourceComponent
@@ -39751,7 +39751,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SpecimenCollectionComponent
   @exports  SpecimenCollectionComponent as SpecimenCollectionComponent
@@ -39852,7 +39852,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SpecimenTreatmentComponent
   @exports  SpecimenTreatmentComponent as SpecimenTreatmentComponent
@@ -39912,7 +39912,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SpecimenContainerComponent
   @exports  SpecimenContainerComponent as SpecimenContainerComponent
@@ -40439,7 +40439,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class StatusResponseNotesComponent
   @exports  StatusResponseNotesComponent as StatusResponseNotesComponent
@@ -40739,7 +40739,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SubscriptionChannelComponent
   @exports  SubscriptionChannelComponent as SubscriptionChannelComponent
@@ -40798,7 +40798,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SubscriptionTagComponent
   @exports  SubscriptionTagComponent as SubscriptionTagComponent
@@ -41033,7 +41033,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SubstanceInstanceComponent
   @exports  SubstanceInstanceComponent as SubstanceInstanceComponent
@@ -41088,7 +41088,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class SubstanceIngredientComponent
   @exports  SubstanceIngredientComponent as SubstanceIngredientComponent
@@ -41268,7 +41268,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SupplyDispenseComponent
   @exports  SupplyDispenseComponent as SupplyDispenseComponent
@@ -41573,7 +41573,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class SupportingDocumentationDetailComponent
   @exports  SupportingDocumentationDetailComponent as SupportingDocumentationDetailComponent
@@ -41880,7 +41880,7 @@
   Element = CORE.Element;
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptDefinitionDesignationComponent
   @exports  ConceptDefinitionDesignationComponent as ConceptDefinitionDesignationComponent
@@ -41931,7 +41931,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptDefinitionComponent
   @exports  ConceptDefinitionComponent as ConceptDefinitionComponent
@@ -42028,7 +42028,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ValueSetDefineComponent
   @exports  ValueSetDefineComponent as ValueSetDefineComponent
@@ -42096,7 +42096,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptReferenceComponent
   @exports  ConceptReferenceComponent as ConceptReferenceComponent
@@ -42154,7 +42154,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptSetFilterComponent
   @exports  ConceptSetFilterComponent as ConceptSetFilterComponent
@@ -42203,7 +42203,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ConceptSetComponent
   @exports  ConceptSetComponent as ConceptSetComponent
@@ -42280,7 +42280,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ValueSetComposeComponent
   @exports  ValueSetComposeComponent as ValueSetComposeComponent
@@ -42347,7 +42347,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ValueSetExpansionContainsComponent
   @exports  ValueSetExpansionContainsComponent as ValueSetExpansionContainsComponent
@@ -42435,7 +42435,7 @@
   })(BackboneElement);
 
 
-  /** 
+  /**
   Embedded class
   @class ValueSetExpansionComponent
   @exports  ValueSetExpansionComponent as ValueSetExpansionComponent
@@ -43233,13 +43233,11 @@
 },{}],133:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.6
 (function() {
-  var DateTime, Quantity, Uncertainty, areDateTimesOrQuantities, areNumbers, equals, isUncertainty;
+  var DateTime, Uncertainty, areDateTimesOrQuantities, areNumbers, equals, isUncertainty;
 
   DateTime = require('../datatypes/datetime').DateTime;
 
   Uncertainty = require('../datatypes/uncertainty').Uncertainty;
-
-  Quantity = require('../elm/quantity').Quantity;
 
   areNumbers = function(a, b) {
     return typeof a === 'number' && typeof b === 'number';
@@ -43327,11 +43325,11 @@
   };
 
   module.exports.equals = equals = function(a, b) {
-    var aClass, aKeys, bClass, bKeys, key, obj, ref;
+    var aClass, aKeys, bClass, bKeys, key, obj, ref, ref1;
     if ((a == null) || (b == null)) {
       return a === b;
     }
-    if (a instanceof Quantity) {
+    if ((a != null ? (ref = a.constructor) != null ? ref.name : void 0 : void 0) === 'Quantity') {
       return a.equals(b);
     }
     if (a instanceof Uncertainty) {
@@ -43345,16 +43343,16 @@
     if (a === b) {
       return true;
     }
-    ref = (function() {
-      var j, len, ref, results;
-      ref = [a, b];
+    ref1 = (function() {
+      var j, len, ref1, results;
+      ref1 = [a, b];
       results = [];
-      for (j = 0, len = ref.length; j < len; j++) {
-        obj = ref[j];
+      for (j = 0, len = ref1.length; j < len; j++) {
+        obj = ref1[j];
         results.push({}.toString.call(obj));
       }
       return results;
-    })(), aClass = ref[0], bClass = ref[1];
+    })(), aClass = ref1[0], bClass = ref1[1];
     if (aClass !== bClass) {
       return false;
     }
@@ -43404,7 +43402,7 @@
 
 
 
-},{"../datatypes/datetime":7,"../datatypes/uncertainty":11,"../elm/quantity":32}],134:[function(require,module,exports){
+},{"../datatypes/datetime":7,"../datatypes/uncertainty":11}],134:[function(require,module,exports){
 // Generated by CoffeeScript 1.12.6
 (function() {
   var DateTime, Exception, MAX_DATE_VALUE, MAX_FLOAT_VALUE, MAX_INT_VALUE, MIN_DATE_VALUE, MIN_FLOAT_PRECISION_VALUE, MIN_FLOAT_VALUE, MIN_INT_VALUE, OverFlowException, Uncertainty, predecessor, successor,

--- a/Src/coffeescript/cql-execution/test/elm/list/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/list/data.coffee
@@ -5833,6 +5833,8 @@ using QUICK
 context Patient
 define LotsOfDups: distinct {1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 3, 2, 1}
 define NoDups: distinct {2, 4, 6, 8, 10}
+define DupsTuples: distinct { Tuple{ hello: 'world' }, Tuple{ hello: 'cleveland' }, Tuple{ hello: 'world' }, Tuple{ hello: 'dolly' } }
+define NoDupsTuples: distinct { Tuple{ hello: 'world' }, Tuple{ hello: 'cleveland' } }
 ###
 
 module.exports['Distinct'] = {
@@ -5981,6 +5983,88 @@ module.exports['Distinct'] = {
                      "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
                      "value" : "10",
                      "type" : "Literal"
+                  } ]
+               }
+            }
+         }, {
+            "name" : "DupsTuples",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Distinct",
+               "operand" : {
+                  "type" : "List",
+                  "element" : [ {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "world",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }, {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "cleveland",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }, {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "world",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }, {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "dolly",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  } ]
+               }
+            }
+         }, {
+            "name" : "NoDupsTuples",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Distinct",
+               "operand" : {
+                  "type" : "List",
+                  "element" : [ {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "world",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }, {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "hello",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                           "value" : "cleveland",
+                           "type" : "Literal"
+                        }
+                     } ]
                   } ]
                }
             }

--- a/Src/coffeescript/cql-execution/test/elm/list/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/list/data.cql
@@ -136,6 +136,8 @@ define NullValue: flatten null
 // @Test: Distinct
 define LotsOfDups: distinct {1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 3, 2, 1}
 define NoDups: distinct {2, 4, 6, 8, 10}
+define DupsTuples: distinct { Tuple{ hello: 'world' }, Tuple{ hello: 'cleveland' }, Tuple{ hello: 'world' }, Tuple{ hello: 'dolly' } }
+define NoDupsTuples: distinct { Tuple{ hello: 'world' }, Tuple{ hello: 'cleveland' } }
 
 // @Test: First
 define Numbers: First({1, 2, 3, 4})

--- a/Src/coffeescript/cql-execution/test/elm/list/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/list/test.coffee
@@ -359,6 +359,12 @@ describe 'Distinct', ->
   it 'should do nothing to an already distinct array', ->
     @noDups.exec(@ctx).should.eql [2, 4, 6, 8, 10]
 
+  it 'should remove duplicate tuples', ->
+    @dupsTuples.exec(@ctx).should.eql [{ hello: 'world' }, { hello: 'cleveland' }, { hello: 'dolly'}]
+
+  it 'should do nothing to an array of distinct tuples', ->
+    @noDupsTuples.exec(@ctx).should.eql [{ hello: 'world' }, { hello: 'cleveland' }]
+
 describe 'First', ->
   @beforeEach ->
     setup @, data


### PR DESCRIPTION
Prior to this fix, the Distinct operator had a bug that caused lists of objects to always be reduced to only a list of one -- whether or not they were distinct.

cql4browsers also picked up another very small recent change that apparently hadn't been browserified.