### PR TITLE
Implementing the ability to a query source to be derived from a singl…

### DIFF
--- a/Src/coffeescript/cql-execution/src/elm/query.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/query.coffee
@@ -21,7 +21,9 @@ module.exports.With = class With extends Expression
     @expression = build json.expression
     @suchThat = build json.suchThat
   exec: (ctx) ->
-    records = @expression.execute(ctx) || []
+    records = @expression.execute(ctx)
+    @isList = typeIsArray(records)
+    records = if @isList then records else [records]
     returns = for rec in records
       childCtx = ctx.childContext()
       childCtx.set @alias, rec
@@ -180,7 +182,7 @@ class MultiSource
     @isList || (@rest && @rest.returnsList())
 
   forEach: (ctx, func) ->
-    records = @expression.execute(ctx) || []
+    records = @expression.execute(ctx)
     @isList = typeIsArray(records)
     records = if @isList then records else [records]
     for rec in records

--- a/Src/coffeescript/cql-execution/src/elm/query.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/query.coffee
@@ -177,7 +177,7 @@ class MultiSource
     a
 
   returnsList: ->
-    if @rest then @isList || @rest.returnsList() else @isList
+    @isList || (@rest && @rest.returnsList())
 
   forEach: (ctx, func) ->
     records = @expression.execute(ctx) || []

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -5495,7 +5495,9 @@
 
     With.prototype.exec = function(ctx) {
       var childCtx, rec, records, returns;
-      records = this.expression.execute(ctx) || [];
+      records = this.expression.execute(ctx);
+      this.isList = typeIsArray(records);
+      records = this.isList ? records : [records];
       returns = (function() {
         var i, len, results;
         results = [];
@@ -5813,7 +5815,7 @@
 
     MultiSource.prototype.forEach = function(ctx, func) {
       var i, len, rctx, rec, records, results;
-      records = this.expression.execute(ctx) || [];
+      records = this.expression.execute(ctx);
       this.isList = typeIsArray(records);
       records = this.isList ? records : [records];
       results = [];

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -2308,3 +2308,350 @@ module.exports['Distinct'] = {
    }
 }
 
+### SingleObjectAlias
+library TestSnippet version '1'
+using QUICK
+context Patient
+define encounters: [Encounter] E
+define conditions: [Condition] C
+define firstEncounter: First([Encounter] E )
+define firstCondition: First([Condition] C)
+define singleAlias: firstEncounter E
+define singleAliasWhere: firstEncounter E where E is not null
+define singleAliasWhereToNull: firstEncounter  E where E.period is null
+define singleAliases: from firstEncounter E, firstCondition C
+define singleAliasesAndList: from firstEncounter E, firstCondition C , conditions Con
+//define singleAliasWith: firstEncounter E with [Condition] C
+//                         such that C.id = 'http://cqframework.org/3/2'
+//define singleAliasWithNull: firstEncounter E with conditions C
+//                        such that C.id is null
+define singleAliasReturnTuple: firstEncounter E return Tuple{a:1}
+define singleAliasReturnList: firstEncounter E return {'foo', 'bar', 'baz', 'bar'}
+###
+
+module.exports['SingleObjectAlias'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "encounters",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ ]
+            }
+         }, {
+            "name" : "conditions",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "C",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Condition",
+                     "templateId" : "condition-qicore-qicore-condition",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ ]
+            }
+         }, {
+            "name" : "firstEncounter",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "First",
+               "source" : {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "E",
+                     "expression" : {
+                        "dataType" : "{http://hl7.org/fhir}Encounter",
+                        "templateId" : "encounter-qicore-qicore-encounter",
+                        "type" : "Retrieve"
+                     }
+                  } ],
+                  "relationship" : [ ]
+               }
+            }
+         }, {
+            "name" : "firstCondition",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "First",
+               "source" : {
+                  "type" : "Query",
+                  "source" : [ {
+                     "alias" : "C",
+                     "expression" : {
+                        "dataType" : "{http://hl7.org/fhir}Condition",
+                        "templateId" : "condition-qicore-qicore-condition",
+                        "type" : "Retrieve"
+                     }
+                  } ],
+                  "relationship" : [ ]
+               }
+            }
+         }, {
+            "name" : "singleAlias",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ]
+            }
+         }, {
+            "name" : "singleAliasWhere",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "type" : "Not",
+                  "operand" : {
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "E",
+                        "type" : "AliasRef"
+                     }
+                  }
+               }
+            }
+         }, {
+            "name" : "singleAliasWhereToNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "where" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                     "path" : "period",
+                     "scope" : "E",
+                     "type" : "Property"
+                  }
+               }
+            }
+         }, {
+            "name" : "singleAliases",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "alias" : "C",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "distinct" : true,
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "E",
+                        "value" : {
+                           "name" : "E",
+                           "type" : "AliasRef"
+                        }
+                     }, {
+                        "name" : "C",
+                        "value" : {
+                           "name" : "C",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
+            "name" : "singleAliasesAndList",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "alias" : "C",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  }
+               }, {
+                  "alias" : "Con",
+                  "expression" : {
+                     "name" : "conditions",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "distinct" : true,
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "E",
+                        "value" : {
+                           "name" : "E",
+                           "type" : "AliasRef"
+                        }
+                     }, {
+                        "name" : "C",
+                        "value" : {
+                           "name" : "C",
+                           "type" : "AliasRef"
+                        }
+                     }, {
+                        "name" : "Con",
+                        "value" : {
+                           "name" : "Con",
+                           "type" : "AliasRef"
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
+            "name" : "singleAliasReturnTuple",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "expression" : {
+                     "type" : "Tuple",
+                     "element" : [ {
+                        "name" : "a",
+                        "value" : {
+                           "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                           "value" : "1",
+                           "type" : "Literal"
+                        }
+                     } ]
+                  }
+               }
+            }
+         }, {
+            "name" : "singleAliasReturnList",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "name" : "firstEncounter",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "expression" : {
+                     "type" : "List",
+                     "element" : [ {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "foo",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "bar",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "baz",
+                        "type" : "Literal"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "bar",
+                        "type" : "Literal"
+                     } ]
+                  }
+               }
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -2325,6 +2325,9 @@ define singleAliasWith:  [Encounter] E with firstCondition C such that C.id = 'h
 define singleAliasWithOut:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3'
 define singleAliasWithEmpty:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3'
 define singleAliasWithOutEmpty:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3/2'
+define asNull: null
+define nullQuery: asNull N
+
 //define singleAliasWith: firstEncounter E with [Condition] C
 //                         such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWithNull: firstEncounter E with conditions C
@@ -2740,6 +2743,28 @@ module.exports['SingleObjectAlias'] = {
                      } ]
                   }
                } ]
+            }
+         }, {
+            "name" : "asNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Null"
+            }
+         }, {
+            "name" : "nullQuery",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "N",
+                  "expression" : {
+                     "name" : "asNull",
+                     "type" : "ExpressionRef"
+                  }
+               } ],
+               "relationship" : [ ]
             }
          }, {
             "name" : "singleAliasReturnTuple",

--- a/Src/coffeescript/cql-execution/test/elm/query/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.coffee
@@ -2315,12 +2315,16 @@ context Patient
 define encounters: [Encounter] E
 define conditions: [Condition] C
 define firstEncounter: First([Encounter] E )
-define firstCondition: First([Condition] C)
+define firstCondition: First([Condition] C where C.id = 'http://cqframework.org/3/2')
 define singleAlias: firstEncounter E
 define singleAliasWhere: firstEncounter E where E is not null
 define singleAliasWhereToNull: firstEncounter  E where E.period is null
 define singleAliases: from firstEncounter E, firstCondition C
 define singleAliasesAndList: from firstEncounter E, firstCondition C , conditions Con
+define singleAliasWith:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3/2'
+define singleAliasWithOut:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3'
+define singleAliasWithEmpty:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3'
+define singleAliasWithOutEmpty:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWith: firstEncounter E with [Condition] C
 //                         such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWithNull: firstEncounter E with conditions C
@@ -2427,7 +2431,19 @@ module.exports['SingleObjectAlias'] = {
                         "type" : "Retrieve"
                      }
                   } ],
-                  "relationship" : [ ]
+                  "relationship" : [ ],
+                  "where" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "path" : "id",
+                        "scope" : "C",
+                        "type" : "Property"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://cqframework.org/3/2",
+                        "type" : "Literal"
+                     } ]
+                  }
                }
             }
          }, {
@@ -2584,6 +2600,146 @@ module.exports['SingleObjectAlias'] = {
                      } ]
                   }
                }
+            }
+         }, {
+            "name" : "singleAliasWith",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ {
+                  "alias" : "C",
+                  "type" : "With",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  },
+                  "suchThat" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "path" : "id",
+                        "scope" : "C",
+                        "type" : "Property"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://cqframework.org/3/2",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ]
+            }
+         }, {
+            "name" : "singleAliasWithOut",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ {
+                  "alias" : "C",
+                  "type" : "Without",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  },
+                  "suchThat" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "path" : "id",
+                        "scope" : "C",
+                        "type" : "Property"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://cqframework.org/3",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ]
+            }
+         }, {
+            "name" : "singleAliasWithEmpty",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ {
+                  "alias" : "C",
+                  "type" : "With",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  },
+                  "suchThat" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "path" : "id",
+                        "scope" : "C",
+                        "type" : "Property"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://cqframework.org/3",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ]
+            }
+         }, {
+            "name" : "singleAliasWithOutEmpty",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Query",
+               "source" : [ {
+                  "alias" : "E",
+                  "expression" : {
+                     "dataType" : "{http://hl7.org/fhir}Encounter",
+                     "templateId" : "encounter-qicore-qicore-encounter",
+                     "type" : "Retrieve"
+                  }
+               } ],
+               "relationship" : [ {
+                  "alias" : "C",
+                  "type" : "Without",
+                  "expression" : {
+                     "name" : "firstCondition",
+                     "type" : "ExpressionRef"
+                  },
+                  "suchThat" : {
+                     "type" : "Equal",
+                     "operand" : [ {
+                        "path" : "id",
+                        "scope" : "C",
+                        "type" : "Property"
+                     }, {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                        "value" : "http://cqframework.org/3/2",
+                        "type" : "Literal"
+                     } ]
+                  }
+               } ]
             }
          }, {
             "name" : "singleAliasReturnTuple",

--- a/Src/coffeescript/cql-execution/test/elm/query/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.cql
@@ -76,12 +76,16 @@ define allTuples: ({Tuple{a: 1, b:2}, Tuple{a: 2, b: 3}, Tuple{a: 1, b: 2}}) T r
 define encounters: [Encounter] E
 define conditions: [Condition] C
 define firstEncounter: First([Encounter] E )
-define firstCondition: First([Condition] C)
+define firstCondition: First([Condition] C where C.id = 'http://cqframework.org/3/2')
 define singleAlias: firstEncounter E
 define singleAliasWhere: firstEncounter E where E is not null
 define singleAliasWhereToNull: firstEncounter  E where E.period is null
 define singleAliases: from firstEncounter E, firstCondition C
 define singleAliasesAndList: from firstEncounter E, firstCondition C , conditions Con
+define singleAliasWith:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3/2'
+define singleAliasWithOut:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3'
+define singleAliasWithEmpty:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3'
+define singleAliasWithOutEmpty:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWith: firstEncounter E with [Condition] C
 //                         such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWithNull: firstEncounter E with conditions C

--- a/Src/coffeescript/cql-execution/test/elm/query/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.cql
@@ -71,3 +71,20 @@ define distinctTuples: ({Tuple{a: 1, b:2}, Tuple{a: 2, b: 3}, Tuple{a: 1, b: 2}}
 define allNumbers: ({1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1}) N return all N
 define allStrings: ({'foo', 'bar', 'baz', 'bar'}) S return all S
 define allTuples: ({Tuple{a: 1, b:2}, Tuple{a: 2, b: 3}, Tuple{a: 1, b: 2}}) T return all T
+
+// @Test: SingleObjectAlias
+define encounters: [Encounter] E
+define conditions: [Condition] C
+define firstEncounter: First([Encounter] E )
+define firstCondition: First([Condition] C)
+define singleAlias: firstEncounter E
+define singleAliasWhere: firstEncounter E where E is not null
+define singleAliasWhereToNull: firstEncounter  E where E.period is null
+define singleAliases: from firstEncounter E, firstCondition C
+define singleAliasesAndList: from firstEncounter E, firstCondition C , conditions Con
+//define singleAliasWith: firstEncounter E with [Condition] C
+//                         such that C.id = 'http://cqframework.org/3/2'
+//define singleAliasWithNull: firstEncounter E with conditions C
+//                        such that C.id is null
+define singleAliasReturnTuple: firstEncounter E return Tuple{a:1}
+define singleAliasReturnList: firstEncounter E return {'foo', 'bar', 'baz', 'bar'}

--- a/Src/coffeescript/cql-execution/test/elm/query/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/query/data.cql
@@ -86,6 +86,9 @@ define singleAliasWith:  [Encounter] E with firstCondition C such that C.id = 'h
 define singleAliasWithOut:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3'
 define singleAliasWithEmpty:  [Encounter] E with firstCondition C such that C.id = 'http://cqframework.org/3'
 define singleAliasWithOutEmpty:  [Encounter] E without firstCondition C such that C.id = 'http://cqframework.org/3/2'
+define asNull: null
+define nullQuery: asNull N
+
 //define singleAliasWith: firstEncounter E with [Condition] C
 //                         such that C.id = 'http://cqframework.org/3/2'
 //define singleAliasWithNull: firstEncounter E with conditions C

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -221,3 +221,6 @@ describe 'SingleObjectAlias', ->
      encounters = @encounters.exec(@ctx)
      @singleAliasWithOut.exec(@ctx).should.eql encounters
      @singleAliasWithOutEmpty.exec(@ctx).should.have.length(0)
+
+  it 'should allow single source queries to be null and return null' , ->
+     should.not.exist  @nullQuery.exec(@ctx)

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -208,3 +208,16 @@ describe 'SingleObjectAlias', ->
 
   it 'should be able to return different object that is a list' , ->
     @singleAliasReturnList.exec(@ctx).should.eql ['foo', 'bar', 'baz', 'bar']
+
+  it 'should be able to use a single object alias in a with clause', ->
+     encounters = @encounters.exec(@ctx)
+     debugger
+     aw = @singleAliasWith.exec(@ctx)
+     aw.should.eql encounters
+     awe = @singleAliasWithEmpty.exec(@ctx)
+     awe.should.have.length(0)
+
+  it 'should be able to use a single object alias in a withOut clause', ->
+     encounters = @encounters.exec(@ctx)
+     @singleAliasWithOut.exec(@ctx).should.eql encounters
+     @singleAliasWithOutEmpty.exec(@ctx).should.have.length(0)

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -172,3 +172,39 @@ describe 'Distinct', ->
     @allNumbers.exec(@ctx).should.eql [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1]
     @allStrings.exec(@ctx).should.eql ['foo', 'bar', 'baz', 'bar']
     @allTuples.exec(@ctx).should.eql [{a: 1, b:2}, {a: 2, b:3}, {a: 1, b:2}]
+
+describe 'SingleObjectAlias', ->
+  @beforeEach ->
+    setup @, data, [ p1 ]
+
+  it 'should return object for single object alias' , ->
+    firstEncounter = @firstEncounter.exec(@ctx)
+    @singleAlias.exec(@ctx).should.eql firstEncounter
+
+  it 'should return object for single object alias with a where clause' , ->
+    firstEncounter = @firstEncounter.exec(@ctx)
+    debugger
+    @singleAliasWhere.exec(@ctx).should.eql firstEncounter
+
+  it 'should return single object when multisource query is based on single alias queries' , ->
+    firstEncounter = @firstEncounter.exec(@ctx)
+    firstConditon = @firstCondition.exec(@ctx)
+    @singleAliases.exec(@ctx).should.eql {E: firstEncounter, C: firstConditon}
+
+  it 'should return list for multisource query that contains and single alias and list sources' , ->
+    conditions = @conditions.exec(@ctx)
+    firstEncounter = @firstEncounter.exec(@ctx)
+    firstCondition = @firstCondition.exec(@ctx)
+    expt = for con in conditions
+             {Con: con, E: firstEncounter, C: firstCondition}
+    q = @singleAliasesAndList.exec(@ctx)
+    q.should.have.length(conditions.length)
+    q.should.eql expt
+  it 'should be able to filter to null with where clause ' , ->
+    should.not.exist @singleAliasWhereToNull.exec(@ctx)
+
+  it 'should be able to return different object ' , ->
+    @singleAliasReturnTuple.exec(@ctx).should.eql {a:1}
+
+  it 'should be able to return different object that is a list' , ->
+    @singleAliasReturnList.exec(@ctx).should.eql ['foo', 'bar', 'baz', 'bar']

--- a/Src/coffeescript/cql-execution/test/elm/query/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/query/test.coffee
@@ -183,7 +183,6 @@ describe 'SingleObjectAlias', ->
 
   it 'should return object for single object alias with a where clause' , ->
     firstEncounter = @firstEncounter.exec(@ctx)
-    debugger
     @singleAliasWhere.exec(@ctx).should.eql firstEncounter
 
   it 'should return single object when multisource query is based on single alias queries' , ->
@@ -200,6 +199,7 @@ describe 'SingleObjectAlias', ->
     q = @singleAliasesAndList.exec(@ctx)
     q.should.have.length(conditions.length)
     q.should.eql expt
+
   it 'should be able to filter to null with where clause ' , ->
     should.not.exist @singleAliasWhereToNull.exec(@ctx)
 


### PR DESCRIPTION
…e object instead of a list.  When used as a single source the query will return a single object, not a list.  When used in conjuntion with other sources to a multicource query the returned value will be a single object if all sources are dervied from a single object, or a list if any of the sources are list based
