### PR TITLE
Merge r for annotations if child chunk is all strings

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -229,6 +229,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                     }
                     else {
                         currentNarrative.getContent().addAll(chunkNarrative.getContent());
+                        if (currentNarrative.getR() == null) {
+                            currentNarrative.setR(chunkNarrative.getR());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When rolling up annotations the id was sometimes lost as seen in #303. This PR fixes that.