### PR TITLE
#707: Fixed several issues related to backwards compatibility with 1.…

### DIFF
--- a/Src/cql-lm/schema/elm/clinicalexpression.xsd
+++ b/Src/cql-lm/schema/elm/clinicalexpression.xsd
@@ -476,6 +476,7 @@ Note that the recommended approach to statically binding to an expansion set is 
 			<xs:extension base="Expression">
 				<xs:attribute name="name" type="xs:string"/>
 				<xs:attribute name="libraryName" type="xs:string" use="optional"/>
+				<xs:attribute name="preserve" type="xs:boolean" use="optional"/>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
@@ -598,6 +599,18 @@ The second argument is expected to be of type ValueSet. When this argument is st
 					<xs:element name="valuesetExpression" type="Expression" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExpandValueSet">
+		<xs:annotation>
+			<xs:documentation>The ExpandValueSet operator returns the current expansion for the given value set.
+
+The operation exoects a single argument of type ValueSet. This may be a static reference to a value set (i.e. a ValueSetRef), or a ValueSet value to support dynamic value set usage. The operation is used as the implicit conversion from a ValueSet reference to a list of codes.
+
+If the argument is null, the result is null.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="UnaryExpression"/>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="Subsumes">

--- a/Src/cql-lm/schema/elm/types.xsd
+++ b/Src/cql-lm/schema/elm/types.xsd
@@ -36,13 +36,18 @@
 				<xs:sequence>
 					<xs:element name="id" type="String" minOccurs="1" maxOccurs="1"/>
 					<xs:element name="version" type="String" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="name" type="String" minOccurs="0" maxOccurs="1"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="ValueSet">
 		<xs:complexContent>
-			<xs:extension base="Vocabulary"/>
+			<xs:extension base="Vocabulary">
+				<xs:sequence>
+					<xs:element name="codesystem" type="CodeSystem" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<xs:complexType name="CodeSystem">

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
@@ -230,7 +230,8 @@ public class SystemFunctionResolver {
                 case "Exists":
                 case "Flatten":
                 case "Collapse":
-                case "SingletonFrom": {
+                case "SingletonFrom":
+                case "ExpandValueSet": {
                     return resolveUnary(fun);
                 }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.java
@@ -744,6 +744,10 @@ public class SystemLibraryHelper {
         add(system, tb, new Operator("AnyInCodeSystem", new Signature(new ListType(systemModel.getCode()), systemModel.getCodeSystem()), systemModel.getBoolean()));
         add(system, tb, new Operator("AnyInCodeSystem", new Signature(new ListType(systemModel.getConcept()), systemModel.getCodeSystem()), systemModel.getBoolean()));
 
+        Operator expandValueSet = new Operator("ExpandValueSet", new Signature(systemModel.getValueSet()), new ListType(systemModel.getCode()));
+        add(system, tb, expandValueSet);
+        add(system, tb, new Conversion(expandValueSet, true));
+
         add(system, tb, new Operator("Subsumes", new Signature(systemModel.getCode(), systemModel.getCode()), systemModel.getBoolean()));
         add(system, tb, new Operator("Subsumes", new Signature(systemModel.getConcept(), systemModel.getConcept()), systemModel.getBoolean()));
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/AnyInCodeSystemInvocation.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/AnyInCodeSystemInvocation.java
@@ -21,10 +21,7 @@ public class AnyInCodeSystemInvocation extends OperatorExpressionInvocation {
     public Iterable<Expression> getOperands() {
         List<Expression> result = new ArrayList<>();
         result.add(((AnyInCodeSystem)expression).getCodes());
-        if (((AnyInCodeSystem)expression).getCodesystem() != null) {
-            result.add(((AnyInCodeSystem)expression).getCodesystem());
-        }
-        else {
+        if (((AnyInCodeSystem)expression).getCodesystemExpression() != null) {
             result.add(((AnyInCodeSystem)expression).getCodesystemExpression());
         }
         return result;
@@ -36,20 +33,13 @@ public class AnyInCodeSystemInvocation extends OperatorExpressionInvocation {
         for (Expression operand : operands) {
             switch (i) {
                 case 0: ((AnyInCodeSystem)expression).setCodes(operand); break;
-                case 1:
-                    if (operand instanceof CodeSystemRef) {
-                        ((AnyInCodeSystem)expression).setCodesystem((CodeSystemRef)operand);
-                    }
-                    else {
-                        ((AnyInCodeSystem)expression).setCodesystemExpression(operand);
-                    }
-                break;
+                case 1: ((AnyInCodeSystem)expression).setCodesystemExpression(operand); break;
             }
             i++;
         }
 
-        if (i != 2) {
-            throw new IllegalArgumentException("Binary operator expected");
+        if (i > 2) {
+            throw new IllegalArgumentException("Unary or binary operator expected");
         }
     }
 }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/AnyInValueSetInvocation.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/AnyInValueSetInvocation.java
@@ -20,10 +20,7 @@ public class AnyInValueSetInvocation extends OperatorExpressionInvocation {
     public Iterable<Expression> getOperands() {
         List<Expression> result = new ArrayList<>();
         result.add(((AnyInValueSet)expression).getCodes());
-        if (((AnyInValueSet)expression).getValueset() instanceof ValueSetRef) {
-            result.add(((AnyInValueSet)expression).getValueset());
-        }
-        else {
+        if (((AnyInValueSet)expression).getValuesetExpression() != null) {
             result.add(((AnyInValueSet)expression).getValuesetExpression());
         }
         return result;
@@ -35,21 +32,13 @@ public class AnyInValueSetInvocation extends OperatorExpressionInvocation {
         for (Expression operand : operands) {
             switch (i) {
                 case 0: ((AnyInValueSet)expression).setCodes(operand); break;
-                case 1:
-                    if (operand instanceof ValueSetRef) {
-                        ((AnyInValueSet)expression).setValueset((ValueSetRef)operand);
-                    }
-                    else {
-                        ((AnyInValueSet)expression).setValuesetExpression(operand);
-                    }
-                break;
+                case 1: ((AnyInValueSet)expression).setValuesetExpression(operand); break;
             }
             i++;
         }
 
-        if (i != 2) {
-            throw new IllegalArgumentException("Binary operator expected");
+        if (i > 2) {
+            throw new IllegalArgumentException("Unary or binary operator expected");
         }
-        //((AnyInValueSet) expression).setCodes(assertAndGetSingleOperand(operands));
     }
 }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/InCodeSystemInvocation.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/InCodeSystemInvocation.java
@@ -18,10 +18,7 @@ public class InCodeSystemInvocation extends OperatorExpressionInvocation {
     public Iterable<Expression> getOperands() {
         List<Expression> result = new ArrayList<>();
         result.add(((InCodeSystem)expression).getCode());
-        if (((InCodeSystem)expression).getCodesystem() instanceof CodeSystemRef) {
-            result.add(((InCodeSystem)expression).getCodesystem());
-        }
-        else {
+        if (((InCodeSystem)expression).getCodesystemExpression() != null) {
             result.add(((InCodeSystem)expression).getCodesystemExpression());
         }
         return result;
@@ -33,20 +30,13 @@ public class InCodeSystemInvocation extends OperatorExpressionInvocation {
         for (Expression operand : operands) {
             switch (i) {
                 case 0: ((InCodeSystem)expression).setCode(operand); break;
-                case 1:
-                    if (operand instanceof CodeSystemRef) {
-                        ((InCodeSystem)expression).setCodesystem((CodeSystemRef)operand);
-                    }
-                    else {
-                        ((InCodeSystem)expression).setCodesystemExpression(operand);
-                    }
-                break;
+                case 1: ((InCodeSystem)expression).setCodesystemExpression(operand); break;
             }
             i++;
         }
 
-        if (i != 2) {
-            throw new IllegalArgumentException("Binary operator expected");
+        if (i > 2) {
+            throw new IllegalArgumentException("Unary or binary operator expected");
         }
     }
 }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/InValueSetInvocation.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/model/invocation/InValueSetInvocation.java
@@ -17,10 +17,7 @@ public class InValueSetInvocation extends OperatorExpressionInvocation {
     public Iterable<Expression> getOperands() {
         List<Expression> result = new ArrayList<>();
         result.add(((InValueSet)expression).getCode());
-        if (((InValueSet)expression).getValueset() instanceof ValueSetRef) {
-            result.add(((InValueSet)expression).getValueset());
-        }
-        else {
+        if (((InValueSet)expression).getValuesetExpression() != null) {
             result.add(((InValueSet)expression).getValuesetExpression());
         }
         return result;
@@ -32,21 +29,13 @@ public class InValueSetInvocation extends OperatorExpressionInvocation {
         for (Expression operand : operands) {
             switch (i) {
                 case 0: ((InValueSet)expression).setCode(operand); break;
-                case 1:
-                    if (operand instanceof ValueSetRef) {
-                        ((InValueSet)expression).setValueset((ValueSetRef)operand);
-                    }
-                    else {
-                        ((InValueSet)expression).setValuesetExpression(operand);
-                    }
-                break;
+                case 1: ((InValueSet)expression).setValuesetExpression(operand); break;
             }
             i++;
         }
 
-        if (i != 2) {
-            throw new IllegalArgumentException("Binary operator expected");
+        if (i > 2) {
+            throw new IllegalArgumentException("Unary or binary operator expected");
         }
-        //((InValueSet) expression).setCode(assertAndGetSingleOperand(operands));
     }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146ElmTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146ElmTest.java
@@ -53,31 +53,31 @@ public class CMS146ElmTest {
                         .withTemplateId("condition-qicore-qicore-condition")
                         .withCodeProperty("code")
                         .withCodeComparator("in")
-                        .withCodes(of.createValueSetRef().withName("Acute Pharyngitis")),
+                        .withCodes(of.createValueSetRef().withName("Acute Pharyngitis").withPreserve(true)),
                 of.createRetrieve()
                         .withDataType(quickDataType("Condition"))
                         .withTemplateId("condition-qicore-qicore-condition")
                         .withCodeProperty("code")
                         .withCodeComparator("in")
-                        .withCodes(of.createValueSetRef().withName("Acute Tonsillitis")),
+                        .withCodes(of.createValueSetRef().withName("Acute Tonsillitis").withPreserve(true)),
                 of.createRetrieve()
                         .withDataType(quickDataType("MedicationPrescription"))
                         .withTemplateId("medicationprescription-qicore-qicore-medicationprescription")
                         .withCodeProperty("medication.code")
                         .withCodeComparator("in")
-                        .withCodes(of.createValueSetRef().withName("Antibiotic Medications")),
+                        .withCodes(of.createValueSetRef().withName("Antibiotic Medications").withPreserve(true)),
                 of.createRetrieve()
                         .withDataType(quickDataType("Encounter"))
                         .withTemplateId("encounter-qicore-qicore-encounter")
                         .withCodeProperty("type")
                         .withCodeComparator("in")
-                        .withCodes(of.createValueSetRef().withName("Ambulatory/ED Visit")),
+                        .withCodes(of.createValueSetRef().withName("Ambulatory/ED Visit").withPreserve(true)),
                 of.createRetrieve()
                         .withDataType(quickDataType("Observation"))
                         .withTemplateId("observation-qicore-qicore-observation")
                         .withCodeProperty("code")
                         .withCodeComparator("in")
-                        .withCodes(of.createValueSetRef().withName("Group A Streptococcus Test"))
+                        .withCodes(of.createValueSetRef().withName("Group A Streptococcus Test").withPreserve(true))
         );
 
         assertThat(actualCR, is(expectedCR));

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected.json
@@ -240,6 +240,7 @@
             "type" : "Retrieve",
             "codes" : {
               "name" : "Acute Pharyngitis",
+              "preserve" : true,
               "type" : "ValueSetRef"
             }
           }, {
@@ -250,6 +251,7 @@
             "type" : "Retrieve",
             "codes" : {
               "name" : "Acute Tonsillitis",
+              "preserve" : true,
               "type" : "ValueSetRef"
             }
           } ]
@@ -266,6 +268,7 @@
           "type" : "Retrieve",
           "codes" : {
             "name" : "Antibiotic Medications",
+            "preserve" : true,
             "type" : "ValueSetRef"
           }
         }
@@ -285,6 +288,7 @@
               "type" : "Retrieve",
               "codes" : {
                 "name" : "Ambulatory/ED Visit",
+                "preserve" : true,
                 "type" : "ValueSetRef"
               }
             }
@@ -560,6 +564,7 @@
                 "type" : "Retrieve",
                 "codes" : {
                   "name" : "Group A Streptococcus Test",
+                  "preserve" : true,
                   "type" : "ValueSetRef"
                 }
               }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestVSCastFunction.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestVSCastFunction.cql
@@ -1,0 +1,30 @@
+library TestVSCastFunction
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1'
+
+valueset "Narcolepsy": 'https://example.org/fhir/ValueSet/narcolepsy'
+
+define function "VS Cast Function"(VSet List<System.Code>):
+  ( ( cast { "VSet", 1 }[0]as Tuple {
+      codes List<System.Code>,
+      oid System.String,
+      version System.String
+    }
+  ).codes ) VSetCodes
+    return System.Code { code: VSetCodes.code, system: VSetCodes.system }
+
+define function "Conditions in ValueSet"(conditions List<Condition>, codes List<System.Code>):
+  conditions C
+    where FHIRHelpers.ToConcept(C.code) in codes
+
+define TestConditions:
+  [Condition] C
+    where C.code in "Narcolepsy"
+
+define TestConditionsViaFunction:
+  "Conditions in ValueSet"([Condition], "VS Cast Function"("Narcolepsy"))
+
+define TestConditionsDirectly:
+  "Conditions in ValueSet"([Condition], "Narcolepsy")


### PR DESCRIPTION
…4 and the new terminology types:

1. In 1.4 compatibility mode, a reference to a `codesystem` or `valueset` declaration is typed as a `List<Code>`, rather than the `ValueSet` or `CodeSystem` types introduced in 1.5.
2. In 1.4 compatibility mode, references to the new terminology types results in a compile-time error.
3. In 1.4 compatibility mode, terminology membership operators can only be resolved with references to `codesystem` or `valueset` declarations
4. In 1.5 or greater, a `ValueSetRef` will be output with the new `preserve` attribute set to true.

For a more detailed discussion, see https://github.com/cqframework/CQL-Formatting-and-Usage-Wiki/wiki/Implementing-the-CQL-1.5-Terminology-Types