### PR TITLE
Refactored formatter to return a FormatResult structure

### DIFF
--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
@@ -1381,7 +1381,7 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
         }
     }
 
-    static class FormatResult {
+    public static class FormatResult {
         List<Exception> errors;
         String output;
 

--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
@@ -22,7 +22,7 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
 
     private static List<CommentToken> comments = new ArrayList<>();
 
-    public static String getFormattedOutput(InputStream is) throws IOException {
+    public static FormatResult getFormattedOutput(InputStream is) throws IOException {
         ANTLRInputStream in = new ANTLRInputStream(is);
         cqlLexer lexer = new cqlLexer(in);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
@@ -34,8 +34,7 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
         ParserRuleContext tree = parser.library();
 
         if (((SyntaxErrorListener) parser.getErrorListeners().get(1)).errors.size() > 0) {
-            return ((SyntaxErrorListener) parser.getErrorListeners().get(1)).errors.toString()
-                    + "\r\n\r\n" + in.toString();
+            return new FormatResult(((SyntaxErrorListener) parser.getErrorListeners().get(1)).errors, in.toString());
         }
 
         CqlFormatterVisitor formatter = new CqlFormatterVisitor();
@@ -50,7 +49,7 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
             output += eofComments.toString();
         }
 
-        return output;
+        return new FormatResult(new ArrayList<>(), output);
     }
 
     public static String getInputStreamAsString(InputStream is) {
@@ -1366,7 +1365,7 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
         }
     }
 
-   private static class SyntaxErrorListener extends BaseErrorListener {
+    private static class SyntaxErrorListener extends BaseErrorListener {
 
         private List<Exception> errors = new ArrayList<>();
 
@@ -1379,6 +1378,16 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
             if (!((Token) offendingSymbol).getText().trim().isEmpty()) {
                 errors.add(new Exception(String.format("[%d:%d]: %s", line, charPositionInLine, msg)));
             }
+        }
+    }
+
+    static class FormatResult {
+        List<Exception> errors;
+        String output;
+
+        public FormatResult(List<Exception> errors, String output) {
+            this.errors = errors;
+            this.output = output;
         }
     }
 }

--- a/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
+++ b/Src/java/tools/cql-formatter/src/test/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitorTest.java
@@ -4,21 +4,23 @@ import org.cqframework.cql.cql2elm.Cql2ElmVisitor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.stream.Collectors;
+
+import static org.cqframework.cql.tools.formatter.CqlFormatterVisitor.*;
 
 /**
  * Created by Christopher on 7/20/2017.
  */
 public class CqlFormatterVisitorTest {
 
+    boolean inError = false;
+
     private void runTest(String fileName) throws IOException {
-        String input = CqlFormatterVisitor.getInputStreamAsString(getInput(fileName));
-        String output = CqlFormatterVisitor.getFormattedOutput(getInput(fileName));
-        Assert.assertTrue(inputMatchesOutput(input, output));
+        String input = getInputStreamAsString(getInput(fileName));
+        FormatResult result = getFormattedOutput(getInput(fileName));
+        inError = result.errors.size() > 0 ? true : false;
+        Assert.assertTrue(inputMatchesOutput(input, result.output));
     }
 
     @Test
@@ -28,26 +30,34 @@ public class CqlFormatterVisitorTest {
             // this test has an extra "`", which is ignored - causing the input to differ from the output.
             runTest("git-issue-206-a.cql");
         } catch (AssertionError ae) {
-            // pass
+            Assert.assertFalse(inError);
         }
         try {
             // this test has an extra """, which is not ignored - causing a syntax error.
             runTest("git-issue-206-b.cql");
         } catch (AssertionError ae) {
-            // pass
+            Assert.assertTrue(inError);
         }
         runTest("git-issue-210-a.cql");
+        Assert.assertFalse(inError);
         runTest("git-issue-210-b.cql");
+        Assert.assertFalse(inError);
         runTest("git-issue-210-c.cql");
+        Assert.assertFalse(inError);
         runTest("comment-after.cql");
+        Assert.assertFalse(inError);
         runTest("comment-before.cql");
+        Assert.assertFalse(inError);
         runTest("comment-first.cql");
+        Assert.assertFalse(inError);
         runTest("comment-in-clause.cql");
+        Assert.assertFalse(inError);
         runTest("comment-last.cql");
+        Assert.assertFalse(inError);
         try {
             runTest("invalid-syntax.cql");
         } catch (AssertionError ae) {
-            // pass
+            Assert.assertTrue(inError);
         }
     }
 

--- a/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/invalid-syntax.cql
+++ b/Src/java/tools/cql-formatter/src/test/resources/org/cqframework/cql/tools/formatter/invalid-syntax.cql
@@ -2,8 +2,10 @@ library test version '0.0.000'
 
 using QDM
 
-notvalueset "Female Administrative Sex": '2.16.840.1.113883.3.560.100.2'
+valueset "Female Administrative Sex": '2.16.840.1.113883.3.560.100.2'
 valueset "TestValueset": '1.1.111'
+
+parameter "test param" Interval<DateTime
 
 context Patient
 


### PR DESCRIPTION
This is a resolution for issue [#220](https://github.com/cqframework/clinical_quality_language/issues/220)

The formatter will now return a structure:
FormatResult(Errors[], output)

When syntax errors are encountered within the CQL, the Error[] will be populated and the original input will be returned as the output. When syntax errors aren't encountered, the Error[] will be empty and the formatted output will be returned.

Example usage:
```
FormatResult result = getFormattedOutput(cql);
// access errors
result.errors;
// access output
result.output;
```