### PR TITLE
#570: Fixed targetQualifier incorrectly declared as a QName

### DIFF
--- a/Src/cql-lm/schema/model/modelinfo.xsd
+++ b/Src/cql-lm/schema/model/modelinfo.xsd
@@ -102,7 +102,7 @@
 				<xs:documentation>The schemaLocation attribute is used by the CQL translator to output the schemaLocation of the xsd for the data model in the resulting ELM document.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="targetQualifier" type="xs:QName" use="optional">
+		<xs:attribute name="targetQualifier" type="xs:string" use="optional">
 			<xs:annotation>
 				<xs:documentation>The targetQualifier attribute is used to specify the namespace qualifier that should be used when referencing types of the model within the ELM document.</xs:documentation>
 			</xs:annotation>

--- a/Src/java/tools/xsd-to-modelinfo/src/main/java/org/cqframework/cql/tools/xsd2modelinfo/Main.java
+++ b/Src/java/tools/xsd-to-modelinfo/src/main/java/org/cqframework/cql/tools/xsd2modelinfo/Main.java
@@ -88,7 +88,7 @@ public class Main {
         File outputfile;
         if (! options.has(outputOpt) || outputOpt.value(options).isDirectory()) {
             // construct output filename using modelinfo
-            String name = String.format("%s-modelinfo.xml", modelInfo.getTargetQualifier().getLocalPart());
+            String name = String.format("%s-modelinfo.xml", modelInfo.getTargetQualifier());
             String basePath = options.has(outputOpt) ? outputOpt.value(options).getAbsolutePath() : schemaFile.getParent();
             outputfile = new File(basePath + File.separator + name);
         } else {

--- a/Src/java/tools/xsd-to-modelinfo/src/main/java/org/cqframework/cql/tools/xsd2modelinfo/ModelImporter.java
+++ b/Src/java/tools/xsd-to-modelinfo/src/main/java/org/cqframework/cql/tools/xsd2modelinfo/ModelImporter.java
@@ -88,7 +88,7 @@ public class ModelImporter {
 
         return new ModelInfo()
                 .withName(options.getModel())
-                .withTargetQualifier(new QName(options.getModel().toLowerCase()))
+                .withTargetQualifier(options.getModel().toLowerCase())
                 .withUrl(schema.getTargetNamespace())
                 .withPatientClassName(config != null ? config.getPatientClassName() : null)
                 .withPatientClassIdentifier(config != null ? config.getPatientClassIdentifier() : null)


### PR DESCRIPTION
Although this is not, strictly speaking, a backwards compatible change, at this point the only actual usages of ModelInfo I am aware of are in the translator itself. Looking for confirmation of this as part of this review.