### PR TITLE
Fix diff calculations when straddling DST

### DIFF
--- a/Src/coffeescript/cql-execution/.vscode/launch.json
+++ b/Src/coffeescript/cql-execution/.vscode/launch.json
@@ -20,6 +20,22 @@
         ],
         "internalConsoleOptions": "openOnSessionStart"
     },
+    {
+        "type": "node",
+        "request": "launch",
+        "name": "Mocha Coffee Tests",
+        "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+        "args": [
+            "--compilers",
+            "coffee:coffee-script/register",
+            "--require",
+            "coffee-script",
+            "--recursive",
+            "--colors",
+            "${workspaceRoot}/test"
+        ],
+        "internalConsoleOptions": "openOnSessionStart"
+    },
         {
             "type": "node",
             "request": "launch",
@@ -31,3 +47,6 @@
         }
     ]
 }
+
+
+// NODE_ENV=test ./node_modules/.bin/mocha --compilers coffee:coffee-script/register --require coffee-script --recursive --colors test/datatypes/datetime.coffee

--- a/Src/coffeescript/cql-execution/test/datatypes/datetime.coffee
+++ b/Src/coffeescript/cql-execution/test/datatypes/datetime.coffee
@@ -387,6 +387,16 @@ describe 'DateTime.differenceBetween', ->
     a.differenceBetween(b, DateTime.Unit.SECOND).should.eql new Uncertainty(31622400)
     a.differenceBetween(b, DateTime.Unit.MILLISECOND).should.eql new Uncertainty(31622400000)
 
+  it 'should properly calculate duration and difference for Bonnie test case', ->
+    a = DateTime.parse '2012-02-08T00:00:00.0+00:00'
+    b = DateTime.parse '2012-06-08T23:59:00.0+00:00'
+    a.differenceBetween(b, DateTime.Unit.DAY).should.eql new Uncertainty(121)
+    a.durationBetween(b, DateTime.Unit.DAY).should.eql new Uncertainty(121)
+    a = DateTime.parse '2012-03-15T00:00:00.0+00:00'
+    b = DateTime.parse '2012-07-14T23:59:00.0+00:00'
+    a.differenceBetween(b, DateTime.Unit.DAY).should.eql new Uncertainty(121)
+    a.durationBetween(b, DateTime.Unit.DAY).should.eql new Uncertainty(121)
+
   it 'should handle difference in weeks using Sunday as a boundary', ->
 
     a = DateTime.parse '2012-02-04T23:59:59.999' # Saturday


### PR DESCRIPTION
When a diff is done between two dates, when one is observing DST and the other is not, we need to properly account for the timezone offset differences.

Also updates duration just a bit to do lower level precision comparisons in a more predictible way.