### PR TITLE
fix null check for equivalency

### DIFF
--- a/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
@@ -32,7 +32,8 @@ module.exports.Equivalent = class Equivalent extends Expression
     [a, b] = @execArgs(ctx)
     if not a? or not b?
       false
-    equivalent(a, b)
+    else
+      equivalent(a, b)
 
 module.exports.NotEqual = class NotEqual extends Expression
   constructor: (json) ->

--- a/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
+++ b/Src/coffeescript/cql-execution/src/elm/overloaded.coffee
@@ -30,7 +30,9 @@ module.exports.Equivalent = class Equivalent extends Expression
 
   exec: (ctx) ->
     [a, b] = @execArgs(ctx)
-    if not a? or not b?
+    if not a? and not b?
+      true
+    else if not a? or not b?
       false
     else
       equivalent(a, b)

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -4849,9 +4849,10 @@
       var a, b, ref1;
       ref1 = this.execArgs(ctx), a = ref1[0], b = ref1[1];
       if ((a == null) || (b == null)) {
-        false;
+        return false;
+      } else {
+        return equivalent(a, b);
       }
-      return equivalent(a, b);
     };
 
     return Equivalent;

--- a/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
+++ b/Src/coffeescript/cql-execution/src/example/browser/cql4browsers.js
@@ -4848,7 +4848,9 @@
     Equivalent.prototype.exec = function(ctx) {
       var a, b, ref1;
       ref1 = this.execArgs(ctx), a = ref1[0], b = ref1[1];
-      if ((a == null) || (b == null)) {
+      if ((a == null) && (b == null)) {
+        return true;
+      } else if ((a == null) || (b == null)) {
         return false;
       } else {
         return equivalent(a, b);

--- a/Src/coffeescript/cql-execution/test/elm/comparison/data.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/comparison/data.coffee
@@ -1670,6 +1670,108 @@ module.exports['NotEqual'] = {
    }
 }
 
+### Equivalent
+library TestSnippet version '1'
+using QUICK
+context Patient
+define ANull_BDefined: null ~ 4
+define ADefined_BNull: 5 ~ null
+define ANull_BNull: null ~ null
+define ADefined_BDefined: 3 ~ 3
+###
+
+module.exports['Equivalent'] = {
+   "library" : {
+      "identifier" : {
+         "id" : "TestSnippet",
+         "version" : "1"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "localIdentifier" : "QUICK",
+            "uri" : "http://hl7.org/fhir"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "patient-qicore-qicore-patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "name" : "ANull_BDefined",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equivalent",
+               "operand" : [ {
+                  "type" : "Null"
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "4",
+                  "type" : "Literal"
+               } ]
+            }
+         }, {
+            "name" : "ADefined_BNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equivalent",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "5",
+                  "type" : "Literal"
+               }, {
+                  "type" : "Null"
+               } ]
+            }
+         }, {
+            "name" : "ANull_BNull",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equivalent",
+               "operand" : [ {
+                  "type" : "Null"
+               }, {
+                  "type" : "Null"
+               } ]
+            }
+         }, {
+            "name" : "ADefined_BDefined",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "type" : "Equivalent",
+               "operand" : [ {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "3",
+                  "type" : "Literal"
+               }, {
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                  "value" : "3",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+
 ### Less
 library TestSnippet version '1'
 using QUICK

--- a/Src/coffeescript/cql-execution/test/elm/comparison/data.cql
+++ b/Src/coffeescript/cql-execution/test/elm/comparison/data.cql
@@ -42,6 +42,12 @@ define AGtB_Quantity_incompatible: 5 'Cel' != 4 'm'
 define AEqB_Quantity_incompatible: 5 'Cel' != 5 'm'
 define ALtB_Quantity_incompatible: 5 'Cel' != 40 'm'
 
+// @Test: Equivalent
+define ANull_BDefined: null ~ 4
+define ADefined_BNull: 5 ~ null
+define ANull_BNull: null ~ null
+define ADefined_BDefined: 3 ~ 3
+
 // @Test: Less
 define AGtB_Int: 5 < 4
 define AEqB_Int: 5 < 5

--- a/Src/coffeescript/cql-execution/test/elm/comparison/test.coffee
+++ b/Src/coffeescript/cql-execution/test/elm/comparison/test.coffee
@@ -116,6 +116,22 @@ describe 'NotEqual', ->
   it 'should be null for 5 Cel != 40 m', ->
     should(@aLtB_Quantity_incompatible.exec(@ctx)).be.null()
 
+describe 'Equivalent', ->
+  @beforeEach ->
+    setup @, data
+
+  it 'should be false for null ~ 4', ->
+    @aNull_BDefined.exec(@ctx).should.be.false()
+
+  it 'should be false for 5 ~ null', ->
+    @aDefined_BNull.exec(@ctx).should.be.false()
+
+  it 'should be true for null ~ null', ->
+    @aNull_BNull.exec(@ctx).should.be.true()
+
+  it 'should be true for 3 ~ 3', ->
+    @aDefined_BDefined.exec(@ctx).should.be.true()
+
 describe 'Less', ->
   @beforeEach ->
     setup @, data


### PR DESCRIPTION
This is a fix to the null check for equivalency.

Corresponding cql_qdm_patientapi PR: https://github.com/projecttacoma/cql_qdm_patientapi/pull/85