### PR TITLE
Fix issue #436 - Translator Options flow down

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -314,6 +314,7 @@ public class CqlTranslator {
         LibraryBuilder builder = new LibraryBuilder(modelManager, libraryManager, ucumService);
         builder.setErrorLevel(errorLevel);
         builder.setSignatureLevel(signatureLevel);
+        builder.setTranslatorOptions(options);
         List<CqlTranslator.Options> optionList = Arrays.asList(options);
         Cql2ElmVisitor visitor = new Cql2ElmVisitor(builder);
         if (optionList.contains(CqlTranslator.Options.EnableDateRangeOptimization)) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -1,5 +1,6 @@
 package org.cqframework.cql.cql2elm;
 
+import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.model.*;
 import org.cqframework.cql.cql2elm.model.invocation.*;
 import org.cqframework.cql.elm.tracking.TrackBack;
@@ -118,6 +119,7 @@ public class LibraryBuilder {
     private final org.hl7.cql_annotations.r1.ObjectFactory af = new org.hl7.cql_annotations.r1.ObjectFactory();
     private boolean listTraversal = true;
     private UcumService ucumService = null;
+    private CqlTranslator.Options[] translatorOptions = null;
     private SignatureLevel signatureLevel = SignatureLevel.Differing;
 
     public void enableListTraversal() {
@@ -142,6 +144,14 @@ public class LibraryBuilder {
     }
     public void setErrorLevel(CqlTranslatorException.ErrorSeverity severity) {
         errorLevel = severity;
+    }
+
+    public void setTranslatorOptions(CqlTranslator.Options... options) {
+        this.translatorOptions = options;
+    }
+
+    public CqlTranslator.Options[] getTranslatorOptions() {
+        return this.translatorOptions;
     }
 
     private Model loadModel(VersionedIdentifier modelIdentifier) {
@@ -505,7 +515,7 @@ public class LibraryBuilder {
 
         ArrayList<CqlTranslatorException> errors = new ArrayList<CqlTranslatorException>();
         TranslatedLibrary referencedLibrary = libraryManager.resolveLibrary(libraryIdentifier,
-            this.getErrorLevel(), this.getSignatureLevel(), errors);
+            this.getErrorLevel(), this.getSignatureLevel(), this.getTranslatorOptions(), errors);
         for (CqlTranslatorException error : errors) {
             this.addException(error);
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -1,5 +1,6 @@
 package org.cqframework.cql.cql2elm;
 
+import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.hl7.elm.r1.VersionedIdentifier;
@@ -47,7 +48,7 @@ public class LibraryManager {
     }
 
     public TranslatedLibrary resolveLibrary(VersionedIdentifier libraryIdentifier,
-        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel, List<CqlTranslatorException> errors) {
+        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel, CqlTranslator.Options[] options, List<CqlTranslatorException> errors) {
         if (libraryIdentifier == null) {
             throw new IllegalArgumentException("libraryIdentifier is null.");
         }
@@ -70,7 +71,7 @@ public class LibraryManager {
         }
 
         else {
-            library = translateLibrary(libraryIdentifier, errorLevel, signatureLevel, errors);
+            library = translateLibrary(libraryIdentifier, errorLevel, signatureLevel, options, errors);
             if (!HasErrors(errors)) {
                 libraries.put(libraryIdentifier.getId(), library);
             }
@@ -80,7 +81,7 @@ public class LibraryManager {
     }
 
     private TranslatedLibrary translateLibrary(VersionedIdentifier libraryIdentifier,
-        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel, List<CqlTranslatorException> errors) {
+        CqlTranslatorException.ErrorSeverity errorLevel, SignatureLevel signatureLevel,  CqlTranslator.Options[] options, List<CqlTranslatorException> errors) {
         InputStream librarySource = null;
         try {
             librarySource = librarySourceLoader.getLibrarySource(libraryIdentifier);
@@ -95,7 +96,7 @@ public class LibraryManager {
         }
 
         try {
-            CqlTranslator translator = CqlTranslator.fromStream(librarySource, modelManager, this, errorLevel, signatureLevel);
+            CqlTranslator translator = CqlTranslator.fromStream(librarySource, modelManager, this, errorLevel, signatureLevel, options);
             if (errors != null) {
                 errors.addAll(translator.getExceptions());
             }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -4,6 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -135,4 +139,55 @@ public class LibraryTests {
         }
     }
 
+    @Test
+    public void testTranslatorOptionsFlowDownWithAnnotations() {
+        try {
+            // Test Annotations are created for both libraries
+            CqlTranslator translator = null;
+            libraryManager = new LibraryManager(modelManager);
+            libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
+            translator = CqlTranslator.fromStream(LibraryTests.class.getResourceAsStream("LibraryTests/ReferencingLibrary.cql"),
+                modelManager,
+                libraryManager,
+                CqlTranslatorException.ErrorSeverity.Info,
+                SignatureLevel.All,
+                CqlTranslator.Options.EnableAnnotations);
+
+            assertThat(translator.getErrors().size(), is(0));
+            Map<String, Library> includedLibraries = translator.getLibraries();
+            includedLibraries.values().stream().forEach(includedLibrary -> {
+                // Ensure that some annotations are present.
+                assertTrue(includedLibrary.getStatements().getDef().stream().filter(x -> x.getAnnotation().size() > 0).count() > 0);
+            });
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testTranslatorOptionsFlowDownWithoutAnnotations() {
+
+        try {
+            // Test Annotations are created for both libraries
+            CqlTranslator translator = null;
+            libraryManager = new LibraryManager(modelManager);
+            libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
+            translator = CqlTranslator.fromStream(LibraryTests.class.getResourceAsStream("LibraryTests/ReferencingLibrary.cql"),
+                modelManager,
+                libraryManager,
+                CqlTranslatorException.ErrorSeverity.Info,
+                SignatureLevel.All);
+
+            assertThat(translator.getErrors().size(), is(0));
+            Map<String, Library> includedLibraries = translator.getLibraries();
+            includedLibraries.values().stream().forEach(includedLibrary -> {
+                // Ensure that no annotations are present.
+                assertTrue(includedLibrary.getStatements().getDef().stream().filter(x -> x.getAnnotation().size() > 0).count() == 0);
+            });
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -1,16 +1,21 @@
 package org.cqframework.cql.cql2elm;
 
 import org.cqframework.cql.elm.tracking.TrackBack;
+import org.hl7.elm.r1.ExpressionDef;
 import org.testng.annotations.Test;
 
 import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Scanner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TranslationTests {
     // TODO: sameXMLAs? Couldn't find such a thing in hamcrest, but I don't want this to run on the JSON, I want it to verify the actual XML.
@@ -35,7 +40,7 @@ public class TranslationTests {
     }
 
     @Test
-    public void testIdentiferLocation() throws IOException {
+    public void testIdentifierLocation() throws IOException {
         CqlTranslator translator = TestUtils.createTranslator("TranslatorTests/UnknownIdentifier.cql");
         assertEquals(1, translator.getErrors().size());
 
@@ -50,8 +55,19 @@ public class TranslationTests {
     }
 
     @Test
-    public void testAnnotations() throws IOException {
+    public void testAnnotationsPresent() throws IOException {
         CqlTranslator translator = TestUtils.createTranslator("CMS146v2_Test_CQM.cql", CqlTranslator.Options.EnableAnnotations);
         assertEquals(0, translator.getErrors().size());
+        List<ExpressionDef> defs = translator.getTranslatedLibrary().getLibrary().getStatements().getDef();
+        assertNotNull(defs.get(1).getAnnotation());
+        assertTrue(defs.get(1).getAnnotation().size() > 0);
+    }
+
+    @Test
+    public void testAnnotationsAbsent() throws IOException {
+        CqlTranslator translator = TestUtils.createTranslator("CMS146v2_Test_CQM.cql");
+        assertEquals(0, translator.getErrors().size());
+        List<ExpressionDef> defs = translator.getTranslatedLibrary().getLibrary().getStatements().getDef();
+        assertTrue(defs.get(1).getAnnotation().size() == 0);
     }
 }


### PR DESCRIPTION
* Adds translator options to the library builder which allows them to flow down. Resolves #436 

There's an alternate approach to this PR that is less invasive, which is to pass the Translator options to the LibraryManager directly during construction, bypassing the LibraryBuilder. However, I felt that was less consistent approach since the LibraryBuilder explicitly passes other options such as Error and SignatureLevel.