### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: openjdk11
 script:
 - export TERM=dumb
 - "./Src/java/gradlew --version"
-- "./Src/java/gradlew --no-daemon -b ./Src/java/build.gradle check"
+- "./Src/java/gradlew -b ./Src/java/build.gradle check"
 branches:
   only:
   - master


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
