### PR TITLE
Cql4bonnie param fix

### DIFF
--- a/Src/coffeescript/cql-execution/src/cql-code-service.coffee
+++ b/Src/coffeescript/cql-execution/src/cql-code-service.coffee
@@ -15,9 +15,9 @@ class CodeService
   findValueSet: (oid, version) ->
     oid = oid.replace "urn:oid:", ""
     if version?
-      result = @valueSets[oid]?[version]
-      return result if result
-    results = @findValueSetsByOid(oid)
-    if results.length is 0 then null else results.reduce (a, b) -> if a.version > b.version then a else b
+      @valueSets[oid]?[version]
+    else
+      results = @findValueSetsByOid(oid)
+      if results.length is 0 then null else results.reduce (a, b) -> if a.version > b.version then a else b
 
 module.exports.CodeService = CodeService

--- a/Src/coffeescript/cql-execution/src/cql-code-service.coffee
+++ b/Src/coffeescript/cql-execution/src/cql-code-service.coffee
@@ -13,7 +13,6 @@ class CodeService
     (valueSet for version, valueSet of @valueSets[oid])
 
   findValueSet: (oid, version) ->
-    oid = oid.replace "urn:oid:", ""
     if version?
       @valueSets[oid]?[version]
     else

--- a/Src/coffeescript/cql-execution/src/elm/parameters.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/parameters.coffee
@@ -16,6 +16,8 @@ module.exports.ParameterRef = class ParameterRef extends Expression
   constructor: (json) ->
     super
     @name = json.name
+    @library = json.libraryName
 
   exec: (ctx) ->
+    ctx = if @library then ctx.getLibraryContext(@library) else ctx
     ctx.getParameter(@name)?.execute(ctx)

--- a/Src/coffeescript/cql-execution/src/elm/parameters.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/parameters.coffee
@@ -9,8 +9,15 @@ module.exports.ParameterDef = class ParameterDef extends Expression
     @parameterTypeSpecifier = json.parameterTypeSpecifier
 
   exec: (ctx) ->
-    if (ctx?.parameters[@name]?) then ctx.parameters[@name]
-    else @default?.execute(ctx)
+    # If context parameters contains the name, return value.
+    if (ctx?.parameters[@name]?)
+      ctx.parameters[@name]
+    # If default type exists, execute the default type
+    else if @default?
+      @default?.execute(ctx)
+    # Else, if context and context's parent exist return the value of the parent's parameters with the given name.
+    else
+      ctx?.parent?.parameters[@name]
 
 module.exports.ParameterRef = class ParameterRef extends Expression
   constructor: (json) ->

--- a/Src/coffeescript/cql-execution/src/elm/parameters.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/parameters.coffee
@@ -17,7 +17,7 @@ module.exports.ParameterDef = class ParameterDef extends Expression
       @default?.execute(ctx)
     # Else, if context and context's parent exist return the value of the parent's parameters with the given name.
     else
-      ctx?.parent?.parameters[@name]
+      ctx.getParentParameter @name
 
 module.exports.ParameterRef = class ParameterRef extends Expression
   constructor: (json) ->

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -5277,10 +5277,12 @@
     function ParameterRef(json) {
       ParameterRef.__super__.constructor.apply(this, arguments);
       this.name = json.name;
+      this.library = json.libraryName;
     }
 
     ParameterRef.prototype.exec = function(ctx) {
       var ref;
+      ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
       return (ref = ctx.getParameter(this.name)) != null ? ref.execute(ctx) : void 0;
     };
 
@@ -42958,15 +42960,8 @@
 
     Context.property("parameters", {
       get: function() {
-        var k, p, ref, v;
-        p = (ref = this.parent) != null ? ref.parameters : void 0;
-        for (k in p) {
-          v = p[k];
-          if (!(k in this._parameters)) {
-            this._parameters[k] = v;
-          }
-        }
-        return this._parameters;
+        var ref;
+        return this._parameters || ((ref = this.parent) != null ? ref.parameters : void 0);
       },
       set: function(params) {
         this.checkParameters(params);

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -42,25 +42,22 @@
     };
 
     CodeService.prototype.findValueSet = function(oid, version) {
-      var ref1, result, results;
-      oid = oid.replace("urn:oid:", "");
+      var ref1, results;
       if (version != null) {
-        result = (ref1 = this.valueSets[oid]) != null ? ref1[version] : void 0;
-        if (result) {
-          return result;
-        }
-      }
-      results = this.findValueSetsByOid(oid);
-      if (results.length === 0) {
-        return null;
+        return (ref1 = this.valueSets[oid]) != null ? ref1[version] : void 0;
       } else {
-        return results.reduce(function(a, b) {
-          if (a.version > b.version) {
-            return a;
-          } else {
-            return b;
-          }
-        });
+        results = this.findValueSetsByOid(oid);
+        if (results.length === 0) {
+          return null;
+        } else {
+          return results.reduce(function(a, b) {
+            if (a.version > b.version) {
+              return a;
+            } else {
+              return b;
+            }
+          });
+        }
       }
     };
 
@@ -5262,8 +5259,10 @@
       var ref;
       if (((ctx != null ? ctx.parameters[this.name] : void 0) != null)) {
         return ctx.parameters[this.name];
-      } else {
+      } else if (this["default"] != null) {
         return (ref = this["default"]) != null ? ref.execute(ctx) : void 0;
+      } else {
+        return ctx.getParentParameter(this.name);
       }
     };
 
@@ -43025,6 +43024,15 @@
     Context.prototype.getParameter = function(name) {
       var ref;
       return (ref = this.parent) != null ? ref.getParameter(name) : void 0;
+    };
+
+    Context.prototype.getParentParameter = function(name) {
+      var ref;
+      if (((ref = this.parent) != null ? ref.parameters[name] : void 0) != null) {
+        return this.parent.parameters[name];
+      } else if (this.parent != null) {
+        return this.parent.getParentParameter(name);
+      }
     };
 
     Context.prototype.getValueSet = function(name) {

--- a/Src/coffeescript/cql-execution/src/runtime/context.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/context.coffee
@@ -16,14 +16,9 @@ module.exports.Context = class Context
     @_parameters = _parameters
 
   @property "parameters" ,
-    get: -> 
-      p = @parent?.parameters
-      for k, v of p
-        # If key (of parent) is not found in current parameters, add it 
-        if !(k of @_parameters)
-          @_parameters[k] = v
-      @_parameters
-    
+    get: ->
+      @_parameters || @parent?.parameters
+
     set: (params) ->
       @checkParameters(params)
       @_parameters = params
@@ -199,7 +194,7 @@ module.exports.PatientContext = class PatientContext extends Context
 
   getLibraryContext: (library) ->
     @library_context[library] ||= new PatientContext(@get(library),@patient,@codeService,@parameters)
-    
+
   getLocalIdContext: (localId) ->
     @localId_context[localId] ||= new PatientContext(@get(library),@patient,@codeService,@parameters)
 

--- a/Src/coffeescript/cql-execution/src/runtime/context.coffee
+++ b/Src/coffeescript/cql-execution/src/runtime/context.coffee
@@ -56,6 +56,12 @@ module.exports.Context = class Context
   getParameter: (name) ->
     @parent?.getParameter(name)
 
+  getParentParameter: (name) ->
+    if @parent?.parameters[name]?
+      @parent.parameters[name]
+    else if @parent?
+      @parent.getParentParameter name
+
   getValueSet: (name) ->
     @parent?.getValueSet(name)
 

--- a/Src/coffeescript/cql-execution/test/elm/clinical/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/clinical/test.coffee
@@ -171,7 +171,7 @@ describe 'CalculateAge', ->
   it 'should execute age in months', ->
     # what is returned will depend on whether the day in the current month has
     # made it to the 17th day of the month as declared in the birthday
-    [@full_months, @full_months-1].indexOf(@months.exec(@ctx)).should.not.equal -1
+    [@full_months, @full_months+1].indexOf(@months.exec(@ctx)).should.not.equal -1
 
   # Skipping because cql-to-elm in this branch does not properly translate AgeInWeeks
   it.skip 'should execute age in weeks', ->

--- a/Src/coffeescript/cql-execution/test/elm/library/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.coffee
@@ -793,6 +793,7 @@ include Common2 called common2
 context Patient
 
 define ExprUsesParam: common2.TheParameter
+define ExprUsesParamDirectly: common2.SomeNumber
 define FuncUsesParam: common2.addToParameter(5)
 define ExprCallsFunc: common2.TwoTimesThree
 define FuncCallsFunc: common2.square(5)
@@ -846,6 +847,15 @@ module.exports['Using CommonLib2'] = {
                "name" : "TheParameter",
                "libraryName" : "common2",
                "type" : "ExpressionRef"
+            }
+         }, {
+            "name" : "ExprUsesParamDirectly",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "SomeNumber",
+               "libraryName" : "common2",
+               "type" : "ParameterRef"
             }
          }, {
             "name" : "FuncUsesParam",

--- a/Src/coffeescript/cql-execution/test/elm/library/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/library/data.cql
@@ -73,6 +73,7 @@ include Common2 called common2
 context Patient
 
 define ExprUsesParam: common2.TheParameter
+define ExprUsesParamDirectly: common2.SomeNumber
 define FuncUsesParam: common2.addToParameter(5)
 define ExprCallsFunc: common2.TwoTimesThree
 define FuncCallsFunc: common2.square(5)

--- a/Src/coffeescript/cql-execution/test/elm/library/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/library/test.coffee
@@ -43,6 +43,15 @@ describe 'Using CommonLib2', ->
   it "should execute expression from included library that uses parameter", ->
     @exprUsesParam.exec(@ctx).should.equal 17
 
+  it "should execute expression from included library that uses sent-in parameter", ->
+    @exprUsesParam.exec(@ctx.withParameters({SomeNumber: 42})).should.equal 42
+
+  it "should execute parameter from included library", ->
+    @exprUsesParamDirectly.exec(@ctx).should.equal 17
+
+  it "should execute sent-in parameter from included library", ->
+    @exprUsesParamDirectly.exec(@ctx.withParameters({SomeNumber: 73})).should.equal 73
+
   it "should execute function from included library that uses parameter", ->
     @funcUsesParam.exec(@ctx).should.equal 22
 

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
@@ -1256,3 +1256,111 @@ module.exports['DefaultAndNoDefault'] = {
    }
 }
 
+### MeasurementPeriodParameter
+library TestSnippet version '1'
+using QUICK
+parameter "Measurement Period" Interval<DateTime>
+context Patient
+define MeasurementPeriod: Interval[DateTime(2011, 1, 1), DateTime(2013, 1, 1)] overlaps "Measurement Period"
+###
+
+module.exports['MeasurementPeriodParameter'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "name" : "Measurement Period",
+            "accessLevel" : "Public",
+            "parameterTypeSpecifier" : {
+               "type" : "IntervalTypeSpecifier",
+               "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "MeasurementPeriod",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Overlaps",
+               "operand" : [ {
+                  "lowClosed" : true,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "low" : {
+                     "type" : "DateTime",
+                     "year" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "2011",
+                        "type" : "Literal"
+                     },
+                     "month" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     },
+                     "day" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     }
+                  },
+                  "high" : {
+                     "type" : "DateTime",
+                     "year" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "2013",
+                        "type" : "Literal"
+                     },
+                     "month" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     },
+                     "day" : {
+                        "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                        "value" : "1",
+                        "type" : "Literal"
+                     }
+                  }
+               }, {
+                  "name" : "Measurement Period",
+                  "type" : "ParameterRef"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.coffee
@@ -1176,3 +1176,83 @@ module.exports['TupleParameterTypes'] = {
    }
 }
 
+### DefaultAndNoDefault
+library TestSnippet version '1'
+using QUICK
+parameter FooWithNoDefault Integer
+parameter FooWithDefault default 5
+context Patient
+define Foo: FooWithNoDefault
+define Foo2: FooWithDefault
+###
+
+module.exports['DefaultAndNoDefault'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "name" : "FooWithNoDefault",
+            "accessLevel" : "Public",
+            "parameterTypeSpecifier" : {
+               "name" : "{urn:hl7-org:elm-types:r1}Integer",
+               "type" : "NamedTypeSpecifier"
+            }
+         }, {
+            "name" : "FooWithDefault",
+            "accessLevel" : "Public",
+            "default" : {
+               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "value" : "5",
+               "type" : "Literal"
+            }
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "Foo",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "FooWithNoDefault",
+               "type" : "ParameterRef"
+            }
+         }, {
+            "name" : "Foo2",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "name" : "FooWithDefault",
+               "type" : "ParameterRef"
+            }
+         } ]
+      }
+   }
+}
+

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
@@ -81,3 +81,7 @@ parameter FooWithNoDefault Integer
 parameter FooWithDefault default 5
 define Foo: FooWithNoDefault
 define Foo2: FooWithDefault
+
+// @Test: MeasurementPeriodParameter
+parameter "Measurement Period" Interval<DateTime>
+define MeasurementPeriod: Interval[DateTime(2011, 1, 1), DateTime(2013, 1, 1)] overlaps "Measurement Period"

--- a/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/data.cql
@@ -75,3 +75,9 @@ parameter FooP Tuple { Hello String, MeaningOfLife Integer }
 parameter FooDP default Tuple { Hello: 'Universe', MeaningOfLife: 24 }
 define Foo: FooP
 define Foo2: FooDP
+
+// @Test: DefaultAndNoDefault
+parameter FooWithNoDefault Integer
+parameter FooWithDefault default 5
+define Foo: FooWithNoDefault
+define Foo2: FooWithDefault

--- a/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
@@ -301,3 +301,11 @@ describe 'TupleParameterTypes', ->
 
   it 'should throw when overriding tuple contains a wrong property type', ->
     should(() => @foo2.exec(@ctx.withParameters { FooP: { Hello: "World", MeaningOfLife: "Forty-Two" } })).throw(/.*wrong type.*/)
+
+describe 'DefaultAndNoDefault', ->
+  @beforeEach ->
+    setup @, data
+
+  it 'should be able to retrieve a provided value and a default value', ->
+    @foo.exec(@ctx.withParameters { FooWithNoDefault: 1 }).should.eql 1
+    @foo2.exec(@ctx.withParameters { FooWithNoDefault: 1 }).should.eql 5

--- a/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
@@ -314,7 +314,14 @@ describe 'MeasurementPeriodParameter', ->
   @beforeEach ->
     setup @, data
 
-  it "should execute expression from library that uses passed in measurement period in a child context", ->
+  it 'should execute expression with a passed in measurement period in a child context', ->
     @ctx = @ctx.withParameters({"Measurement Period": new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2013, 1, 1, 0, 0, 0, 0))})
     rctx = @ctx.childContext()
     @measurementPeriod.exec(rctx).should.equal true
+
+  it 'should execute expression with a passed in measurement period in a child context', ->
+    @ctx = @ctx.withParameters({"Measurement Period": new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2013, 1, 1, 0, 0, 0, 0))})
+    r1ctx = @ctx.childContext()
+    r2ctx = r1ctx.childContext()
+    r3ctx = r2ctx.childContext()
+    @measurementPeriod.exec(r3ctx).should.equal true

--- a/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/parameters/test.coffee
@@ -309,3 +309,12 @@ describe 'DefaultAndNoDefault', ->
   it 'should be able to retrieve a provided value and a default value', ->
     @foo.exec(@ctx.withParameters { FooWithNoDefault: 1 }).should.eql 1
     @foo2.exec(@ctx.withParameters { FooWithNoDefault: 1 }).should.eql 5
+
+describe 'MeasurementPeriodParameter', ->
+  @beforeEach ->
+    setup @, data
+
+  it "should execute expression from library that uses passed in measurement period in a child context", ->
+    @ctx = @ctx.withParameters({"Measurement Period": new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2013, 1, 1, 0, 0, 0, 0))})
+    rctx = @ctx.childContext()
+    @measurementPeriod.exec(rctx).should.equal true


### PR DESCRIPTION
Chris added code to ParameterRef in support of libraries. Added fix for parameters in children contexts. Reverted findValueSet code back to original state. All but one CalculateAge unit test pass now. CalculateAge unit test passes sometimes (Moesel can explain in more detail why that happens).