### PR TITLE
Adding getters for FormatResult class data members

### DIFF
--- a/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
+++ b/Src/java/tools/cql-formatter/src/main/java/org/cqframework/cql/tools/formatter/CqlFormatterVisitor.java
@@ -1389,5 +1389,13 @@ public class CqlFormatterVisitor extends cqlBaseVisitor {
             this.errors = errors;
             this.output = output;
         }
+
+        public List<Exception> getErrors() {
+            return this.errors;
+        }
+
+        public String getOutput() {
+            return this.output;
+        }
     }
 }


### PR DESCRIPTION
Fixed bug - unable to access FormatResult data members. Implemented some getters to do the work.