### PR TITLE
Feature shared serialization functions

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -57,6 +57,7 @@ public class CqlTranslator {
     }
     public static enum Format { XML, JSON, JXSON, COFFEE }
     private static JAXBContext jaxbContext;
+    private static ObjectMapper jxsonMapper;
 
     private Library library = null;
     private TranslatedLibrary translatedLibrary = null;
@@ -519,6 +520,19 @@ public class CqlTranslator {
         return jaxbContext;
     }
 
+    public static ObjectMapper getJxsonMapper() {
+        if (jxsonMapper == null) {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
+            mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+            JaxbAnnotationModule annotationModule = new JaxbAnnotationModule();
+            mapper.registerModule(annotationModule);
+            jxsonMapper = mapper;
+        }
+
+        return jxsonMapper;
+    }
+
     private class CqlErrorListener extends BaseErrorListener {
 
         private LibraryBuilder builder;
@@ -614,7 +628,7 @@ public class CqlTranslator {
         messages.addAll(builder.getMessages());
     }
 
-    public String convertToXml(Library library) throws JAXBException {
+    public static String convertToXml(Library library) throws JAXBException {
         Marshaller marshaller = getJaxbContext().createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
@@ -643,7 +657,7 @@ public class CqlTranslator {
         */
     }
 
-    public String convertToJson(Library library) throws JAXBException {
+    public static String convertToJson(Library library) throws JAXBException {
         Marshaller marshaller = getJaxbContext().createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
         marshaller.setProperty("eclipselink.media-type", "application/json");
@@ -653,15 +667,10 @@ public class CqlTranslator {
         return writer.getBuffer().toString();
     }
 
-    public String convertToJxson(Library library) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_DEFAULT);
-        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        JaxbAnnotationModule annotationModule = new JaxbAnnotationModule();
-        mapper.registerModule(annotationModule);
+    public static String convertToJxson(Library library) throws JsonProcessingException {
         LibraryWrapper wrapper = new LibraryWrapper();
         wrapper.setLibrary(library);
-        return mapper.writeValueAsString(wrapper);
+        return getJxsonMapper().writeValueAsString(wrapper);
     }
 
     public static void loadModelInfo(File modelInfoXML) {


### PR DESCRIPTION
* Made serialization functions of the translator public

The rationale for the change is that this code is duplicated frequently throughout the cql-related codebases (cql-engine, cql-evaluator, cql-ruler) where ever an ELM library needs to be serialized. Most of the other projects are not configured the same way (a specific example is handing the XML 1.0->1.1 replacement) leading to some cases of differences between the serialized ELM being generated by the cql-translator itself and the other libraries.