### PR TITLE
Add fix for MoneyQuantity

### DIFF
--- a/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.0.xml
@@ -10072,6 +10072,7 @@
         <ns4:element name="amount" elementType="FHIR.Quantity"/>
     </ns4:typeInfo>
     <ns4:typeInfo xsi:type="ns4:ClassInfo" name="Distance" retrievable="false" baseType="FHIR.Quantity"/>
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="MoneyQuantity" retrievable="false" baseType="FHIR.Quantity"/>
     <ns4:typeInfo xsi:type="ns4:ClassInfo" name="ImplementationGuide.Definition" retrievable="false" baseType="FHIR.BackboneElement">
         <ns4:element name="grouping">
             <ns4:elementTypeSpecifier xsi:type="ns4:ListTypeSpecifier" elementType="FHIR.ImplementationGuide.Grouping"/>


### PR DESCRIPTION
* Add mapping for MoneyQuantity to FHIR 4.0.0 modelInfo. This change was picked up from the tooling updates on the fix-278 branch