### PR TITLE
Bump cql-execution to v1.2.0

### DIFF
--- a/Src/coffeescript/cql-execution/package.json
+++ b/Src/coffeescript/cql-execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-execution",
-  "version": "0.0.6",
+  "version": "1.2.0",
   "description": "An execution framework for the Clinical Quality Language (CQL)",
   "keywords": [
     "CQL",
@@ -23,6 +23,34 @@
     {
       "name": "Jason Walonoski",
       "email": "jwalonoski@mitre.org"
+    },
+    {
+      "name": "Luke Osborne",
+      "email": "lwosborne@mitre.org"
+    },
+    {
+      "name": "Kristian Mulcahy",
+      "email": "kmulcahy@mitre.org"
+    },
+    {
+      "name": "James Bradley",
+      "email": "jhbradley@mitre.org"
+    },
+    {
+      "name": "Chris Hossenlopp",
+      "email": "hossenlopp@mitre.org"
+    },
+    {
+      "name": "Chris Tohline",
+      "email": "ctohline@mitre.org"
+    },
+    {
+      "name": "Adam Holmes",
+      "email": "aholmes@mitre.org"
+    },
+    {
+      "name": "Pete Krautscheid",
+      "email": "krautscheid@mitre.org"
     }
   ],
   "repository": {


### PR DESCRIPTION
Bump cql-execution version to 1.2.0 to reflect the targeted CQL
specification version. This also reflects a jump in maturity from the
previous 0.0.6 version.  The current version is now used in the
production Bonnie application.