### PR TITLE
#513: Added a JXSON format option to support using the Jackson serial…

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -116,6 +116,10 @@ configure(subprojects.findAll {it.name in ['model', 'elm', 'quick', 'qdm']}) {
         runtime group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.4.0-b180830.0438'
         runtime group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
         runtime group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
+        runtime group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.1'
+        runtime group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.10.1'
+        runtime group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.1'
+        runtime group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.10.1'
     }
 
     ext.xjc = [

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/serialization/LibraryWrapper.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/serialization/LibraryWrapper.java
@@ -1,0 +1,14 @@
+package org.cqframework.cql.cql2elm.model.serialization;
+
+import org.hl7.elm.r1.Library;
+
+public class LibraryWrapper {
+    private Library library;
+    public Library getLibrary() {
+        return this.library;
+    }
+
+    public void setLibrary(Library library) {
+        this.library = library;
+    }
+}

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/Trackable.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/Trackable.java
@@ -1,5 +1,8 @@
 package org.cqframework.cql.elm.tracking;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.hl7.cql.model.DataType;
 
 import javax.xml.bind.annotation.XmlTransient;
@@ -7,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public class Trackable {
     private final UUID trackerId;
     private final List<TrackBack> trackbacks;
@@ -18,15 +22,20 @@ public class Trackable {
         this.trackbacks = new ArrayList<>();
     }
 
+    @XmlTransient
+    @JsonIgnore
     public UUID getTrackerId() {
         return trackerId;
     }
 
+    @XmlTransient
+    @JsonIgnore
     public List<TrackBack> getTrackbacks() {
         return trackbacks;
     }
 
     @XmlTransient
+    @JsonIgnore
     public DataType getResultType() {
         return resultType;
     }


### PR DESCRIPTION
…izer to produce JSON output.

We've recently tried deserializing JSON ELM in the Java library and the output from the JAXB-JSON serialization is inconsistent (i.e. it produces type elements only in the case that the type cannot be inferred from the element definition). Deserializing using JAXB is not possible for certain environments (specifically Android phones just don't work with it). We have been able to successfully deserialize JSON in Java on Android, but only with the Jackson deserializer, but the Jackson deserializer doesn't work with the JAXB-JSON serialized output. So we're proposing a new JXSON format option that instructs the translator to serialize to JSON with the Jackson serializer, resulting in consistent, and we believe backwards-compatible, JSON output.

However, we're not 100% confident in that backwards-compatible output, and that's the reason for introducing it as a separate option. So the JSON option works the same as it always did, using the JAXB-JSON serializer, where the JXSON option produces JSON, but using the Jackson serializer. We've added a suite of regression tests to the Java engine project, but it only verifies that the content can be deserialized without errors, not that the resulting content is semantically equivalent.

So, this PR is a request to add JXSON as an option to support efforts to use CQL in an Android device, but without impacting the current capabilities, and providing a trajectory to align on JXSON support moving forward (since JAXB support seems to be a dying thing).