### PR TITLE
Closing unclosed extension tag

### DIFF
--- a/Src/cql-lm/schema/elm/types.xsd
+++ b/Src/cql-lm/schema/elm/types.xsd
@@ -27,7 +27,7 @@
 					<xs:element name="codes" type="Code" minOccurs="1" maxOccurs="unbounded"/>
 					<xs:element name="display" type="String" minOccurs="0" maxOccurs="1"/>
 				</xs:sequence>
-			<xs:extension>
+			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="Vocabulary" abstract="true">


### PR DESCRIPTION
The types.xsd file has an unclosed tag - this causes an error while trying to parse the xsd (atleast on some parsers). 

Introduced in #542 