### PR TITLE
Add getModelManager

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -70,7 +70,6 @@ public class CqlTranslator {
     private NamespaceInfo namespaceInfo = null;
     private ModelManager modelManager = null;
     private LibraryManager libraryManager = null;
-    private CqlTranslatorException.ErrorSeverity errorLevel = CqlTranslatorException.ErrorSeverity.Info;
     private UcumService ucumService = null;
 
     public static CqlTranslator fromText(String cqlText, ModelManager modelManager, LibraryManager libraryManager, CqlTranslator.Options... options) {
@@ -364,7 +363,6 @@ public class CqlTranslator {
         this.modelManager = modelManager;
         this.libraryManager = libraryManager;
         this.ucumService = ucumService;
-        this.errorLevel = options.getErrorLevel();
 
         if (this.sourceInfo == null) {
             this.sourceInfo = new VersionedIdentifier().withId("Anonymous").withSystem("text/cql");

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -1,7 +1,5 @@
 package org.cqframework.cql.cql2elm;
 
-import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.fhir.ucum.UcumService;
 import org.hl7.elm.r1.VersionedIdentifier;
@@ -37,6 +35,10 @@ public class LibraryManager {
         libraries = new HashMap<>();
         translationStack = new Stack<>();
         this.librarySourceLoader = new PriorityLibrarySourceLoader();
+    }
+
+    public ModelManager getModelManager(){
+        return this.modelManager;
     }
 
     public NamespaceManager getNamespaceManager() {


### PR DESCRIPTION
* Removes dead ErrorSeverity code
* Adds getModelManager to the LibraryManager API, which simplifies some downstream code that has to pass both around.