### PR TITLE
Fix 181 formatter testing

### DIFF
--- a/Src/java/tools/cql-formatter/build.gradle
+++ b/Src/java/tools/cql-formatter/build.gradle
@@ -3,5 +3,11 @@ apply plugin: 'application'
 mainClassName = 'org.cqframework.cql.tools.formatter.Main'
 
 dependencies {
-    compile project(':cql')
+    compile project(":cql-to-elm")
+    compile project(":cql")
+}
+
+
+test {
+    classpath = project.sourceSets.test.runtimeClasspath + files("${rootDir}/cql-to-elm/src/test/resources")
 }

--- a/Src/java/tools/cql-formatter/build.gradle
+++ b/Src/java/tools/cql-formatter/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 mainClassName = 'org.cqframework.cql.tools.formatter.Main'
 
 dependencies {
-    compile project(":cql-to-elm")
+    testCompile project(":cql-to-elm")
     compile project(":cql")
 }
 

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CommentListener.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CommentListener.java
@@ -1,0 +1,201 @@
+package org.cqframework.cql.tools.formatter;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.cqframework.cql.gen.cqlBaseListener;
+import org.cqframework.cql.gen.cqlParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Christopher on 7/25/2017.
+ */
+public class CommentListener extends cqlBaseListener {
+
+    CommonTokenStream tokens;
+
+    public CommentListener(CommonTokenStream tokens) {
+        this.tokens = tokens;
+    }
+
+    private List<Token> getLeftHiddenChannelTokens(int start) {
+        return tokens.getHiddenTokensToLeft(start, 1);
+    }
+
+    private List<Token> getRightHiddenChannelTokens(int end) {
+        return tokens.getHiddenTokensToRight(end, 1);
+    }
+
+    private void includeLeftComments(ParserRuleContext ctx) {
+        List<Token> hiddenTokens = getLeftHiddenChannelTokens(ctx.getStart().getTokenIndex());
+
+        if (hiddenTokens == null || hiddenTokens.size() == 1) return;
+
+        List<ParseTree> theKids = new ArrayList<>(ctx.children);
+
+        // remove the cql statement
+        int numKids = ctx.children.size();
+        for (int i = 0; i < numKids; ++i) {
+            ctx.removeLastChild();
+        }
+
+        // add the comments
+        for (Token token : hiddenTokens) {
+            if (token.getText().equals(" ")) continue;
+            ctx.addChild(new CommonToken(0, token.getText()));
+        }
+
+        // put cql statement back
+        for (ParseTree kid : theKids) {
+            if (kid instanceof Token) {
+                ctx.addChild((Token) kid);
+            }
+
+            else if (kid instanceof RuleContext) {
+                ctx.addChild((RuleContext) kid);
+            }
+
+            else if (kid instanceof TerminalNode) {
+                ctx.addChild((TerminalNode) kid);
+            }
+        }
+    }
+
+    public void includeRightComments(ParserRuleContext ctx) {
+        List<Token> hiddenTokens = getRightHiddenChannelTokens(ctx.getStop().getTokenIndex());
+
+        if (hiddenTokens == null) return;
+
+        // Checking for EOF
+        if (tokens.get(hiddenTokens.get(hiddenTokens.size()-1).getTokenIndex() + 1).getType() == -1) {
+            for (Token token : hiddenTokens) {
+                // also adding the whitespace
+                ctx.addChild(token);
+            }
+        }
+    }
+
+//    private String formatComment(String comment) {
+//        if (comment.startsWith("//")) {
+//            return "// " + comment.replaceFirst("//\\s+", "");
+//        }
+//        else {
+//            String content = comment.replaceFirst("/\\*", "").replace("*/", "").trim();
+//            return "/*\n\t" + content + "\n*/";
+//        }
+//    }
+
+    @Override
+    public void exitStatement(cqlParser.StatementContext ctx) {
+        includeLeftComments(ctx);
+        // Need to account for comments at the end of a file -> look to the right
+        // This is tricky because it is easy to duplicate comments looking both ways
+        includeRightComments(ctx);
+    }
+
+    @Override
+    public void exitTermExpression(cqlParser.TermExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+//    So, this is usually going to go to exitQuery - will duplicate comments...
+//    TODO: find a way to include both and not dup comments
+//    @Override
+//    public void exitRetrieve(cqlParser.RetrieveContext ctx) {
+//        includeLeftComments(ctx);
+//        
+//    }
+
+//    @Override
+//    public void exitQuery(cqlParser.QueryContext ctx) {
+//        includeLeftComments(ctx);
+//        
+//    }
+
+    @Override
+    public void exitSourceClause(cqlParser.SourceClauseContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitBooleanExpression(cqlParser.BooleanExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitTypeExpression(cqlParser.TypeExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitCastExpression(cqlParser.CastExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitNotExpression(cqlParser.NotExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitExistenceExpression(cqlParser.ExistenceExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitBetweenExpression(cqlParser.BetweenExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitDurationBetweenExpression(cqlParser.DurationBetweenExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitDifferenceBetweenExpression(cqlParser.DifferenceBetweenExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitInequalityExpression(cqlParser.InequalityExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitTimingExpression(cqlParser.TimingExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitEqualityExpression(cqlParser.EqualityExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitMembershipExpression(cqlParser.MembershipExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitAndExpression(cqlParser.AndExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitOrExpression(cqlParser.OrExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitImpliesExpression(cqlParser.ImpliesExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+
+    @Override
+    public void exitInFixSetExpression(cqlParser.InFixSetExpressionContext ctx) {
+        includeLeftComments(ctx);
+    }
+}

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CommentListener.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CommentListener.java
@@ -1,10 +1,9 @@
 package org.cqframework.cql.tools.formatter;
 
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
 import org.cqframework.cql.gen.cqlBaseListener;
-import org.cqframework.cql.gen.cqlParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,187 +14,551 @@ import java.util.List;
 public class CommentListener extends cqlBaseListener {
 
     CommonTokenStream tokens;
+    List<Token> commentsAtTop;
 
     public CommentListener(CommonTokenStream tokens) {
         this.tokens = tokens;
+        this.commentsAtTop = new ArrayList<>();
     }
 
-    private List<Token> getLeftHiddenChannelTokens(int start) {
-        return tokens.getHiddenTokensToLeft(start, 1);
-    }
+    public void rewriteTokens() {
+        for (int i = 0; i < tokens.getTokens().size(); ++i) {
+            Token token = tokens.getTokens().get(i);
+            if (token.getChannel() == 1 && token.getText().startsWith("//") || token.getText().startsWith("/*")) {
+                ((CommonToken) token).setChannel(0);
+                if (i == commentsAtTop.size()) {
+                    commentsAtTop.add(token);
+                }
 
-    private List<Token> getRightHiddenChannelTokens(int end) {
-        return tokens.getHiddenTokensToRight(end, 1);
-    }
-
-    private void includeLeftComments(ParserRuleContext ctx) {
-        List<Token> hiddenTokens = getLeftHiddenChannelTokens(ctx.getStart().getTokenIndex());
-
-        if (hiddenTokens == null || hiddenTokens.size() == 1) return;
-
-        List<ParseTree> theKids = new ArrayList<>(ctx.children);
-
-        // remove the cql statement
-        int numKids = ctx.children.size();
-        for (int i = 0; i < numKids; ++i) {
-            ctx.removeLastChild();
-        }
-
-        // add the comments
-        for (Token token : hiddenTokens) {
-            if (token.getText().equals(" ")) continue;
-            ctx.addChild(new CommonToken(0, token.getText()));
-        }
-
-        // put cql statement back
-        for (ParseTree kid : theKids) {
-            if (kid instanceof Token) {
-                ctx.addChild((Token) kid);
-            }
-
-            else if (kid instanceof RuleContext) {
-                ctx.addChild((RuleContext) kid);
-            }
-
-            else if (kid instanceof TerminalNode) {
-                ctx.addChild((TerminalNode) kid);
+                // preserve whitespace
+                if (i > 0) {
+                    if (tokens.getTokens().get(i - 1).getText().trim().isEmpty()) {
+                        ((CommonToken) tokens.getTokens().get(i - 1)).setChannel(0);
+                    }
+                }
+                if (i < tokens.getTokens().size() - 2) {
+                    if (tokens.getTokens().get(i + 1).getText().trim().isEmpty()) {
+                        ((CommonToken) tokens.getTokens().get(i + 1)).setChannel(0);
+                    }
+                }
             }
         }
     }
 
-    public void includeRightComments(ParserRuleContext ctx) {
-        List<Token> hiddenTokens = getRightHiddenChannelTokens(ctx.getStop().getTokenIndex());
-
-        if (hiddenTokens == null) return;
-
-        // Checking for EOF
-        if (tokens.get(hiddenTokens.get(hiddenTokens.size()-1).getTokenIndex() + 1).getType() == -1) {
-            for (Token token : hiddenTokens) {
-                // also adding the whitespace
-                ctx.addChild(token);
-            }
+    // Easier to format some things post hoc
+    public String refineOutput(String output) {
+        // Case where comments are at top of library - before any other constructs
+        for (Token token : commentsAtTop) {
+            output = token.getText() + "\r\n" + output;
         }
+
+        // Comments preserve whitespace, which can lead to extra newlines before statements
+        return output.replaceAll("\\r\\n\\r\\n\\r\\n", "\r\n");
     }
 
-//    private String formatComment(String comment) {
-//        if (comment.startsWith("//")) {
-//            return "// " + comment.replaceFirst("//\\s+", "");
+//    This is a more complex method, which includes comments by accessing the hidden channel
+//    private List<Token> getLeftHiddenChannelTokens(int start) {
+//        return tokens.getHiddenTokensToLeft(start, 1);
+//    }
+//
+//    private List<Token> getRightHiddenChannelTokens(int end) {
+//        return tokens.getHiddenTokensToRight(end, 1);
+//    }
+//
+//    private void includeLeftComments(ParserRuleContext ctx) {
+//        List<Token> hiddenTokens = getLeftHiddenChannelTokens(ctx.getStart().getTokenIndex());
+//
+//        if (hiddenTokens == null || hiddenTokens.size() == 1) return;
+//
+//        List<ParseTree> theKids = new ArrayList<>(ctx.children);
+//
+//        // remove the cql statement
+//        int numKids = ctx.children.size();
+//        for (int i = 0; i < numKids; ++i) {
+//            ctx.removeLastChild();
 //        }
-//        else {
-//            String content = comment.replaceFirst("/\\*", "").replace("*/", "").trim();
-//            return "/*\n\t" + content + "\n*/";
+//
+//        // add the comments
+//        for (Token token : hiddenTokens) {
+//            if (token.getText().trim().isEmpty()) continue;
+//            ctx.addChild(new CommonToken(0, token.getText()));
+//        }
+//
+//        // put cql statement back
+//        for (ParseTree kid : theKids) {
+//            if (kid instanceof Token) {
+//                ctx.addChild((Token) kid);
+//            }
+//
+//            else if (kid instanceof RuleContext) {
+//                ctx.addChild((RuleContext) kid);
+//            }
+//
+//            else if (kid instanceof TerminalNode) {
+//                ctx.addChild((TerminalNode) kid);
+//            }
 //        }
 //    }
-
-    @Override
-    public void exitStatement(cqlParser.StatementContext ctx) {
-        includeLeftComments(ctx);
-        // Need to account for comments at the end of a file -> look to the right
-        // This is tricky because it is easy to duplicate comments looking both ways
-        includeRightComments(ctx);
-    }
-
-    @Override
-    public void exitTermExpression(cqlParser.TermExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-//    So, this is usually going to go to exitQuery - will duplicate comments...
-//    TODO: find a way to include both and not dup comments
-//    @Override
-//    public void exitRetrieve(cqlParser.RetrieveContext ctx) {
-//        includeLeftComments(ctx);
-//        
+//
+//    public void includeRightComments(ParserRuleContext ctx) {
+//        List<Token> hiddenTokens = getRightHiddenChannelTokens(ctx.getStop().getTokenIndex());
+//
+//        if (hiddenTokens == null) return;
+//
+//        // Checking for EOF
+//        if (tokens.get(hiddenTokens.get(hiddenTokens.size()-1).getTokenIndex() + 1).getType() == -1) {
+//            for (Token token : hiddenTokens) {
+//                // also adding the whitespace
+//                ctx.addChild(token);
+//            }
+//        }
 //    }
-
-//    @Override
-//    public void exitQuery(cqlParser.QueryContext ctx) {
+//
+//    @Override public void exitLibrary(cqlParser.LibraryContext ctx) {
 //        includeLeftComments(ctx);
-//        
 //    }
-
-    @Override
-    public void exitSourceClause(cqlParser.SourceClauseContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitBooleanExpression(cqlParser.BooleanExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitTypeExpression(cqlParser.TypeExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitCastExpression(cqlParser.CastExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitNotExpression(cqlParser.NotExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitExistenceExpression(cqlParser.ExistenceExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitBetweenExpression(cqlParser.BetweenExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitDurationBetweenExpression(cqlParser.DurationBetweenExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitDifferenceBetweenExpression(cqlParser.DifferenceBetweenExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitInequalityExpression(cqlParser.InequalityExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitTimingExpression(cqlParser.TimingExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitEqualityExpression(cqlParser.EqualityExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitMembershipExpression(cqlParser.MembershipExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitAndExpression(cqlParser.AndExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitOrExpression(cqlParser.OrExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitImpliesExpression(cqlParser.ImpliesExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
-
-    @Override
-    public void exitInFixSetExpression(cqlParser.InFixSetExpressionContext ctx) {
-        includeLeftComments(ctx);
-    }
+//    @Override public void exitLibraryDefinition(cqlParser.LibraryDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitUsingDefinition(cqlParser.UsingDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIncludeDefinition(cqlParser.IncludeDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitLocalIdentifier(cqlParser.LocalIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAccessModifier(cqlParser.AccessModifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitParameterDefinition(cqlParser.ParameterDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodesystemDefinition(cqlParser.CodesystemDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitValuesetDefinition(cqlParser.ValuesetDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodesystems(cqlParser.CodesystemsContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodesystemIdentifier(cqlParser.CodesystemIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitLibraryIdentifier(cqlParser.LibraryIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodeDefinition(cqlParser.CodeDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitConceptDefinition(cqlParser.ConceptDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodeIdentifier(cqlParser.CodeIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodesystemId(cqlParser.CodesystemIdContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitValuesetId(cqlParser.ValuesetIdContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitVersionSpecifier(cqlParser.VersionSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodeId(cqlParser.CodeIdContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTypeSpecifier(cqlParser.TypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitNamedTypeSpecifier(cqlParser.NamedTypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitModelIdentifier(cqlParser.ModelIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitListTypeSpecifier(cqlParser.ListTypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIntervalTypeSpecifier(cqlParser.IntervalTypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTupleTypeSpecifier(cqlParser.TupleTypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTupleElementDefinition(cqlParser.TupleElementDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitChoiceTypeSpecifier(cqlParser.ChoiceTypeSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitStatement(cqlParser.StatementContext ctx) {
+//        includeLeftComments(ctx);
+//        // Need to account for comments at the end of a file -> look to the right
+//        // This is tricky because it is easy to duplicate comments looking both ways
+//        includeRightComments(ctx);
+//    }
+//    @Override public void exitExpressionDefinition(cqlParser.ExpressionDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitContextDefinition(cqlParser.ContextDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitFunctionDefinition(cqlParser.FunctionDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitOperandDefinition(cqlParser.OperandDefinitionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitFunctionBody(cqlParser.FunctionBodyContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQuerySource(cqlParser.QuerySourceContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAliasedQuerySource(cqlParser.AliasedQuerySourceContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAlias(cqlParser.AliasContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQueryInclusionClause(cqlParser.QueryInclusionClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitWithClause(cqlParser.WithClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitWithoutClause(cqlParser.WithoutClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitRetrieve(cqlParser.RetrieveContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodePath(cqlParser.CodePathContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTerminology(cqlParser.TerminologyContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQualifier(cqlParser.QualifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQuery(cqlParser.QueryContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSourceClause(cqlParser.SourceClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSingleSourceClause(cqlParser.SingleSourceClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitMultipleSourceClause(cqlParser.MultipleSourceClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitLetClause(cqlParser.LetClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitLetClauseItem(cqlParser.LetClauseItemContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitWhereClause(cqlParser.WhereClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitReturnClause(cqlParser.ReturnClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSortClause(cqlParser.SortClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSortDirection(cqlParser.SortDirectionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSortByItem(cqlParser.SortByItemContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQualifiedIdentifier(cqlParser.QualifiedIdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDurationBetweenExpression(cqlParser.DurationBetweenExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInFixSetExpression(cqlParser.InFixSetExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitRetrieveExpression(cqlParser.RetrieveExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTimingExpression(cqlParser.TimingExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitNotExpression(cqlParser.NotExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQueryExpression(cqlParser.QueryExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitBooleanExpression(cqlParser.BooleanExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitOrExpression(cqlParser.OrExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCastExpression(cqlParser.CastExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAndExpression(cqlParser.AndExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitBetweenExpression(cqlParser.BetweenExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitMembershipExpression(cqlParser.MembershipExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDifferenceBetweenExpression(cqlParser.DifferenceBetweenExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInequalityExpression(cqlParser.InequalityExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitEqualityExpression(cqlParser.EqualityExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitExistenceExpression(cqlParser.ExistenceExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitImpliesExpression(cqlParser.ImpliesExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTermExpression(cqlParser.TermExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTypeExpression(cqlParser.TypeExpressionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDateTimePrecision(cqlParser.DateTimePrecisionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDateTimeComponent(cqlParser.DateTimeComponentContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitPluralDateTimePrecision(cqlParser.PluralDateTimePrecisionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAdditionExpressionTerm(cqlParser.AdditionExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIndexedExpressionTerm(cqlParser.IndexedExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitWidthExpressionTerm(cqlParser.WidthExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTimeUnitExpressionTerm(cqlParser.TimeUnitExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIfThenElseExpressionTerm(cqlParser.IfThenElseExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTimeBoundaryExpressionTerm(cqlParser.TimeBoundaryExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitElementExtractorExpressionTerm(cqlParser.ElementExtractorExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitConversionExpressionTerm(cqlParser.ConversionExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTypeExtentExpressionTerm(cqlParser.TypeExtentExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitPredecessorExpressionTerm(cqlParser.PredecessorExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitPointExtractorExpressionTerm(cqlParser.PointExtractorExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitMultiplicationExpressionTerm(cqlParser.MultiplicationExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitAggregateExpressionTerm(cqlParser.AggregateExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDurationExpressionTerm(cqlParser.DurationExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCaseExpressionTerm(cqlParser.CaseExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitPowerExpressionTerm(cqlParser.PowerExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitSuccessorExpressionTerm(cqlParser.SuccessorExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitPolarityExpressionTerm(cqlParser.PolarityExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTermExpressionTerm(cqlParser.TermExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInvocationExpressionTerm(cqlParser.InvocationExpressionTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCaseExpressionItem(cqlParser.CaseExpressionItemContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDateTimePrecisionSpecifier(cqlParser.DateTimePrecisionSpecifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitRelativeQualifier(cqlParser.RelativeQualifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitOffsetRelativeQualifier(cqlParser.OffsetRelativeQualifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitExclusiveRelativeQualifier(cqlParser.ExclusiveRelativeQualifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQuantityOffset(cqlParser.QuantityOffsetContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTemporalRelationship(cqlParser.TemporalRelationshipContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitConcurrentWithIntervalOperatorPhrase(cqlParser.ConcurrentWithIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIncludesIntervalOperatorPhrase(cqlParser.IncludesIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIncludedInIntervalOperatorPhrase(cqlParser.IncludedInIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitBeforeOrAfterIntervalOperatorPhrase(cqlParser.BeforeOrAfterIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitWithinIntervalOperatorPhrase(cqlParser.WithinIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitMeetsIntervalOperatorPhrase(cqlParser.MeetsIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitOverlapsIntervalOperatorPhrase(cqlParser.OverlapsIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitStartsIntervalOperatorPhrase(cqlParser.StartsIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitEndsIntervalOperatorPhrase(cqlParser.EndsIntervalOperatorPhraseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInvocationTerm(cqlParser.InvocationTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitLiteralTerm(cqlParser.LiteralTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitExternalConstantTerm(cqlParser.ExternalConstantTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIntervalSelectorTerm(cqlParser.IntervalSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTupleSelectorTerm(cqlParser.TupleSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInstanceSelectorTerm(cqlParser.InstanceSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitListSelectorTerm(cqlParser.ListSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodeSelectorTerm(cqlParser.CodeSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitConceptSelectorTerm(cqlParser.ConceptSelectorTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitParenthesizedTerm(cqlParser.ParenthesizedTermContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitBooleanLiteral(cqlParser.BooleanLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitNullLiteral(cqlParser.NullLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitStringLiteral(cqlParser.StringLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitNumberLiteral(cqlParser.NumberLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDateTimeLiteral(cqlParser.DateTimeLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTimeLiteral(cqlParser.TimeLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQuantityLiteral(cqlParser.QuantityLiteralContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIntervalSelector(cqlParser.IntervalSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTupleSelector(cqlParser.TupleSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitTupleElementSelector(cqlParser.TupleElementSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInstanceSelector(cqlParser.InstanceSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitInstanceElementSelector(cqlParser.InstanceElementSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitListSelector(cqlParser.ListSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitDisplayClause(cqlParser.DisplayClauseContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitCodeSelector(cqlParser.CodeSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitConceptSelector(cqlParser.ConceptSelectorContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitIdentifier(cqlParser.IdentifierContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitExternalConstant(cqlParser.ExternalConstantContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitMemberInvocation(cqlParser.MemberInvocationContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitFunctionInvocation(cqlParser.FunctionInvocationContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitThisInvocation(cqlParser.ThisInvocationContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitFunction(cqlParser.FunctionContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitParamList(cqlParser.ParamListContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitQuantity(cqlParser.QuantityContext ctx) {
+//        includeLeftComments(ctx);
+//    }
+//    @Override public void exitUnit(cqlParser.UnitContext ctx) {
+//        includeLeftComments(ctx);
+//    }
 }

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
@@ -140,6 +140,10 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
     }
 
     private boolean needsWhitespaceBefore(String terminal) {
+        if (terminal.trim().isEmpty() || terminal.startsWith("//") || terminal.startsWith("/*")) {
+            return false;
+        }
+
         switch (terminal) {
             case ":": return false;
             case ".": return false;

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/Main.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/Main.java
@@ -27,11 +27,13 @@ public class Main {
         cqlLexer lexer = new cqlLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         tokens.fill();
-        cqlParser parser = new cqlParser(tokens);
+        CommentListener listener = new CommentListener(tokens);
+        listener.rewriteTokens();
+        cqlParser parser = new cqlParser(listener.tokens);
         parser.setBuildParseTree(true);
         ParserRuleContext tree = parser.library();
         CqlFormatterVisitor formatter = new CqlFormatterVisitor();
         String output = (String)formatter.visit(tree);
-        System.out.print(output);
+        System.out.print(listener.refineOutput(output));
     }
 }

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/Main.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/Main.java
@@ -14,15 +14,8 @@ import java.io.InputStream;
  * A simple wrapper around the ANTLR4 testrig.
  */
 public class Main {
-    public static void main(String[] args) throws IOException {
-        String inputFile = null;
-        if (args.length > 0) {
-            inputFile = args[0];
-        }
-        InputStream is = System.in;
-        if (inputFile != null) {
-            is = new FileInputStream(inputFile);
-        }
+
+    public static String getFormattedOutput(InputStream is) throws IOException {
         ANTLRInputStream input = new ANTLRInputStream(is);
         cqlLexer lexer = new cqlLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -34,6 +27,19 @@ public class Main {
         ParserRuleContext tree = parser.library();
         CqlFormatterVisitor formatter = new CqlFormatterVisitor();
         String output = (String)formatter.visit(tree);
-        System.out.print(listener.refineOutput(output));
+        return listener.refineOutput(output);
+    }
+
+    public static void main(String[] args) throws IOException {
+        String inputFile = null;
+        if (args.length > 0) {
+            inputFile = args[0];
+        }
+        InputStream is = System.in;
+        if (inputFile != null) {
+            is = new FileInputStream(inputFile);
+        }
+
+        System.out.print(getFormattedOutput(is));
     }
 }

--- a/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
+++ b/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
@@ -1,0 +1,124 @@
+package org.cqframework.cql.tools.formatter;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.cqframework.cql.cql2elm.Cql2ElmVisitor;
+import org.cqframework.cql.gen.cqlLexer;
+import org.cqframework.cql.gen.cqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Christopher on 7/20/2017.
+ */
+public class CqlFormatterVisitorTest {
+
+    private void runTest(String fileName) throws IOException {
+        String input = getInputStreamAsString(getInput(fileName));
+        String output = format(getInput(fileName));
+        Assert.assertTrue(inputMatchesOutput(input, output));
+    }
+
+    @Test
+    public void TestFormatterSpecific() throws IOException {
+        runTest("invalid-syntax.cql");
+    }
+
+    @Test
+    public void RunCql2ElmRegressionTestSuite() throws IOException {
+        runTest("CMS146v2_Test_CQM.cql");
+        runTest("CodeAndConceptTest.cql");
+        runTest("DateTimeLiteralTest.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("EscapeSequenceTests.cql");
+        // runTest("InTest.cql");
+        runTest("ParameterTest.cql");
+        runTest("PropertyTest.cql");
+        runTest("SignatureResolutionTest.cql");
+        runTest("TranslationTests.cql");
+        runTest("LibraryTests/BaseLibrary.cql");
+        runTest("LibraryTests/DuplicateExpressionLibrary.cql");
+        runTest("LibraryTests/FHIRHelpers-1.8.cql");
+        runTest("LibraryTests/InvalidLibraryReference.cql");
+        runTest("LibraryTests/InvalidReferencingLibrary.cql");
+        runTest("LibraryTests/MissingLibrary.cql");
+        runTest("LibraryTests/ReferencingLibrary.cql");
+        runTest("ModelTests/ModelTest.cql");
+        runTest("OperatorTests/AggregateOperators.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/ArithmeticOperators.cql");
+        runTest("OperatorTests/ComparisonOperators.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/CqlComparisonOperators.cql");
+        // runTest("OperatorTests/CqlIntervalOperators.cql");
+        // runTest("OperatorTests/CqlListOperators.cql");
+        runTest("OperatorTests/DateTimeOperators.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/ForwardReferences.cql");
+        runTest("OperatorTests/Functions.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/ImplicitConversions.cql");
+        // runTest("OperatorTests/IntervalOperatorPhrases.cql");
+        runTest("OperatorTests/IntervalOperators.cql");
+        runTest("OperatorTests/InvalidCastExpression.cql");
+        runTest("OperatorTests/InvalidSortClauses.cql");
+        runTest("OperatorTests/ListOperators.cql");
+        runTest("OperatorTests/LogicalOperators.cql");
+        runTest("OperatorTests/MessageOperators.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/MultiSourceQuery.cql");
+        // runTest("OperatorTests/NameHiding.cql");
+        runTest("OperatorTests/NullologicalOperators.cql");
+        runTest("OperatorTests/RecursiveFunctions.cql");
+        runTest("OperatorTests/Sorting.cql");
+        runTest("OperatorTests/StringOperators.cql");
+        runTest("OperatorTests/TimeOperators.cql");
+        runTest("OperatorTests/TupleAndClassConversions.cql");
+        // TODO: uncomment once comments aren't stripped
+        // runTest("OperatorTests/TypeOperators.cql");
+        // runTest("OperatorTests/UndeclaredForward.cql");
+        // runTest("OperatorTests/UndeclaredSignature.cql");
+        // runTest("PathTests/PathTests.cql");
+    }
+
+    private String format(InputStream is) throws IOException {
+        ANTLRInputStream input = new ANTLRInputStream(is);
+        cqlLexer lexer = new cqlLexer(input);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        tokens.fill();
+        cqlParser parser = new cqlParser(tokens);
+        parser.setBuildParseTree(true);
+        ParserRuleContext tree = parser.library();
+        CqlFormatterVisitor formatter = new CqlFormatterVisitor();
+        return (String)formatter.visit(tree);
+    }
+
+    private boolean inputMatchesOutput(String input, String output) {
+        return input.replaceAll("\\s", "").equals(output.replaceAll("\\s", ""));
+    }
+
+    private InputStream getInput(String fileName) {
+        InputStream is = Cql2ElmVisitor.class.getResourceAsStream(fileName);
+
+        if (is == null) {
+            is = CqlFormatterVisitorTest.class.getResourceAsStream(fileName);
+
+            if (is == null) {
+                throw new IllegalArgumentException(String.format("Invalid test resource: %s not in %s or %s", fileName, Cql2ElmVisitor.class.getSimpleName(), CqlFormatterVisitor.class.getSimpleName()));
+            }
+        }
+
+        return is;
+    }
+
+    private String getInputStreamAsString(InputStream is) {
+        return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
+    }
+}

--- a/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
+++ b/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
@@ -28,6 +28,7 @@ public class CqlFormatterVisitorTest {
 
     @Test
     public void TestFormatterSpecific() throws IOException {
+        runTest("comments.cql");
         runTest("invalid-syntax.cql");
     }
 
@@ -36,9 +37,8 @@ public class CqlFormatterVisitorTest {
         runTest("CMS146v2_Test_CQM.cql");
         runTest("CodeAndConceptTest.cql");
         runTest("DateTimeLiteralTest.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("EscapeSequenceTests.cql");
-        // runTest("InTest.cql");
+        runTest("EscapeSequenceTests.cql");
+        runTest("InTest.cql");
         runTest("ParameterTest.cql");
         runTest("PropertyTest.cql");
         runTest("SignatureResolutionTest.cql");
@@ -52,40 +52,34 @@ public class CqlFormatterVisitorTest {
         runTest("LibraryTests/ReferencingLibrary.cql");
         runTest("ModelTests/ModelTest.cql");
         runTest("OperatorTests/AggregateOperators.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/ArithmeticOperators.cql");
+        runTest("OperatorTests/ArithmeticOperators.cql");
         runTest("OperatorTests/ComparisonOperators.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/CqlComparisonOperators.cql");
-        // runTest("OperatorTests/CqlIntervalOperators.cql");
-        // runTest("OperatorTests/CqlListOperators.cql");
+        runTest("OperatorTests/CqlComparisonOperators.cql");
+        runTest("OperatorTests/CqlIntervalOperators.cql");
+        runTest("OperatorTests/CqlListOperators.cql");
         runTest("OperatorTests/DateTimeOperators.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/ForwardReferences.cql");
+        runTest("OperatorTests/ForwardReferences.cql");
         runTest("OperatorTests/Functions.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/ImplicitConversions.cql");
-        // runTest("OperatorTests/IntervalOperatorPhrases.cql");
+        runTest("OperatorTests/ImplicitConversions.cql");
+        runTest("OperatorTests/IntervalOperatorPhrases.cql");
         runTest("OperatorTests/IntervalOperators.cql");
         runTest("OperatorTests/InvalidCastExpression.cql");
         runTest("OperatorTests/InvalidSortClauses.cql");
         runTest("OperatorTests/ListOperators.cql");
         runTest("OperatorTests/LogicalOperators.cql");
         runTest("OperatorTests/MessageOperators.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/MultiSourceQuery.cql");
-        // runTest("OperatorTests/NameHiding.cql");
+        runTest("OperatorTests/MultiSourceQuery.cql");
+        runTest("OperatorTests/NameHiding.cql");
         runTest("OperatorTests/NullologicalOperators.cql");
         runTest("OperatorTests/RecursiveFunctions.cql");
         runTest("OperatorTests/Sorting.cql");
         runTest("OperatorTests/StringOperators.cql");
         runTest("OperatorTests/TimeOperators.cql");
         runTest("OperatorTests/TupleAndClassConversions.cql");
-        // TODO: uncomment once comments aren't stripped
-        // runTest("OperatorTests/TypeOperators.cql");
-        // runTest("OperatorTests/UndeclaredForward.cql");
-        // runTest("OperatorTests/UndeclaredSignature.cql");
-        // runTest("PathTests/PathTests.cql");
+        runTest("OperatorTests/TypeOperators.cql");
+        runTest("OperatorTests/UndeclaredForward.cql");
+        runTest("OperatorTests/UndeclaredSignature.cql");
+        runTest("PathTests/PathTests.cql");
     }
 
     private String format(InputStream is) throws IOException {
@@ -94,6 +88,8 @@ public class CqlFormatterVisitorTest {
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         tokens.fill();
         cqlParser parser = new cqlParser(tokens);
+        CommentListener listener = new CommentListener(tokens);
+        parser.addParseListener(listener);
         parser.setBuildParseTree(true);
         ParserRuleContext tree = parser.library();
         CqlFormatterVisitor formatter = new CqlFormatterVisitor();

--- a/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
+++ b/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
@@ -87,13 +87,14 @@ public class CqlFormatterVisitorTest {
         cqlLexer lexer = new cqlLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         tokens.fill();
-        cqlParser parser = new cqlParser(tokens);
         CommentListener listener = new CommentListener(tokens);
-        parser.addParseListener(listener);
+        listener.rewriteTokens();
+        cqlParser parser = new cqlParser(listener.tokens);
         parser.setBuildParseTree(true);
         ParserRuleContext tree = parser.library();
         CqlFormatterVisitor formatter = new CqlFormatterVisitor();
-        return (String)formatter.visit(tree);
+        String output = (String)formatter.visit(tree);
+        return listener.refineOutput(output);
     }
 
     private boolean inputMatchesOutput(String input, String output) {

--- a/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
+++ b/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
@@ -1,11 +1,6 @@
 package org.cqframework.cql.tools.formatter;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
 import org.cqframework.cql.cql2elm.Cql2ElmVisitor;
-import org.cqframework.cql.gen.cqlLexer;
-import org.cqframework.cql.gen.cqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -22,7 +17,7 @@ public class CqlFormatterVisitorTest {
 
     private void runTest(String fileName) throws IOException {
         String input = getInputStreamAsString(getInput(fileName));
-        String output = format(getInput(fileName));
+        String output = Main.getFormattedOutput(getInput(fileName));
         Assert.assertTrue(inputMatchesOutput(input, output));
     }
 
@@ -80,21 +75,6 @@ public class CqlFormatterVisitorTest {
         runTest("OperatorTests/UndeclaredForward.cql");
         runTest("OperatorTests/UndeclaredSignature.cql");
         runTest("PathTests/PathTests.cql");
-    }
-
-    private String format(InputStream is) throws IOException {
-        ANTLRInputStream input = new ANTLRInputStream(is);
-        cqlLexer lexer = new cqlLexer(input);
-        CommonTokenStream tokens = new CommonTokenStream(lexer);
-        tokens.fill();
-        CommentListener listener = new CommentListener(tokens);
-        listener.rewriteTokens();
-        cqlParser parser = new cqlParser(listener.tokens);
-        parser.setBuildParseTree(true);
-        ParserRuleContext tree = parser.library();
-        CqlFormatterVisitor formatter = new CqlFormatterVisitor();
-        String output = (String)formatter.visit(tree);
-        return listener.refineOutput(output);
     }
 
     private boolean inputMatchesOutput(String input, String output) {

--- a/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/comments.cql
+++ b/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/comments.cql
@@ -1,23 +1,88 @@
-// Single-line comment
-// Nested // Single // Line comments
-// Single-line
-/*Multi-line one one line*/
+library ExistsIssue
+
+using QDM version '5.0.2'
+
+// NOTE: Simplified measure definition for illustration purposes only
+
+valueset "Prostate Cancer": 'urn:oid:2.16.840.1.113883.3.526.3.319'
+valueset "Patient Reason Refused": 'urn:oid:2.16.840.1.113883.3.600.1.1503'
+valueset "Androgen deprivation therapy for Urology Care": 'urn:oid:2.16.840.1.113762.1.4.1151.48'
+valueset "Male": 'urn:oid:2.16.840.1.113883.3.560.100.1'
+valueset "Injection Leuprolide Acetate": 'urn:oid:2.16.840.1.113762.1.4.1151.16'
+valueset "Office Visit": 'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1001'
+
+parameter "Measurement Period" Interval<DateTime>
+
+context Patient
+
+define "Office Visit Encounter":
+  ["Encounter, Performed": "Office Visit"] Encounter
+    where Encounter.relevantPeriod during "Measurement Period"
+
+define "Male Patient":
+  ["Patient Characteristic": "Male"]
+
+// NOTE: The latest version of the MAT includes support for CQL 1.2, so this comparison:
+//define "Prostate Cancer Diagnosis":
+//  ["Diagnosis": "Prostate Cancer"] ProstateCancerDx
+//    where ProstateCancerDx.prevalencePeriod starts before end "Measurement Period"
+//      or ProstateCancerDx.prevalencePeriod starts same as end "Measurement Period"
+
+// Can now be expressed using the "on or before" syntax:
+define "Prostate Cancer Diagnosis":
+  ["Diagnosis": "Prostate Cancer"] ProstateCancerDx
+    where ProstateCancerDx.prevalencePeriod starts on or before end "Measurement Period"
+
+define "Active Medications for Androgen deprivation therapy for Urology Care":
+  ["Medication, Active": "Androgen deprivation therapy for Urology Care"] ADT
+    with "Prostate Cancer Diagnosis" ProstateCancerDx // comments within a clause
+      such that /* multi-line within a line */ ADT.relevantPeriod starts on or after start ProstateCancerDx.prevalencePeriod
+    with ["Procedure, Order": "Injection Leuprolide Acetate"] ADTOrder /* multi-line comments
+        within a clause */ // followed by a comment
+      such that ADT.relevantPeriod includes ADTOrder.authorDatetime
+
+// NOTE: The latest version of the MAT now correctly identifies some invalid syntax that was previously missed
+// by the translator. Specifically, the use of alias references in a sort by clause.
+
+// sort by start of ADT.relevantPeriod
+
+// To fix the issue, remove the alias reference from the sort:
+
+// sort by start of relevantPeriod
+
+define "Androgen Deprivation Therapy":
+  {
+    First("Active Medications for Androgen deprivation therapy for Urology Care" ADT
+        sort by start of relevantPeriod
+    )
+  }
+
+define "Initial Population":
+  exists "Androgen Deprivation Therapy"
+    and exists "Male Patient"
+    and exists "Office Visit Encounter"
+
+// NOTE: The above approach uses list syntax ({ }) to allow the "Androgen Deprivation Therapy"
+// to be used with an "exists". However, in the case that there is no "First" result, the behavior
+// of exists is unintuitive (but correct according to the CQL specification):
+
+define Result: exists ({ null })
+
+// This is because from the perspective of the "exists", the list has a single element
+// of null, and the exists is evaluated as "if the list has any elements, return true"
+// This behavior is unintuitive and we are submitting a comment to CQL to discuss it
+// further with the community. However, it can be addressed by changing to a "null test"
+// rather than using an "exists":
+
 /*
-    Nice Multi-line
+define "Androgen Deprivation Therapy":
+  First("Active Medications for Androgen deprivation therapy for Urology Care" ADT
+      sort by start of relevantPeriod
+  )
+
+define "Initial Population":
+  "Androgen Deprivation Therapy" is not null
+    and exists "Male Patient"
+    and exists "Office Visit Encounter"
 */
-/*
-Not so nice Multi-line*/
-define test1:
-exists "A thing" /* Another not so good
 
-        Location        Multi-line comment
-        */
-// single line
-
-
-
-define "test 2":
-// comment
-[Condition] C
-where C.onset is not null
-and C.clinicalStatus = 'active'

--- a/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/comments.cql
+++ b/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/comments.cql
@@ -1,0 +1,23 @@
+// Single-line comment
+// Nested // Single // Line comments
+// Single-line
+/*Multi-line one one line*/
+/*
+    Nice Multi-line
+*/
+/*
+Not so nice Multi-line*/
+define test1:
+exists "A thing" /* Another not so good
+
+        Location        Multi-line comment
+        */
+// single line
+
+
+
+define "test 2":
+// comment
+[Condition] C
+where C.onset is not null
+and C.clinicalStatus = 'active'

--- a/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/invalid-syntax.cql
+++ b/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/invalid-syntax.cql
@@ -1,0 +1,11 @@
+library test version '0.0.000'
+
+using QDM
+
+notvalueset "Female Administrative Sex": '2.16.840.1.113883.3.560.100.2'
+valueset "TestValueset": '1.1.111'
+
+context Patient
+
+define "TestDefinition":
+	["Encounter, Performed": "TestValueset "]


### PR DESCRIPTION
This pull request addresses the following issues with the CqlFormatter:
[#191](https://github.com/cqframework/clinical_quality_language/issues/191) - Stripping comments
[#163](https://github.com/cqframework/clinical_quality_language/issues/163) - Spacing and cleaner Tuple output
[#174](https://github.com/cqframework/clinical_quality_language/issues/174) - Deletion of code with syntax errors
[#181](https://github.com/cqframework/clinical_quality_language/issues/181) - Unit testing