### PR TITLE
Removed all, contains, distinct, exists, not, and where as identifier…

### DIFF
--- a/Src/grammar/cql.g4
+++ b/Src/grammar/cql.g4
@@ -439,23 +439,23 @@ identifier
     : IDENTIFIER
     | DELIMITEDIDENTIFIER
     | QUOTEDIDENTIFIER
-    | 'all'
+    //| 'all'
     | 'Code'
     | 'code'
     | 'Concept'
     | 'concept'
-    | 'contains'
+    //| 'contains'
     | 'date'
     | 'display'
-    | 'distinct'
+    //| 'distinct'
     | 'end'
-    // | 'exists' NOTE: This is excluded because including it causes a significant performance degradation in the ANTLR parser, still looking into a fix for this
-    | 'not'
+    //| 'exists' // NOTE: This is excluded because including it causes a significant performance degradation in the ANTLR parser, still looking into a fix for this
+    //| 'not'
     | 'start'
     | 'time'
     | 'timezone'
     | 'version'
-    | 'where'
+    //| 'where'
     ;
 
 QUOTEDIDENTIFIER

--- a/Src/grammar/cql.g4
+++ b/Src/grammar/cql.g4
@@ -435,6 +435,9 @@ conceptSelector
     : 'Concept' '{' codeSelector (',' codeSelector)* '}' displayClause?
     ;
 
+// NOTE: These keywords are commented out because of an issue with the ANTLR tooling. In 4.5, having these keywords
+// as identifiers results in unacceptable parsing performance. In 4.6+, having them as identifiers results in incorrect
+// parsing. See Github issue [#343](https://github.com/cqframework/clinical_quality_language/issues/343) for more detail
 identifier
     : IDENTIFIER
     | DELIMITEDIDENTIFIER
@@ -449,7 +452,7 @@ identifier
     | 'display'
     //| 'distinct'
     | 'end'
-    //| 'exists' // NOTE: This is excluded because including it causes a significant performance degradation in the ANTLR parser, still looking into a fix for this
+    //| 'exists'
     //| 'not'
     | 'start'
     | 'time'

--- a/Src/java-quickstart/build.gradle
+++ b/Src/java-quickstart/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.antlr', name: 'antlr4', version: '4.7.2'
+    compile group: 'org.antlr', name: 'antlr4', version: '4.5'
     testCompile group: 'org.testng', name: 'testng', version: '6.8.8'
 }
 

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile project(':cql')
     compile project(':model')
     compile project(':elm')
-    compile group: 'org.antlr', name: 'antlr4', version: '4.7.2'
+    compile group: 'org.antlr', name: 'antlr4', version: '4.5'
     compile group: 'com.fasterxml.jackson.core', name:'jackson-core', version:'2.4.1'
     compile group: 'com.fasterxml.jackson.core', name:'jackson-databind', version:'2.4.1'
     compile group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -724,7 +724,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                             .withName(identifier)
                             .withContext(currentContext)
                             .withExpression((Expression) visit(ctx.expression()));
-                    def.setResultType(def.getExpression().getResultType());
+                    if (def.getExpression() != null) {
+                        def.setResultType(def.getExpression().getResultType());
+                    }
                     libraryBuilder.addExpression(def);
                 } finally {
                     libraryBuilder.popExpressionDefinition();

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -3447,11 +3447,17 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
     private Expression resolveFunction(String libraryName, @NotNull cqlParser.FunctionContext ctx) {
         String functionName = parseString(ctx.identifier());
-        if ((libraryName == null || libraryName.equals("System")) && functionName.equals("distinct")) {
-            // Because distinct can be both a keyword and the name of a method, it can be resolved by the
-            // parser as a function, instead of as an aggregateExpressionTerm. In this case, the function
+        if (libraryName == null || libraryName.equals("System")) {
+            // Because these functions can be both a keyword and the name of a method, they can be resolved by the
+            // parser as a function, instead of as the keyword-based parser rule. In this case, the function
             // name needs to be translated to the System function name in order to resolve.
-            functionName = "Distinct";
+            switch (functionName) {
+                case "distinct": functionName = "Distinct"; break;
+                case "contains": functionName = "Contains"; break;
+                case "not": functionName = "Not"; break;
+                case "exists": functionName = "Exists"; break;
+            }
+            //functionName = "Distinct";
         }
         return resolveFunction(libraryName, functionName, ctx.paramList());
     }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
@@ -253,9 +253,6 @@ public class SystemFunctionResolver {
                 }
 
                 // Logical Functions
-                case "not": {
-                    return resolveUnary(fun.withName("Not"));
-                }
                 case "Not": {
                     return resolveUnary(fun);
                 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -190,6 +190,11 @@ public class SemanticTests {
         runSemanticTest("OperatorTests/Query.cql", 0);
     }
 
+    @Test
+    public void testParserPerformance() throws IOException {
+        runSemanticTest("ParserPerformance.cql");
+    }
+
     private void runSemanticTest(String testFileName) throws IOException {
         runSemanticTest(testFileName, 0);
     }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -190,9 +190,19 @@ public class SemanticTests {
         runSemanticTest("OperatorTests/Query.cql", 0);
     }
 
+    //@Test
+    //public void testParserPerformance() throws IOException {
+    //    runSemanticTest("ParserPerformance.cql");
+    //}
+
     @Test
-    public void testParserPerformance() throws IOException {
-        runSemanticTest("ParserPerformance.cql");
+    public void tricksyParse() throws IOException {
+        runSemanticTest("TricksyParse.cql");
+    }
+
+    @Test
+    public void shouldFail() throws IOException {
+        runSemanticTest("ShouldFail.cql", 1);
     }
 
     private void runSemanticTest(String testFileName) throws IOException {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -190,6 +190,10 @@ public class SemanticTests {
         runSemanticTest("OperatorTests/Query.cql", 0);
     }
 
+    // NOTE: This test is commented out to an issue with the ANTLR tooling. In 4.5, this test documents the
+    // unacceptable performance of the parser. In 4.6+, the parser does not correctly resolve some types of
+    // expressions (see TricksyParse and ShouldFail). See Github issue [#343](https://github.com/cqframework/clinical_quality_language/issues/343)
+    // for more detail.
     //@Test
     //public void testParserPerformance() throws IOException {
     //    runSemanticTest("ParserPerformance.cql");

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/ParserPerformance.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/ParserPerformance.cql
@@ -1,0 +1,145 @@
+library testassociations version '0.0.000'
+
+// Github Issue [#149](https://github.com/cqframework/clinical_quality_language/issues/149)
+// On older versions of Antlr4, this library would never finish parsing
+
+using QDM version '5.4'
+
+codesystem "LOINC": 'urn:oid:2.16.840.1.113883.6.1'
+codesystem "SNOMEDCT": 'urn:oid:2.16.840.1.113883.6.96'
+
+valueset "Ethnicity": 'urn:oid:2.16.840.1.114222.4.11.837'
+valueset "ONC Administrative Sex": 'urn:oid:2.16.840.1.113762.1.4.1'
+valueset "Payer": 'urn:oid:2.16.840.1.114222.4.11.3591'
+valueset "Race": 'urn:oid:2.16.840.1.114222.4.11.836'
+
+code "Birth date": '21112-8' from "LOINC" display 'Birth date'
+code "Dead (finding)": '419099009' from "SNOMEDCT" display 'Dead (finding)'
+code "Duration (attribute)": '103335007' from "SNOMEDCT" display 'Duration (attribute)'
+code "Patient data Document": '55188-7' from "LOINC" display 'Patient data Document'
+
+parameter "Measurement Period" Interval<DateTime>
+
+context Patient
+
+define "SDE Ethnicity":
+  ["Patient Characteristic Ethnicity": "Ethnicity"]
+
+define "SDE Payer":
+  ["Patient Characteristic Payer": "Payer"]
+
+define "SDE Race":
+  ["Patient Characteristic Race": "Race"]
+
+define "SDE Sex":
+  ["Patient Characteristic Sex": "ONC Administrative Sex"]
+
+define "test1":
+  exists ( ["Patient Characteristic": "Patient data Document"] Alias
+      where ToDate(Alias.authorDatetime)= @2012-05-01
+  )
+    or exists ( ["Patient Characteristic": code in "Patient data Document"] )
+    or exists ( ["Patient Characteristic": "Patient data Document"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic": "Patient data Document"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic": "Patient data Document"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Birthdate": "Birth date"] Alias
+        where CalculateAgeInYearsAt(Alias.birthDatetime, start of "Measurement Period")> 21
+    )
+		// this line is where it looks like the issue is
+        or CalculateAgeInYearsAt(Patient.birthDatetime, start of "Measurement Period")> 21
+    or exists ( ["Patient Characteristic Birthdate": "Birth date"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Birthdate": "Birth date"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Birthdate": "Birth date"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Clinical Trial Participant": "Patient data Document"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Clinical Trial Participant": "Patient data Document"] Alias
+        where Alias.reason is not null
+    )
+    or exists ( ["Patient Characteristic Clinical Trial Participant": "Patient data Document"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Clinical Trial Participant": "Patient data Document"] Alias
+        where Alias.relevantPeriod is not null
+    )
+    or exists ( ["Patient Characteristic Clinical Trial Participant": "Patient data Document"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Ethnicity": "Ethnicity"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Ethnicity": "Ethnicity"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Ethnicity": "Ethnicity"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Expired": "Dead (finding)"] Alias
+        where Alias.cause = "Duration (attribute)"
+    )
+    or exists ( ["Patient Characteristic Expired": "Dead (finding)"] Alias
+        where Alias.expiredDatetime < @2012-06-01
+    )
+    or exists ( ["Patient Characteristic Expired": "Dead (finding)"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Expired": "Dead (finding)"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Expired": "Dead (finding)"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Payer": "Payer"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Payer": "Payer"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Payer": "Payer"] Alias
+        where Alias.relevantPeriod during "Measurement Period"
+    )
+    or exists ( ["Patient Characteristic Payer": "Payer"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Race": "Race"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Race": "Race"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Race": "Race"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Patient Characteristic Sex": "ONC Administrative Sex"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Patient Characteristic Sex": "ONC Administrative Sex"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Patient Characteristic Sex": "ONC Administrative Sex"] Alias
+        where Alias.reporter is not null
+    )
+    or exists ( ["Provider Characteristic": "Patient data Document"] Alias
+        where Alias.authorDatetime = @2102-05-01T12:50
+    )
+    or exists ( ["Provider Characteristic": "Patient data Document"] Alias
+        where Alias.id is not null
+    )
+    or exists ( ["Provider Characteristic": "Patient data Document"] Alias
+        where Alias.recorder is not null
+    )
+    or exists ( ["Provider Characteristic": "Patient data Document"] Alias
+        where Alias.reporter is not null
+    )

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/ShouldFail.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/ShouldFail.cql
@@ -1,0 +1,6 @@
+/*
+This test should produce an error, but with ANTLR 4.6+, the parser pulls in the list selector,
+and then ignores the rest of the expression.
+*/
+
+define TestShouldFail: { 1, 2, 3 } A bunch of gobbledygook that ANTLR ignores

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TricksyParse.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TricksyParse.cql
@@ -1,0 +1,44 @@
+/*
+The overlap of keywords in CQL with FHIRPath functions means that FHIRPath
+expressions won't parse correctly. However, introducing the keywords as identifiers
+in the grammar (the recommended approach to allowing keywords to be identifiers within ANTLR)
+results in unacceptable performance in 4.5 and unacceptable changes to the parsing in 4.6+.
+
+The TestFunctionKeywords expression addresses the keywords issue. It should be parsable in CQL
+regardless of FHIRPath support.
+
+The "Has First Hypertensive Reading With Interventions" expression is an example of an expression
+ that parses correctly in 4.5, but incorrectly in 4.6+. Specifically, the phrase
+   `not "Last Blood Pressure With One Year High"`
+ parses as a query rather than a not expression if the keywords are included as identifiers.
+*/
+
+
+define "TestFunctionKeywords":
+  ({ 1, 2, 3 }) A
+    where(not(exists(distinct({ 1, 2, 3 })) or ({ 1, 2, 3 } contains(1)))
+      or exists(({ 1, 2, 3 }) B return all(B))
+    )
+
+define "High Blood Pressure at Most Recent Screening Encounter":
+  { id: 1, date: @2012-01-01 }
+
+define "Last Blood Pressure Within One Year High":
+  true
+
+define "Hypertensive Interventions at Most Recent Blood Pressure Encounter":
+  { { id: 1, date: @2012-01-01 } }
+
+define "Follow Up Within 4 Weeks":
+  { { id: 1, date: @2012-01-01 } }
+
+define "Referral to Alternate Provider":
+  { { id: 1, date: @2012-01-01 } }
+
+define "Has First Hypertensive Reading With Interventions":
+	"High Blood Pressure at Most Recent Screening Encounter" is not null
+		and not "Last Blood Pressure Within One Year High"
+		and ( exists ( "Hypertensive Interventions at Most Recent Blood Pressure Encounter" )
+				and exists ( "Follow Up Within 4 Weeks" )
+		)
+		or exists ( "Referral to Alternate Provider" )

--- a/Src/java/cql/build.gradle
+++ b/Src/java/cql/build.gradle
@@ -5,7 +5,7 @@ mainClassName = 'org.cqframework.cql.Main'
 run.args = ["${projectDir}/../../../Examples/ChlamydiaScreening_CQM.cql"]
 
 dependencies {
-    antlr group: 'org.antlr', name: 'antlr4', version: '4.7.2'
+    antlr group: 'org.antlr', name: 'antlr4', version: '4.5'
 }
 
 ext.antlr = [

--- a/Src/java/tools/cql-parsetree/src/main/java/org/cqframework/cql/tools/parsetree/Main.java
+++ b/Src/java/tools/cql-parsetree/src/main/java/org/cqframework/cql/tools/parsetree/Main.java
@@ -3,7 +3,6 @@ package org.cqframework.cql.tools.parsetree;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.gui.Trees;
 import org.cqframework.cql.gen.cqlLexer;
 import org.cqframework.cql.gen.cqlParser;
 
@@ -31,6 +30,6 @@ public class Main {
         cqlParser parser = new cqlParser(tokens);
         parser.setBuildParseTree(true);
         ParserRuleContext tree = parser.library();
-        Trees.inspect(tree, parser);
+        tree.inspect(parser);
     }
 }


### PR DESCRIPTION
…s in the language. The update to Antlr4 changes how LR rules are parsed and no longer parses correctly with these identifiers present. This will need to be addressed as part of the May ballot, but only impacts FHIRPath usage, so is not relevant for the 1.3 Maintenance release.