### PR TITLE
#526: Fixed syntax errors reporting with library "unknown", rather th…

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -523,21 +523,14 @@ public class CqlTranslator {
 
         private VersionedIdentifier extractLibraryIdentifier(cqlParser parser) {
             RuleContext context = parser.getContext();
-            while (!(context instanceof cqlParser.LibraryContext)) {
+            while (context != null && !(context instanceof cqlParser.LibraryContext)) {
                 context = context.parent;
-                if (context == null) {
-                    break;
-                }
             }
 
             if (context instanceof cqlParser.LibraryContext) {
-                for (ParseTree pt : ((cqlParser.LibraryContext)context).children) {
-                    if (pt instanceof cqlParser.LibraryDefinitionContext) {
-                        cqlParser.LibraryDefinitionContext ldc = (cqlParser.LibraryDefinitionContext)pt;
-                        if (ldc.qualifiedIdentifier() != null && ldc.qualifiedIdentifier().identifier() != null) {
-                            return new VersionedIdentifier().withId(StringEscapeUtils.unescapeCql(ldc.qualifiedIdentifier().identifier().getText()));
-                        }
-                    }
+                cqlParser.LibraryDefinitionContext ldc = ((cqlParser.LibraryContext)context).libraryDefinition();
+                if (ldc != null && ldc.qualifiedIdentifier() != null && ldc.qualifiedIdentifier().identifier() != null) {
+                    return new VersionedIdentifier().withId(StringEscapeUtils.unescapeCql(ldc.qualifiedIdentifier().identifier().getText()));
                 }
             }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -61,6 +61,7 @@ public class CqlTranslator {
     private List<CqlTranslatorException> errors = null;
     private List<CqlTranslatorException> warnings = null;
     private List<CqlTranslatorException> messages = null;
+    private VersionedIdentifier sourceInfo = null;
     private NamespaceInfo namespaceInfo = null;
     private ModelManager modelManager = null;
     private LibraryManager libraryManager = null;
@@ -180,115 +181,115 @@ public class CqlTranslator {
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, null, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, String cqlFileName, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFileName), new ANTLRInputStream(new FileInputStream(cqlFileName)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, CqlTranslatorException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, LibraryBuilder.SignatureLevel.None, options);
     }
 
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
                                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, errorLevel, signatureLevel, options);
     }
 
     public static CqlTranslator fromText(String cqlText, ModelManager modelManager,
@@ -301,6 +302,11 @@ public class CqlTranslator {
         return new CqlTranslator(namespaceInfo, new ANTLRInputStream(cqlText), modelManager, libraryManager, ucumService, options);
     }
 
+    public static CqlTranslator fromText(NamespaceInfo namespaceInfo, VersionedIdentifier sourceInfo, String cqlText, ModelManager modelManager,
+                                         LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) {
+        return new CqlTranslator(namespaceInfo, sourceInfo, new ANTLRInputStream(cqlText), modelManager, libraryManager, ucumService, options);
+    }
+
     public static CqlTranslator fromStream(InputStream cqlStream, ModelManager modelManager,
                                            LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) throws IOException {
         return new CqlTranslator(null, new ANTLRInputStream(cqlStream), modelManager, libraryManager, ucumService, options);
@@ -311,14 +317,29 @@ public class CqlTranslator {
         return new CqlTranslator(namespaceInfo, new ANTLRInputStream(cqlStream), modelManager, libraryManager, ucumService, options);
     }
 
+    public static CqlTranslator fromStream(NamespaceInfo namespaceInfo, VersionedIdentifier sourceInfo, InputStream cqlStream, ModelManager modelManager,
+                                           LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) throws IOException {
+        return new CqlTranslator(namespaceInfo, sourceInfo, new ANTLRInputStream(cqlStream), modelManager, libraryManager, ucumService, options);
+    }
+
     public static CqlTranslator fromFile(File cqlFile, ModelManager modelManager,
                                          LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) throws IOException {
-        return new CqlTranslator(null, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, options);
+        return new CqlTranslator(null, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, options);
     }
 
     public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, File cqlFile, ModelManager modelManager,
                                          LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) throws IOException {
-        return new CqlTranslator(namespaceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, options);
+        return new CqlTranslator(namespaceInfo, getSourceInfo(cqlFile), new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, options);
+    }
+
+    public static CqlTranslator fromFile(NamespaceInfo namespaceInfo, VersionedIdentifier sourceInfo, File cqlFile, ModelManager modelManager,
+                                         LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) throws IOException {
+        return new CqlTranslator(namespaceInfo, sourceInfo, new ANTLRInputStream(new FileInputStream(cqlFile)), modelManager, libraryManager, ucumService, options);
+    }
+
+    private CqlTranslator(NamespaceInfo namespaceInfo, VersionedIdentifier sourceInfo, ANTLRInputStream is, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
+                          CqlTranslatorException.ErrorSeverity errorLevel, LibraryBuilder.SignatureLevel signatureLevel, CqlTranslator.Options... options) {
+        this(namespaceInfo, sourceInfo, is, modelManager, libraryManager, ucumService, new CqlTranslatorOptions(errorLevel, signatureLevel, options));
     }
 
     private CqlTranslator(NamespaceInfo namespaceInfo, ANTLRInputStream is, ModelManager modelManager, LibraryManager libraryManager, UcumService ucumService,
@@ -328,11 +349,21 @@ public class CqlTranslator {
 
     private CqlTranslator(NamespaceInfo namespaceInfo, ANTLRInputStream is, ModelManager modelManager,
                           LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) {
+        this(namespaceInfo, null, is, modelManager, libraryManager, ucumService, options);
+    }
+
+    private CqlTranslator(NamespaceInfo namespaceInfo, VersionedIdentifier sourceInfo, ANTLRInputStream is, ModelManager modelManager,
+                          LibraryManager libraryManager, UcumService ucumService, CqlTranslatorOptions options) {
+        this.sourceInfo = sourceInfo;
         this.namespaceInfo = namespaceInfo;
         this.modelManager = modelManager;
         this.libraryManager = libraryManager;
         this.ucumService = ucumService;
         this.errorLevel = options.getErrorLevel();
+
+        if (this.sourceInfo == null) {
+            sourceInfo = new VersionedIdentifier().withId("Anonymous").withSystem("text/cql");
+        }
 
         if (this.namespaceInfo != null) {
             libraryManager.getNamespaceManager().ensureNamespaceRegistered(this.namespaceInfo);
@@ -347,6 +378,26 @@ public class CqlTranslator {
         }
 
         translateToELM(is, options);
+    }
+
+    private static VersionedIdentifier getSourceInfo(String cqlFileName) {
+        return getSourceInfo(new File(cqlFileName));
+    }
+
+    private static VersionedIdentifier getSourceInfo(File cqlFile) {
+        String name = cqlFile.getName();
+        int extensionIndex = name.lastIndexOf('.');
+        if (extensionIndex > 0) {
+            name = name.substring(0, extensionIndex);
+        }
+        String system = null;
+        try {
+            system = cqlFile.getCanonicalPath();
+        } catch (IOException e) {
+            system = cqlFile.getAbsolutePath();
+        }
+
+        return new VersionedIdentifier().withId(name).withSystem(system);
     }
 
     private String toXml(Library library) {
@@ -472,7 +523,11 @@ public class CqlTranslator {
 
         @Override
         public void syntaxError(@NotNull Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, @NotNull String msg, RecognitionException e) {
-            TrackBack trackback = new TrackBack(new VersionedIdentifier().withId("unknown"), line, charPositionInLine, line, charPositionInLine);
+            VersionedIdentifier libraryIdentifier = builder.getLibraryIdentifier();
+            if (libraryIdentifier == null) {
+                libraryIdentifier = sourceInfo;
+            }
+            TrackBack trackback = new TrackBack(libraryIdentifier, line, charPositionInLine, line, charPositionInLine);
 
             if (detailedErrors) {
                 builder.recordParsingException(new CqlSyntaxException(msg, trackback, e));

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -113,7 +113,7 @@ public class LibraryManager {
 
         try {
             CqlTranslator translator = CqlTranslator.fromStream(namespaceManager.getNamespaceInfoFromUri(libraryIdentifier.getSystem()),
-                    librarySource, modelManager, this, ucumService, options);
+                    libraryIdentifier, librarySource, modelManager, this, ucumService, options);
             if (errors != null) {
                 errors.addAll(translator.getExceptions());
             }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -236,6 +236,13 @@ public class LibraryTests {
     }
 
     @Test
+    public void testSyntaxErrorWithLibraryFromStream() throws IOException {
+        CqlTranslator translator = TestUtils.createTranslatorFromStream("LibraryTests/SyntaxErrorWithLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(1));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithLibrary"));
+    }
+
+    @Test
     public void testSyntaxErrorReferencingLibrary() throws IOException {
         CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorReferencingLibrary.cql");
         assertThat(translator.getErrors().size(), greaterThanOrEqualTo(2));

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -219,4 +219,27 @@ public class LibraryTests {
             e.printStackTrace();
         }
     }
+
+    @Test
+    public void testSynaxErrorWithNoLibrary() throws IOException {
+        // Syntax errors in anonymous libraries are reported with the name of the source file as the library identifier
+        CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorWithNoLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(1));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithNoLibrary"));
+    }
+
+    @Test
+    public void testSyntaxErrorWithLibrary() throws IOException {
+        CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorWithLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(1));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithLibrary"));
+    }
+
+    @Test
+    public void testSyntaxErrorReferencingLibrary() throws IOException {
+        CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorReferencingLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(2));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorReferencingLibrary"));
+        assertThat(translator.getErrors().get(1).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithLibrary"));
+    }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryTests.java
@@ -229,6 +229,14 @@ public class LibraryTests {
     }
 
     @Test
+    public void testSynaxErrorWithNoLibraryFromStream() throws IOException {
+        // Syntax errors in anonymous libraries are reported with the name of the source file as the library identifier
+        CqlTranslator translator = TestUtils.createTranslatorFromStream("LibraryTests/SyntaxErrorWithNoLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(1));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("Anonymous"));
+    }
+
+    @Test
     public void testSyntaxErrorWithLibrary() throws IOException {
         CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorWithLibrary.cql");
         assertThat(translator.getErrors().size(), greaterThanOrEqualTo(1));
@@ -245,6 +253,14 @@ public class LibraryTests {
     @Test
     public void testSyntaxErrorReferencingLibrary() throws IOException {
         CqlTranslator translator = TestUtils.createTranslator("LibraryTests/SyntaxErrorReferencingLibrary.cql");
+        assertThat(translator.getErrors().size(), greaterThanOrEqualTo(2));
+        assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorReferencingLibrary"));
+        assertThat(translator.getErrors().get(1).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithLibrary"));
+    }
+
+    @Test
+    public void testSyntaxErrorReferencingLibraryFromStream() throws IOException {
+        CqlTranslator translator = TestUtils.createTranslatorFromStream("LibraryTests/SyntaxErrorReferencingLibrary.cql");
         assertThat(translator.getErrors().size(), greaterThanOrEqualTo(2));
         assertThat(translator.getErrors().get(0).getLocator().getLibrary().getId(), equalTo("SyntaxErrorReferencingLibrary"));
         assertThat(translator.getErrors().get(1).getLocator().getLibrary().getId(), equalTo("SyntaxErrorWithLibrary"));

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -183,6 +183,7 @@ public class TestUtils {
         File translationTestFile = new File(URLDecoder.decode(Cql2ElmVisitorTest.class.getResource(testFileName).getFile(), "UTF-8"));
         ModelManager modelManager = new ModelManager();
         LibraryManager libraryManager = new LibraryManager(modelManager);
+        libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
         libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
         CqlTranslator translator = CqlTranslator.fromFile(namespaceInfo, translationTestFile, modelManager, libraryManager, getUcumService(), options);
         return translator;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -175,6 +175,20 @@ public class TestUtils {
         return translator;
     }
 
+    public static CqlTranslator createTranslatorFromStream(String testFileName, CqlTranslator.Options... options) throws IOException {
+        return createTranslatorFromStream(null, testFileName, options);
+    }
+
+    public static CqlTranslator createTranslatorFromStream(NamespaceInfo namespaceInfo, String testFileName, CqlTranslator.Options... options) throws IOException {
+        InputStream inputStream = Cql2ElmVisitorTest.class.getResourceAsStream(testFileName);
+        ModelManager modelManager = new ModelManager();
+        LibraryManager libraryManager = new LibraryManager(modelManager);
+        libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
+        libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
+        CqlTranslator translator = CqlTranslator.fromStream(namespaceInfo, inputStream, modelManager, libraryManager, getUcumService(), options);
+        return translator;
+    }
+
     public static CqlTranslator createTranslator(String testFileName, CqlTranslator.Options... options) throws IOException {
         return createTranslator(null, testFileName, options);
     }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorReferencingLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorReferencingLibrary.cql
@@ -1,0 +1,5 @@
+library SyntaxErrorReferencingLibrary
+
+include SyntaxErrorWithLibrary
+
+define Test: this is a syntax error referencing a library with a syntax error

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorWithLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorWithLibrary.cql
@@ -1,0 +1,3 @@
+library SyntaxErrorWithLibrary version '1.0.0'
+
+define Test: this is a syntax error with a library declaration

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorWithNoLibrary.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/SyntaxErrorWithNoLibrary.cql
@@ -1,0 +1,1 @@
+define Test: This is a syntax error with no library declaration


### PR DESCRIPTION
…an the source library context. Syntax errors will now be reported with "Anonymous" if there is no source library, or with the name of the source file if it can be inferred from the translator construction. Users of the translator can also provide sourceinfo if they know it.