### PR TITLE
Add line break after comment in annotation narrative

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -2,9 +2,9 @@ package org.cqframework.cql.cql2elm;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.misc.*;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.commons.lang3.StringUtils;
 import org.cqframework.cql.cql2elm.model.invocation.*;
 import org.cqframework.cql.cql2elm.preprocessor.*;
 import org.cqframework.cql.elm.tracking.*;
@@ -468,6 +468,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 chunkContent = chunkContent.trim();
             }
             chunkContent = normalizeWhitespace(chunkContent);
+            chunkContent = makeSeparationBetweenCommentAndDefinition(chunkContent);
             narrative.getContent().add(chunkContent);
         }
 
@@ -476,6 +477,13 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
     private String normalizeWhitespace(String input) {
         return input.replace("\r\n", "\n");
+    }
+
+    private String makeSeparationBetweenCommentAndDefinition(String input) {
+        if(StringUtils.startsWith(input, "//") || StringUtils.endsWith(input, "*/")) {
+            return input + "\n";
+        }
+        return input;
     }
 
     private boolean hasChunks(Narrative narrative) {


### PR DESCRIPTION
Referring issue : https://github.com/cqframework/clinical_quality_language/issues/657

Actually it is not an issue as it has been described, as the reporter state "...which causes the define declaration to appear commented out in the ELM". 
Actually translator renders the define declaration good.
When translator option EnableNarrative is on, in the annotation narrative it includes comments and function definitions which is normal. 

In this PR, added a line break between comment and definition for clarity. The output is as below:

![image](https://user-images.githubusercontent.com/31050924/135503406-d4ad9f6b-2c18-4fb6-99f7-5947cd16bc66.png)
