### PR TITLE
add attributes to enable processing of claims CQL

### DIFF
--- a/Src/java/quick/src/main/resources/org/hl7/fhir/quick-modelinfo.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/quick-modelinfo.xml
@@ -2442,8 +2442,7 @@
         <ns4:element name="rate" type="QUICK.Ratio"/>
         <ns4:element name="maxDosePerPeriod" type="QUICK.Ratio"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="QUICK.Claim" baseType="QUICK.DomainResource">
-        <ns4:element name="type" type="QUICK.ClaimType"/>
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="QUICK.Claim" retrievable="true" baseType="QUICK.DomainResource" identifier="claim-qicore-qicore-claim">        <ns4:element name="type" type="QUICK.ClaimType"/>
         <ns4:element name="identifier" type="list&lt;QUICK.Identifier&gt;"/>
         <ns4:element name="ruleset" type="System.Code"/>
         <ns4:element name="originalRuleset" type="System.Code"/>


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-66](https://jira.amida-tech.com/browse/SAR-66)
- [ORDER-66](https://media.giphy.com/media/MYjD5GZDTwiZy/giphy.gif)

# Other Repos' PR(s) Intended to Work With This PR

https://github.com/amida-tech/cql-execution/pull/1

# How Things Worked (or Didn't) Before This PR

There was no `claim.coffee` file (in the `fhir` directory), so if claim data needed to be processed, it couldn't be.

# How Things Work Now (And How to Test)
I added `src/fhir/claim.coffee` to support claim processing, and modified `src/fhir/core.coffee` to support the creation of a diagnosis object. 

Additionally, this repo contains the CQL file to filter a claim by a diagnosis of diabetes (`CQL/claim.cql`), the processed JSON-ELM version of this CQL file (`src/claim.coffee` - which isn't 100% necessary as it can be generated, but thought it might be good to have so a tester doesn't have to generate it manually if they don't need to), and the execution file that includes dummy data (`src/claim-exec.coffee`) as well as debug config to debug the execution of the CQL query.
 
I also threw in a new PR template that will better match our needs in this forked repo

<!-- Include test setup, testing steps, and expected results -->
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->

## To Test This PR Independently
Install coffeescript - `npm install --global coffeescript`
run `yarn`
`cd lib`
run `cake build && node claim-exec.js`
You'll see this message for a minute before anything happens `Completed transpiling src to lib, exit code 0`
You should get this result:
```
done
Results {
  patientResults: {
    '2': { Patient: [Patient], DiagnosisIsDiabetes: [Array] },
    '40d2066e-9037-763e-2bb3-c7e4b20a79d9': { Patient: [Patient], DiagnosisIsDiabetes: [] }
  },
  unfilteredResults: {},
  localIdPatientResultsMap: {
    '2': { AgeAtMP: {} },
    '40d2066e-9037-763e-2bb3-c7e4b20a79d9': { AgeAtMP: {} }
  }
}
```
If you want to be really thorough, you can see that the diagnosis is 'Diabetes' by adding this console log to the bottom of `src/claim-exec.coffee` (`console.log(result.patientResults["2"]["DiagnosisIsDiabetes"][0].json.diagnosis)`)

## Test this in conjunction with 

