### PR TITLE
Add primaryCodePath to FHIR 1.0.2 MedicationStatement

### DIFF
--- a/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-1.0.2.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-1.0.2.xml
@@ -3622,7 +3622,7 @@
         <ns4:element name="entity" type="FHIR.Reference"/>
         <ns4:element name="role" type="list&lt;FHIR.CodeableConcept&gt;"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="FHIR.MedicationStatement" retrievable="true" baseType="FHIR.DomainResource">
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="FHIR.MedicationStatement" retrievable="true" primaryCodePath="medicationCodeableConcept" baseType="FHIR.DomainResource">
         <ns4:element name="identifier" type="list&lt;FHIR.Identifier&gt;"/>
         <ns4:element name="patient" type="FHIR.Reference"/>
         <ns4:element name="informationSource" type="FHIR.Reference"/>


### PR DESCRIPTION
Fixes #296 by setting MedicationStatement's primaryCodePath to medicationCodeableConcept.  This aligns with the current definitions in FHIR 3.0.0 and 3.2.0.