### PR TITLE
#451 CQL-to-ELM Translator - Signature annotations missing from included libraries

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -472,7 +472,8 @@ public class LibraryBuilder {
                 .withVersion(includeDef.getVersion());
 
         ArrayList<CqlTranslatorException> errors = new ArrayList<CqlTranslatorException>();
-        TranslatedLibrary referencedLibrary = libraryManager.resolveLibrary(libraryIdentifier, errors);
+        TranslatedLibrary referencedLibrary = libraryManager.resolveLibrary(libraryIdentifier,
+            this.getErrorLevel(), this.getSignatureLevel(), errors);
         for (CqlTranslatorException error : errors) {
             this.addException(error);
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -1,5 +1,6 @@
 package org.cqframework.cql.cql2elm;
 
+import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.hl7.elm.r1.VersionedIdentifier;
 
@@ -41,7 +42,8 @@ public class LibraryManager {
         return libraries;
     }
 
-    public TranslatedLibrary resolveLibrary(VersionedIdentifier libraryIdentifier, List<CqlTranslatorException> errors) {
+    public TranslatedLibrary resolveLibrary(VersionedIdentifier libraryIdentifier,
+        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel, List<CqlTranslatorException> errors) {
         if (libraryIdentifier == null) {
             throw new IllegalArgumentException("libraryIdentifier is null.");
         }
@@ -64,7 +66,7 @@ public class LibraryManager {
         }
 
         else {
-            library = translateLibrary(libraryIdentifier, errors);
+            library = translateLibrary(libraryIdentifier, errorLevel, signatureLevel, errors);
             if (!HasErrors(errors)) {
                 libraries.put(libraryIdentifier.getId(), library);
             }
@@ -73,7 +75,8 @@ public class LibraryManager {
         return library;
     }
 
-    private TranslatedLibrary translateLibrary(VersionedIdentifier libraryIdentifier, List<CqlTranslatorException> errors) {
+    private TranslatedLibrary translateLibrary(VersionedIdentifier libraryIdentifier,
+        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel, List<CqlTranslatorException> errors) {
         InputStream librarySource = null;
         try {
             librarySource = librarySourceLoader.getLibrarySource(libraryIdentifier);
@@ -88,7 +91,7 @@ public class LibraryManager {
         }
 
         try {
-            CqlTranslator translator = CqlTranslator.fromStream(librarySource, modelManager, this);
+            CqlTranslator translator = CqlTranslator.fromStream(librarySource, modelManager, this, errorLevel, signatureLevel);
             if (errors != null) {
                 errors.addAll(translator.getExceptions());
             }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/BaseLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/BaseLibrary.cql
@@ -9,3 +9,5 @@ valueset "Pregnancy Test": '2.16.840.1.113883.3.464.1003.111.12.1011' codesystem
 
 define private PrivateExpression: Tuple { Id : '12345', Name : 'John Doe' }
 define BaseExpression: PrivateExpression
+
+define BaseLibSum: Sum({1,2,3})


### PR DESCRIPTION
When Signatures are enabled, only the referencing library when translated to
ELM has the signature annotations whereas the included libraries don't. This PR addresses the issue by passing the signature information to the translator while translating the included library to elm.

Example to reproduce the issue:

**ReferencingLibrary.cql**
```
library ReferencingLib

include BaseLibrary called Base
```

**BaseLibrary.cql**
```
library BaseLibrary

define BaseLibSum: Sum({1,2,3})
```

When the ReferencingLibrary.cql is translated to elm programmatically using the CqlTranslator, the elm corresponding to BaseLibrary does not have the signatures.
