### PR TITLE
Using Jackson's XML reader instead of JAXB.unmarshal for ModelInfo files

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -127,7 +127,10 @@ configure(subprojects.findAll {it.name in ['model', 'elm', 'quick', 'qdm', 'cql-
         xjc group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
         compile group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics', version: '0.12.0'
         compile group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
+        compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2'
+        compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
         compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.2'
+        compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
         compile group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
     }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslator.java
@@ -25,6 +25,7 @@ import org.hl7.elm.r1.ObjectFactory;
 import org.hl7.elm.r1.Retrieve;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 import javax.xml.bind.*;
 import java.io.*;
@@ -668,12 +669,17 @@ public class CqlTranslator {
         return getJxsonMapper().writeValueAsString(wrapper);
     }
 
-    public static void loadModelInfo(File modelInfoXML) {
-        final ModelInfo modelInfo = JAXB.unmarshal(modelInfoXML, ModelInfo.class);
-        final VersionedIdentifier modelId = new VersionedIdentifier().withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-        final ModelInfoProvider modelProvider = (VersionedIdentifier modelIdentifier) -> modelInfo;
-        final ModelInfoLoader modelInfoLoader = new ModelInfoLoader();
-        modelInfoLoader.registerModelInfoProvider(modelProvider);
+    public static void loadModelInfo(File modelInfoXML)  {
+        try {
+            final ModelInfo modelInfo = JacksonXML.readValue(modelInfoXML, ModelInfo.class);
+            final VersionedIdentifier modelId = new VersionedIdentifier().withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+            final ModelInfoProvider modelProvider = (VersionedIdentifier modelIdentifier) -> modelInfo;
+            final ModelInfoLoader modelInfoLoader = new ModelInfoLoader();
+            modelInfoLoader.registerModelInfoProvider(modelProvider);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
     }
 
     private static void outputExceptions(Iterable<CqlTranslatorException> exceptions) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.java
@@ -3,8 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.cqframework.cql.cql2elm.model.Version;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
-import javax.xml.bind.JAXB;
 import java.io.*;
 import java.nio.file.Path;
 
@@ -81,11 +81,13 @@ public class DefaultModelInfoProvider implements ModelInfoProvider {
         try {
             if (modelFile != null) {
                 InputStream is = new FileInputStream(modelFile);
-                return JAXB.unmarshal(is, ModelInfo.class);
+
+                return JacksonXML.readValue(is, ModelInfo.class);
             }
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
+            e.printStackTrace();
             throw new IllegalArgumentException(String.format("Could not load definition for model info %s.", modelIdentifier.getId()), e);
-        }
+        } 
 
         return null;
     }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.java
@@ -3,7 +3,6 @@ package org.cqframework.cql.cql2elm;
 import org.cqframework.cql.cql2elm.model.Version;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 import java.io.*;
 import java.nio.file.Path;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/FhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/FhirModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 4/15/2016.
@@ -27,47 +28,53 @@ public class FhirModelInfoProvider implements ModelInfoProvider, NamespaceAware 
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isFHIRModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "1.0.2":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.0.2.xml"),
-                            ModelInfo.class);
+            try { 
+                switch (localVersion) {
+                    case "1.0.2":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.0.2.xml"),
+                                ModelInfo.class);
 
-                case "1.4":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.4.xml"),
-                            ModelInfo.class);
+                    case "1.4":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.4.xml"),
+                                ModelInfo.class);
 
-                case "1.6":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.6.xml"),
-                            ModelInfo.class);
+                    case "1.6":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.6.xml"),
+                                ModelInfo.class);
 
-                case "1.8":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.8.xml"),
-                            ModelInfo.class);
+                    case "1.8":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.8.xml"),
+                                ModelInfo.class);
 
-                case "3.0.0":
-                case "":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.0.xml"),
-                            ModelInfo.class);
+                    case "3.0.0":
+                    case "":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.0.xml"),
+                                ModelInfo.class);
 
-                case "3.0.1":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.1.xml"),
-                            ModelInfo.class);
+                    case "3.0.1":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.1.xml"),
+                                ModelInfo.class);
 
-                case "3.2.0":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.2.0.xml"),
-                            ModelInfo.class);
+                    case "3.2.0":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.2.0.xml"),
+                                ModelInfo.class);
 
-                case "4.0.0":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.0.xml"),
-                            ModelInfo.class);
+                    case "4.0.0":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.0.xml"),
+                                ModelInfo.class);
 
-                case "4.0.1":
-                    return JAXB.unmarshal(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.1.xml"),
-                            ModelInfo.class);
+                    case "4.0.1":
+                        return JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.1.xml"),
+                                ModelInfo.class);
 
-                // Do not throw, allow other providers to return the model if known
-                //default:
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the FHIR model.", localVersion));
+                    // Do not throw, allow other providers to return the model if known
+                    //default:
+                    //    throw new IllegalArgumentException(String.format("Unknown version %s of the FHIR model.", localVersion));
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            // Do not throw, allow other providers to resolve
+            //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/FhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/FhirModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 4/15/2016.
@@ -73,8 +72,8 @@ public class FhirModelInfoProvider implements ModelInfoProvider, NamespaceAware 
                 }
             } catch (IOException e) {
                 e.printStackTrace();
-            // Do not throw, allow other providers to resolve
-            //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the Fhir model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
@@ -3,9 +3,7 @@ package org.cqframework.cql.cql2elm;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hl7.elm_modelinfo.r1.*;
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hl7.elm_modelinfo.r1.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,16 +40,12 @@ interface TypeInfoMixIn {}
 })
 interface TypeSpecifierMixIn {}
 
-/**
- * Waiting for a solution to this issue: https://github.com/FasterXML/jackson-databind/issues/2968
- */
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         defaultImpl = NamedTypeSpecifier.class)
 interface NamedTypeSpecifierMixIn {}
 
 public class JacksonXML {
-
     static XmlMapper mapper = new XmlMapper().builder()
             .defaultUseWrapper(false)
             .addMixIn(TypeInfo.class, TypeInfoMixIn.class)

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
@@ -1,0 +1,73 @@
+package org.cqframework.cql.cql2elm;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import org.hl7.elm_modelinfo.r1.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SimpleTypeInfo.class, name = "ns4:SimpleTypeInfo"),
+        @JsonSubTypes.Type(value = ClassInfo.class, name = "ns4:ClassInfo"),
+        @JsonSubTypes.Type(value = ChoiceTypeInfo.class, name = "ns4:ChoiceTypeInfo"),
+        @JsonSubTypes.Type(value = IntervalTypeInfo.class, name = "ns4:IntervalTypeInfo"),
+        @JsonSubTypes.Type(value = ListTypeInfo.class, name = "ns4:ListTypeInfo"),
+        @JsonSubTypes.Type(value = ProfileInfo.class, name = "ns4:ProfileInfo"),
+        @JsonSubTypes.Type(value = TupleTypeInfo.class, name = "ns4:TupleTypeInfo")
+})
+interface TypeInfoMixIn {}
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = NamedTypeSpecifier.class, name = "ns4:NamedTypeSpecifier"),
+        @JsonSubTypes.Type(value = ListTypeSpecifier.class, name = "ns4:ListTypeSpecifier"),
+        @JsonSubTypes.Type(value = IntervalTypeSpecifier.class, name = "ns4:IntervalTypeSpecifier"),
+        @JsonSubTypes.Type(value = ChoiceTypeSpecifier.class, name = "ns4:ChoiceTypeSpecifier"),
+        @JsonSubTypes.Type(value = ParameterTypeSpecifier.class, name = "ns4:ParameterTypeSpecifier"),
+        @JsonSubTypes.Type(value = BoundParameterTypeSpecifier.class, name = "ns4:BoundParameterTypeSpecifier"),
+        @JsonSubTypes.Type(value = TupleTypeSpecifier.class, name = "ns4:TupleTypeSpecifier")
+})
+interface TypeSpecifierMixIn {}
+
+/**
+ * Waiting for a solution to this issue: https://github.com/FasterXML/jackson-databind/issues/2968
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        defaultImpl = NamedTypeSpecifier.class)
+interface NamedTypeSpecifierMixIn {}
+
+
+public class JacksonXML {
+
+    static XmlMapper mapper = new XmlMapper().builder()
+            .defaultUseWrapper(false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .addMixIn(TypeInfo.class, TypeInfoMixIn.class)
+            .addMixIn(TypeSpecifier.class, TypeSpecifierMixIn.class)
+            .addMixIn(NamedTypeSpecifier.class, NamedTypeSpecifierMixIn.class)
+            .addModule(new JaxbAnnotationModule())
+            .build();
+
+    public static <T> T readValue(File src, Class<T> valueType) throws IOException {
+        return mapper.readValue(src, valueType);
+    }
+
+    public static <T> T readValue(InputStream src, Class<T> valueType) throws IOException {
+        return mapper.readValue(src, valueType);
+    }
+}

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/JacksonXML.java
@@ -2,11 +2,9 @@ package org.cqframework.cql.cql2elm;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.hl7.elm_modelinfo.r1.*;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,12 +47,10 @@ interface TypeSpecifierMixIn {}
         defaultImpl = NamedTypeSpecifier.class)
 interface NamedTypeSpecifierMixIn {}
 
-
 public class JacksonXML {
 
     static XmlMapper mapper = new XmlMapper().builder()
             .defaultUseWrapper(false)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .addMixIn(TypeInfo.class, TypeInfoMixIn.class)
             .addMixIn(TypeSpecifier.class, TypeSpecifierMixIn.class)
             .addMixIn(NamedTypeSpecifier.class, NamedTypeSpecifierMixIn.class)

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QICoreModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QICoreModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class QICoreModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -41,7 +40,7 @@ public class QICoreModelInfoProvider implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QI model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QICoreModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QICoreModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class QICoreModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -24,17 +25,23 @@ public class QICoreModelInfoProvider implements ModelInfoProvider {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isQICoreModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "4.0.0":
-                    return JAXB.unmarshal(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.0.0.xml"),
-                            ModelInfo.class);
-                case "4.1.0":
-                    return JAXB.unmarshal(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.0.xml"),
-                            ModelInfo.class);
-                case "4.1.1":
-                default:
-                    return JAXB.unmarshal(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.1.xml"),
-                            ModelInfo.class);
+            try {
+                switch (localVersion) {
+                    case "4.0.0":
+                        return JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.0.0.xml"),
+                                ModelInfo.class);
+                    case "4.1.0":
+                        return JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.0.xml"),
+                                ModelInfo.class);
+                    case "4.1.1":
+                    default:
+                        return JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.1.xml"),
+                                ModelInfo.class);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QdmModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QdmModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 2/3/2016.
@@ -61,10 +60,6 @@ public class QdmModelInfoProvider implements ModelInfoProvider, NamespaceAware {
                     case "":
                         return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.6.xml"),
                                 ModelInfo.class);
-    
-                    // Do not throw, allow other providers to resolve
-                    //default:
-                    //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QdmModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QdmModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 2/3/2016.
@@ -27,42 +28,48 @@ public class QdmModelInfoProvider implements ModelInfoProvider, NamespaceAware {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isQDMModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "4.1.2":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo.xml"),
-                            ModelInfo.class);
-                case "4.2":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.2.xml"),
-                            ModelInfo.class);
-                case "4.3":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.3.xml"),
-                            ModelInfo.class);
-                case "5.0":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.xml"),
-                            ModelInfo.class);
-                case "5.0.1":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.1.xml"),
-                            ModelInfo.class);
-                case "5.0.2":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.2.xml"),
-                            ModelInfo.class);
-                case "5.3":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.3.xml"),
-                            ModelInfo.class);
-                case "5.4":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.4.xml"),
-                            ModelInfo.class);
-                case "5.5":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.5.xml"),
-                            ModelInfo.class);
-                case "5.6":
-                case "":
-                    return JAXB.unmarshal(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.6.xml"),
-                            ModelInfo.class);
-
-                // Do not throw, allow other providers to resolve
-                //default:
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            try {
+                switch (localVersion) {
+                    case "4.1.2":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo.xml"),
+                                ModelInfo.class);
+                    case "4.2":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.2.xml"),
+                                ModelInfo.class);
+                    case "4.3":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.3.xml"),
+                                ModelInfo.class);
+                    case "5.0":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.xml"),
+                                ModelInfo.class);
+                    case "5.0.1":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.1.xml"),
+                                ModelInfo.class);
+                    case "5.0.2":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.2.xml"),
+                                ModelInfo.class);
+                    case "5.3":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.3.xml"),
+                                ModelInfo.class);
+                    case "5.4":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.4.xml"),
+                                ModelInfo.class);
+                    case "5.5":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.5.xml"),
+                                ModelInfo.class);
+                    case "5.6":
+                    case "":
+                        return JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.6.xml"),
+                                ModelInfo.class);
+    
+                    // Do not throw, allow other providers to resolve
+                    //default:
+                    //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            // Do not throw, allow other providers to resolve
+            //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickFhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickFhirModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 4/15/2016.
@@ -27,15 +28,22 @@ public class QuickFhirModelInfoProvider implements ModelInfoProvider {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isQuickFhirModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "3.0.1":
-                case "":
-                    return JAXB.unmarshal(QuickFhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quickfhir-modelinfo-3.0.1.xml"),
-                            ModelInfo.class);
-
-                //default:
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QUICKFHIR model.", localVersion));
+            try {
+                switch (localVersion) {
+                    case "3.0.1":
+                    case "":
+                        return JacksonXML.readValue(QuickFhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quickfhir-modelinfo-3.0.1.xml"),
+                                ModelInfo.class);
+    
+                    //default:
+                    //    throw new IllegalArgumentException(String.format("Unknown version %s of the QUICKFHIR model.", localVersion));
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
+
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickFhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickFhirModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * Created by Bryn on 4/15/2016.
@@ -34,14 +33,11 @@ public class QuickFhirModelInfoProvider implements ModelInfoProvider {
                     case "":
                         return JacksonXML.readValue(QuickFhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quickfhir-modelinfo-3.0.1.xml"),
                                 ModelInfo.class);
-    
-                    //default:
-                    //    throw new IllegalArgumentException(String.format("Unknown version %s of the QUICKFHIR model.", localVersion));
                 }
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QUICKFHIR model.", localVersion));
             }
 
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class QuickModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -41,7 +40,7 @@ public class QuickModelInfoProvider implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the Quick model.", localVersion));
             }
             
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class QuickModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -24,17 +25,25 @@ public class QuickModelInfoProvider implements ModelInfoProvider {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isQuickModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "3.3.0":
-                    return JAXB.unmarshal(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.3.0.xml"),
-                            ModelInfo.class);
-                case "3.0.0":
-                    return JAXB.unmarshal(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.0.0.xml"),
-                            ModelInfo.class);
-                default:
-                    return JAXB.unmarshal(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo.xml"),
-                            ModelInfo.class);
+            
+            try {
+                switch (localVersion) {
+                    case "3.3.0":
+                        return JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.3.0.xml"),
+                                ModelInfo.class);
+                    case "3.0.0":
+                        return JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.0.0.xml"),
+                                ModelInfo.class);
+                    default:
+                        return JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo.xml"),
+                                ModelInfo.class);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
+            
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/QuickModelInfoProvider.java
@@ -40,7 +40,7 @@ public class QuickModelInfoProvider implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the Quick model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the Fhir model.", localVersion));
             }
             
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemModelInfoProvider.java
@@ -3,7 +3,7 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
 
 public class SystemModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -23,8 +23,15 @@ public class SystemModelInfoProvider implements ModelInfoProvider {
 
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isSystemModelIdentifier(modelIdentifier)) {
-            return JAXB.unmarshal(SystemModelInfoProvider.class.getResourceAsStream("/org/hl7/elm/r1/system-modelinfo.xml"),
-                    ModelInfo.class);
+            try {
+                return JacksonXML.readValue(SystemModelInfoProvider.class.getResourceAsStream("/org/hl7/elm/r1/system-modelinfo.xml"),
+                ModelInfo.class);
+            } catch (IOException e) {
+                System.out.println("oh no");
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            }
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemModelInfoProvider.java
@@ -27,10 +27,9 @@ public class SystemModelInfoProvider implements ModelInfoProvider {
                 return JacksonXML.readValue(SystemModelInfoProvider.class.getResourceAsStream("/org/hl7/elm/r1/system-modelinfo.xml"),
                 ModelInfo.class);
             } catch (IOException e) {
-                System.out.println("oh no");
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the System model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TranslatorOptionsUtil.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TranslatorOptionsUtil.java
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm;
 
-import org.eclipse.persistence.jaxb.json.JsonSchemaOutputResolver;
 import org.hl7.cql_annotations.r1.CqlToElmInfo;
 import org.hl7.elm.r1.Library;
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
@@ -38,7 +38,7 @@ public class UsCoreModelInfoProvider implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the Fhir model.", localVersion));
             }
             
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
@@ -4,7 +4,6 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import java.io.IOException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class UsCoreModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/UsCoreModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import java.io.IOException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class UsCoreModelInfoProvider implements ModelInfoProvider {
     private NamespaceManager namespaceManager;
@@ -24,15 +25,23 @@ public class UsCoreModelInfoProvider implements ModelInfoProvider {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (isUSCoreModelIdentifier(modelIdentifier)) {
             String localVersion = modelIdentifier.getVersion() == null ? "" : modelIdentifier.getVersion();
-            switch (localVersion) {
-                case "3.1.0":
-                    return JAXB.unmarshal(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.0.xml"),
-                            ModelInfo.class);
-                case "3.1.1":
-                default:
-                    return JAXB.unmarshal(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.1.xml"),
-                            ModelInfo.class);
+
+            try {
+                switch (localVersion) {
+                    case "3.1.0":
+                        return JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.0.xml"),
+                                ModelInfo.class);
+                    case "3.1.1":
+                    default:
+                        return JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.1.xml"),
+                                ModelInfo.class);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
             }
+            
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/JacksonModelInfoLoadingTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/JacksonModelInfoLoadingTests.java
@@ -1,0 +1,152 @@
+package org.cqframework.cql.cql2elm;
+
+import org.hl7.elm_modelinfo.r1.*;
+import org.testng.annotations.Test;
+import java.io.IOException;
+
+public class JacksonModelInfoLoadingTests {
+    @Test
+    public void testSystem() throws IOException {
+        JacksonXML.readValue(SystemModelInfoProvider.class.getResourceAsStream("/org/hl7/elm/r1/system-modelinfo.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testUSCore310() throws IOException {
+        JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testUSCore311() throws IOException {
+        JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/uscore-modelinfo-3.1.1.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQuickFhir301() throws IOException {
+        JacksonXML.readValue(QuickFhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quickfhir-modelinfo-3.0.1.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQuick330() throws IOException {
+        JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.3.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQuick300() throws IOException {
+        JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo-3.0.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQuick() throws IOException {
+        JacksonXML.readValue(QuickModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/quick-modelinfo.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQICore400() throws IOException {
+        JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.0.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQICore410() throws IOException {
+        JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQICore411() throws IOException {
+        JacksonXML.readValue(QICoreModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/qicore-modelinfo-4.1.1.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM420() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.2.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM430() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-4.3.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM500() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM501() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.1.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM502() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.0.2.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM530() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.3.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM540() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.4.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM550() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.5.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testQDM560() throws IOException {
+        JacksonXML.readValue(QdmModelInfoProvider.class.getResourceAsStream("/gov/healthit/qdm/qdm-modelinfo-5.6.xml"), ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo102() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.0.2.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo140() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.4.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo160() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.6.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo180() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-1.8.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo300() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.0.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo301() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.0.1.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo320() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-3.2.0.xml"),ModelInfo.class);
+    }
+
+    @Test
+    public void testFhirModelInfo400() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.0.xml"), ModelInfo.class);
+    }
+    
+    @Test
+    public void testFhirModelInfo401() throws IOException {
+        JacksonXML.readValue(FhirModelInfoProvider.class.getResourceAsStream("/org/hl7/fhir/fhir-modelinfo-4.0.1.xml"), ModelInfo.class);
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestFhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestFhirModelInfoProvider.java
@@ -3,7 +3,8 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.IOException;
 
 /**
  * Created by Bryn on 12/11/2016.
@@ -17,8 +18,15 @@ public class TestFhirModelInfoProvider implements ModelInfoProvider {
 
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (modelIdentifier.getId().equals("FHIR")) {
-            return JAXB.unmarshal(clazz.getResourceAsStream("fhir-modelinfo-1.8.xml"),
-                    ModelInfo.class);
+            try {
+                return JacksonXML.readValue(clazz.getResourceAsStream("fhir-modelinfo-1.8.xml"),
+                ModelInfo.class);
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            }
+
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestFhirModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestFhirModelInfoProvider.java
@@ -3,7 +3,6 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
 
 /**

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestModelInfoProvider.java
@@ -3,13 +3,20 @@ package org.cqframework.cql.cql2elm;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.IOException;
 
 public class TestModelInfoProvider implements ModelInfoProvider {
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (modelIdentifier.getId().equals("Test")) {
-            return JAXB.unmarshal(TestModelInfoProvider.class.getResourceAsStream("ModelTests/test-modelinfo.xml"),
-                    ModelInfo.class);
+            try {
+                return JacksonXML.readValue(TestModelInfoProvider.class.getResourceAsStream("ModelTests/test-modelinfo.xml"),
+                ModelInfo.class);
+            } catch (IOException e) {
+            e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            }
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProvider.java
@@ -5,7 +5,6 @@ import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -19,7 +18,7 @@ public class GentestModelInfoProvider implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the GENTEST model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProvider.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProvider.java
@@ -1,18 +1,26 @@
 package org.cqframework.cql.cql2elm.model;
 
+import org.cqframework.cql.cql2elm.JacksonXML;
 import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.IOException;
 import java.io.InputStream;
 
 public class GentestModelInfoProvider implements ModelInfoProvider {
     @Override
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (modelIdentifier.getId().equals("GENTEST")) {
-            InputStream is = GentestModelInfoProvider.class.getResourceAsStream("/org/cqframework/cql/cql2elm/ModelTests/test-modelinfowithgenerics-happy.xml");
-            return JAXB.unmarshal(is, ModelInfo.class);
+            try {
+                InputStream is = GentestModelInfoProvider.class.getResourceAsStream("/org/cqframework/cql/cql2elm/ModelTests/test-modelinfowithgenerics-happy.xml");
+                return JacksonXML.readValue(is, ModelInfo.class);
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            }
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProviderSad1.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProviderSad1.java
@@ -1,18 +1,26 @@
 package org.cqframework.cql.cql2elm.model;
 
+import org.cqframework.cql.cql2elm.JacksonXML;
 import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import javax.xml.bind.JAXB;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.IOException;
 import java.io.InputStream;
 
 public class GentestModelInfoProviderSad1 implements ModelInfoProvider {
     @Override
     public ModelInfo load(VersionedIdentifier modelIdentifier) {
         if (modelIdentifier.equals("GENTEST")) {
-            InputStream is = GentestModelInfoProviderSad1.class.getResourceAsStream("/org/cqframework/cql/cql2elm/ModelTests/test-modelinfowithgenerics-sad1.xml");
-            return JAXB.unmarshal(is, ModelInfo.class);
+            try { 
+                InputStream is = GentestModelInfoProviderSad1.class.getResourceAsStream("/org/cqframework/cql/cql2elm/ModelTests/test-modelinfowithgenerics-sad1.xml");
+                return JacksonXML.readValue(is, ModelInfo.class);
+            } catch (IOException e) {
+                e.printStackTrace();
+                // Do not throw, allow other providers to resolve
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+            }
         }
 
         return null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProviderSad1.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/model/GentestModelInfoProviderSad1.java
@@ -5,7 +5,6 @@ import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -19,7 +18,7 @@ public class GentestModelInfoProviderSad1 implements ModelInfoProvider {
             } catch (IOException e) {
                 e.printStackTrace();
                 // Do not throw, allow other providers to resolve
-                //    throw new IllegalArgumentException(String.format("Unknown version %s of the QDM model.", localVersion));
+                //    throw new IllegalArgumentException(String.format("Unknown version %s of the GENTEST model.", localVersion));
             }
         }
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/fhir/v18/fhir-modelinfo-1.8.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/fhir/v18/fhir-modelinfo-1.8.xml
@@ -2532,7 +2532,7 @@
     <ns4:typeInfo xsi:type="ns4:ClassInfo" name="NamingSystemIdentifierType" retrievable="false" baseType="FHIR.Element">
         <ns4:element name="value" type="System.String"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="List" retrievable="true" baseType="FHIR.DomainResource" primaryCocdePath="code">
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="List" retrievable="true" baseType="FHIR.DomainResource" primaryCodePath="code">
         <ns4:element name="identifier">
             <ns4:typeSpecifier xsi:type="ns4:ListTypeSpecifier" elementType="FHIR.Identifier"/>
         </ns4:element>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-1.8.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-1.8.xml
@@ -2532,7 +2532,7 @@
     <ns4:typeInfo xsi:type="ns4:ClassInfo" name="NamingSystemIdentifierType" retrievable="false" baseType="FHIR.Element">
         <ns4:element name="value" type="System.String"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="List" retrievable="true" baseType="FHIR.DomainResource" primaryCocdePath="code">
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="List" retrievable="true" baseType="FHIR.DomainResource" primaryCodePath="code">
         <ns4:element name="identifier">
             <ns4:typeSpecifier xsi:type="ns4:ListTypeSpecifier" elementType="FHIR.Identifier"/>
         </ns4:element>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.0.xml
@@ -2727,7 +2727,7 @@
         <ns4:element name="quantity" elementType="FHIR.Quantity"/>
         <ns4:element name="instruction" elementType="FHIR.string"/>
     </ns4:typeInfo>
-    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="PractitionerRole" retrievable="true" baseType="FHIR.DomainResource" primaryCOdePath="code">
+    <ns4:typeInfo xsi:type="ns4:ClassInfo" name="PractitionerRole" retrievable="true" baseType="FHIR.DomainResource" primaryCodePath="code">
         <ns4:element name="identifier">
             <ns4:elementTypeSpecifier xsi:type="ns4:ListTypeSpecifier" elementType="FHIR.Identifier"/>
         </ns4:element>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.1.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="FHIR" version="4.0.1" url="http://hl7.org/fhir" targetQualifier="fhir" patientClassName="FHIR.Patient" patientBirthDatePropertyName="birthDate.value">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Account" identifier="http://hl7.org/fhir/StructureDefinition/Account" label="Account" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Account" identifier="http://hl7.org/fhir/StructureDefinition/Account" label="Account" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Account number" definition="Unique identifier used to reference the account.  Might or might not be intended for human use (e.g. credit card number).">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -47,43 +47,43 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Account.Coverage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Account.Coverage" retrievable="false">
       <element name="coverage" elementType="FHIR.Reference" description="The party(s), such as insurances, that may contribute to the payment of this account" definition="The party(s) that contribute to payment (or part of) of the charges applied to this account (including self-pay).&#xa;&#xa;A coverage may only be responsible for specific types of charges, and the sequence of the coverages in the account could be important when processing billing."/>
       <element name="priority" elementType="FHIR.positiveInt" description="The priority of the coverage in the context of this account" definition="The priority of the coverage in the context of this account." comment="It is common in some jurisdictions for there to be multiple coverages allocated to an account, and a sequence is required to order the settling of the account (often with insurance claiming)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Account.Guarantor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Account.Guarantor" retrievable="false">
       <element name="party" elementType="FHIR.Reference" description="Responsible entity" definition="The entity who is responsible."/>
       <element name="onHold" elementType="FHIR.boolean" description="Credit or other hold applied" definition="A guarantor may be placed on credit hold or otherwise have their role temporarily suspended."/>
       <element name="period" elementType="FHIR.Period" description="Guarantee account during" definition="The timeframe during which the guarantor accepts responsibility for the account."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AccountStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AccountStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionCardinalityBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionCardinalityBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionConditionKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionConditionKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionGroupingBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionGroupingBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionParticipantType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionParticipantType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionPrecheckBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionPrecheckBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionRelationshipType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionRelationshipType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionRequiredBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionRequiredBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActionSelectionBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActionSelectionBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ActivityDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ActivityDefinition" label="ActivityDefinition" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ActivityDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ActivityDefinition" label="ActivityDefinition" retrievable="true" primaryCodePath="topic">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this activity definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this activity definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this activity definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the activity definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the activity definition" definition="A formal identifier that is used to identify this activity definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this activity definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -959,11 +959,11 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="publisher" path="publisher" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ActivityDefinition.DynamicValue" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ActivityDefinition.DynamicValue" retrievable="false">
       <element name="path" elementType="FHIR.string" description="The path to the element to be set dynamically" definition="The path to the element to be customized. This is the path on the resource that will hold the result of the calculation defined by the expression. The specified path SHALL be a FHIRPath resolveable on the specified target type of the ActivityDefinition, and SHALL consist only of identifiers, constant indexers, and a restricted subset of functions. The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details)." comment="The path attribute contains a [Simple FHIRPath Subset](fhirpath.html#simple) that allows path traversal, but not calculation."/>
       <element name="expression" elementType="FHIR.Expression" description="An expression that provides the dynamic value for the customization" definition="An expression specifying the value of the customized element." comment="The expression may be inlined, or may be a reference to a named expression within a logic library referenced by the library element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ActivityDefinition.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ActivityDefinition.Participant" retrievable="false">
       <element name="type" elementType="FHIR.ActivityParticipantType" description="patient | practitioner | related-person | device" definition="The type of participant in the action.">
          <binding name="ActivityParticipantType" description="The type of participant in the activity." strength="Required"/>
       </element>
@@ -971,13 +971,13 @@
          <binding name="ActivityParticipantRole" description="Defines roles played by participants for the action." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActivityDefinitionKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActivityDefinitionKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ActivityParticipantType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ActivityParticipantType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="FHIR.AddressUse" description="home | work | temp | old | billing - purpose of this address" definition="The purpose of this address." comment="Applications can assume that an address is current unless it explicitly says that it is temporary or old.">
          <binding name="AddressUse" description="The use of an address." strength="Required"/>
       </element>
@@ -995,16 +995,16 @@
       <element name="country" elementType="FHIR.string" description="Country (e.g. can be ISO 3166 2 or 3 letter code)" definition="Country - a nation as commonly understood or generally accepted." comment="ISO 3166 3 letter codes can be used in place of a human readable country name."/>
       <element name="period" elementType="FHIR.Period" description="Time period when address was/is in use" definition="Time period when address was/is in use."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AddressType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AddressType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AddressUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AddressUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AdministrativeGender" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="AdverseEvent" identifier="http://hl7.org/fhir/StructureDefinition/AdverseEvent" label="AdverseEvent" retrievable="true" primaryCodePath="event" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="AdverseEvent" identifier="http://hl7.org/fhir/StructureDefinition/AdverseEvent" label="AdverseEvent" retrievable="true" primaryCodePath="event">
       <element name="identifier" elementType="FHIR.Identifier" description="Business identifier for the event" definition="Business identifiers assigned to this adverse event by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number."/>
       <element name="actuality" elementType="FHIR.AdverseEventActuality" description="actual | potential" definition="Whether the event actually happened, or just had the potential to. Note that this is independent of whether anyone was affected or harmed or how severely.">
          <binding name="AdverseEventActuality" description="Overall nature of the adverse event, e.g. real or potential." strength="Required"/>
@@ -1090,13 +1090,13 @@
       <search name="category" path="category" type="System.Code"/>
       <search name="location" path="location" type="FHIR.Location"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AdverseEvent.SuspectEntity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AdverseEvent.SuspectEntity" retrievable="false">
       <element name="instance" elementType="FHIR.Reference" description="Refers to the specific entity that caused the adverse event" definition="Identifies the actual instance of what caused the adverse event.  May be a substance, medication, medication administration, medication statement or a device."/>
       <element name="causality" description="Information on the possible cause of the event" definition="Information on the possible cause of the event.">
          <elementTypeSpecifier elementType="FHIR.AdverseEvent.SuspectEntity.Causality" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AdverseEvent.SuspectEntity.Causality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AdverseEvent.SuspectEntity.Causality" retrievable="false">
       <element name="assessment" elementType="FHIR.CodeableConcept" description="Assessment of if the entity caused the event" definition="Assessment of if the entity caused the event.">
          <binding name="AdverseEventCausalityAssessment" description="Codes for the assessment of whether the entity caused the event." strength="Example"/>
       </element>
@@ -1106,14 +1106,14 @@
          <binding name="AdverseEventCausalityMethod" description="TODO." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AdverseEventActuality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AdverseEventActuality" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="Age" identifier="http://hl7.org/fhir/StructureDefinition/Age" label="Age" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AggregationMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AggregationMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="AllergyIntolerance" identifier="http://hl7.org/fhir/StructureDefinition/AllergyIntolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="AllergyIntolerance" identifier="http://hl7.org/fhir/StructureDefinition/AllergyIntolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External ids for this item" definition="Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1199,7 +1199,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="FHIR.CodeableConcept" description="Specific substance or pharmaceutical product considered to be responsible for event" definition="Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance." comment="Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, &quot;penicillins&quot;), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, &quot;amoxycillin&quot;). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.">
          <binding name="SubstanceCode" description="Codes defining the type of the substance (including pharmaceutical products)." strength="Example"/>
       </element>
@@ -1219,19 +1219,19 @@
          <elementTypeSpecifier elementType="FHIR.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceCategory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceCategory" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceCriticality" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceSeverity" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AllergyIntoleranceType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" description="Individual responsible for the annotation" definition="The individual responsible for making the annotation." comment="Organization is used when there's no need for specific attribution as to who made the comment.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -1241,7 +1241,7 @@
       <element name="time" elementType="FHIR.dateTime" description="When the annotation was made" definition="Indicates when this particular annotation was made."/>
       <element name="text" elementType="FHIR.markdown" description="The annotation  - text content (as markdown)" definition="The text of the annotation in markdown format."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Appointment" identifier="http://hl7.org/fhir/StructureDefinition/Appointment" label="Appointment" retrievable="true" primaryCodePath="serviceType" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Appointment" identifier="http://hl7.org/fhir/StructureDefinition/Appointment" label="Appointment" retrievable="true" primaryCodePath="serviceType">
       <element name="identifier" description="External Ids for this item" definition="This records identifiers associated with this appointment concern that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate (e.g. in CDA documents, or in written / printed documentation).">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1486,7 +1486,7 @@
       <search name="location" path="participant.actor.where(resolve() is Location)" type="FHIR.Location"/>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Appointment.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Appointment.Participant" retrievable="false">
       <element name="type" description="Role of participant in the appointment" definition="Role of participant in the appointment." comment="The role of the participant can be used to declare what the actor will be doing in the scope of this appointment.&#xd;&#xd;If the actor is not specified, then it is expected that the actor will be filled in at a later stage of planning.&#xd;&#xd;This value SHALL be the same when creating an AppointmentResponse so that they can be matched, and subsequently update the Appointment.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="ParticipantType" description="Role of participant in encounter." strength="Extensible"/>
@@ -1500,7 +1500,7 @@
       </element>
       <element name="period" elementType="FHIR.Period" description="Participation period of the actor" definition="Participation period of the actor."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="AppointmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/AppointmentResponse" label="AppointmentResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="AppointmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/AppointmentResponse" label="AppointmentResponse" retrievable="true">
       <element name="identifier" description="External Ids for this item" definition="This records identifiers associated with this appointment response concern that are defined by business processes and/ or used to refer to it when a direct URL reference to the resource itself is not appropriate.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1538,19 +1538,19 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AppointmentStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AppointmentStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AssertionDirectionType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AssertionDirectionType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AssertionOperatorType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AssertionOperatorType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AssertionResponseTypes" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AssertionResponseTypes" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="FHIR.MimeType" description="Mime type of the content, with charset etc." definition="Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.">
          <binding name="MimeType" description="The mime type of an attachment. Any valid mime type is allowed." strength="Required"/>
       </element>
@@ -1564,7 +1564,7 @@
       <element name="title" elementType="FHIR.string" description="Label to display in place of the data" definition="A label or set of text to display in place of the data."/>
       <element name="creation" elementType="FHIR.dateTime" description="Date attachment was first created" definition="The date that the attachment was first created."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="AuditEvent" identifier="http://hl7.org/fhir/StructureDefinition/AuditEvent" label="AuditEvent" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="AuditEvent" identifier="http://hl7.org/fhir/StructureDefinition/AuditEvent" label="AuditEvent" retrievable="true">
       <element name="type" elementType="FHIR.Coding" description="Type/identifier of event" definition="Identifier for a family of the event.  For example, a menu item, program, rule, policy, function code, application name or URL. It identifies the performed function.">
          <binding name="AuditEventType" description="Type of event." strength="Extensible"/>
       </element>
@@ -1783,7 +1783,7 @@
       <search name="altid" path="agent.altId" type="System.Code"/>
       <search name="outcome" path="outcome" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Agent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Agent" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="How agent participated" definition="Specification of the participation type the user plays when performing the event.">
          <binding name="AuditAgentType" description="The Participation type of the agent to the event." strength="Extensible"/>
       </element>
@@ -1808,13 +1808,13 @@
          <binding name="AuditPurposeOfUse" description="The reason the activity took place." strength="Extensible"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Agent.Network" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Agent.Network" retrievable="false">
       <element name="address" elementType="FHIR.string" description="Identifier for the network access point of the user device" definition="An identifier for the network access point of the user device for the audit event." comment="This could be a device id, IP address or some other identifier associated with a device."/>
       <element name="type" elementType="FHIR.AuditEventAgentNetworkType" description="The type of network access point" definition="An identifier for the type of network access point that originated the audit event.">
          <binding name="AuditEventAgentNetworkType" description="The type of network access point of this agent in the audit event." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Entity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Entity" retrievable="false">
       <element name="what" elementType="FHIR.Reference" description="Specific instance of resource" definition="Identifies a specific instance of the entity. The reference should be version specific."/>
       <element name="type" elementType="FHIR.Coding" description="Type of entity involved" definition="The type of the object that was involved in this audit event." comment="This value is distinct from the user's role or any user relationship to the entity.">
          <binding name="AuditEventEntityType" description="Code for the entity type involved in the audit event." strength="Extensible"/>
@@ -1836,7 +1836,7 @@
          <elementTypeSpecifier elementType="FHIR.AuditEvent.Entity.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Entity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Entity.Detail" retrievable="false">
       <element name="type" elementType="FHIR.string" description="Name of the property" definition="The type of extra detail provided in the value."/>
       <element name="value" description="Property value" definition="The  value of the extra detail." comment="The value can be string when known to be a string, else base64 encoding should be used to protect binary or undefined content.  The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, AuditEvent.entity.type, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1845,7 +1845,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Source" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="AuditEvent.Source" retrievable="false">
       <element name="site" elementType="FHIR.string" description="Logical source location within the enterprise" definition="Logical source location within the healthcare enterprise network.  For example, a hospital or other provider location within a multi-entity provider group."/>
       <element name="observer" elementType="FHIR.Reference" description="The identity of source detecting the event" definition="Identifier of the source where the event was detected."/>
       <element name="type" description="The type of source where event originated" definition="Code specifying the type of source where event originated.">
@@ -1853,21 +1853,21 @@
          <binding name="AuditEventSourceType" description="Code specifying the type of system that detected and recorded the event." strength="Extensible"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AuditEventAction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AuditEventAction" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AuditEventAgentNetworkType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AuditEventAgentNetworkType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="AuditEventOutcome" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="AuditEventOutcome" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension" description="Extensions that cannot be ignored even if unrecognized" definition="May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.&#xa;&#xa;Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself)." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="FHIR.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Basic" identifier="http://hl7.org/fhir/StructureDefinition/Basic" label="Basic" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Basic" identifier="http://hl7.org/fhir/StructureDefinition/Basic" label="Basic" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Identifier assigned to the resource for business purposes, outside the context of FHIR.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2044,17 +2044,17 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="code" path="code" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Resource" namespace="FHIR" name="Binary" identifier="http://hl7.org/fhir/StructureDefinition/Binary" label="Binary" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Resource" namespace="FHIR" name="Binary" identifier="http://hl7.org/fhir/StructureDefinition/Binary" label="Binary" retrievable="true">
       <element name="contentType" elementType="FHIR.MimeType" description="MimeType of the binary content" definition="MimeType of the binary content represented as a standard MimeType (BCP 13).">
          <binding name="MimeType" description="The mime type of an attachment. Any valid mime type is allowed." strength="Required"/>
       </element>
       <element name="securityContext" elementType="FHIR.Reference" description="Identifies another resource to use as proxy when enforcing access control" definition="This element identifies another resource that can be used as a proxy of the security sensitivity to use when deciding and enforcing access control rules for the Binary resource. Given that the Binary resource contains very few elements that can be used to determine the sensitivity of the data and relationships to individuals, the referenced resource stands in as a proxy equivalent for this purpose. This referenced resource may be related to the Binary (e.g. Media, DocumentReference), or may be some non-related Resource purely as a security proxy. E.g. to identify that the binary resource relates to a patient, and access should only be granted to applications that have access to the patient." comment="Very often, a server will also know of a resource that references the binary, and can automatically apply the appropriate access rules based on that reference. However, there are some circumstances where this is not appropriate, e.g. the binary is uploaded directly to the server without any linking resource, the binary is referred to from multiple different resources, and/or the binary is content such as an application logo that has less protection than any of the resources that reference it."/>
       <element name="data" elementType="FHIR.base64Binary" description="The actual content" definition="The actual content, base64 encoded." comment="If the content type is itself base64 encoding, then this will be base64 encoded twice - what is created by un-base64ing the content must be the specified content type."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BindingStrength" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BindingStrength" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="BiologicallyDerivedProduct" identifier="http://hl7.org/fhir/StructureDefinition/BiologicallyDerivedProduct" label="BiologicallyDerivedProduct" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="BiologicallyDerivedProduct" identifier="http://hl7.org/fhir/StructureDefinition/BiologicallyDerivedProduct" label="BiologicallyDerivedProduct" retrievable="true">
       <element name="identifier" description="External ids for this item" definition="This records identifiers associated with this biologically derived product instance that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate (e.g. in CDA documents, or in written / printed documentation).">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2083,7 +2083,7 @@
          <elementTypeSpecifier elementType="FHIR.BiologicallyDerivedProduct.Storage" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Collection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Collection" retrievable="false">
       <element name="collector" elementType="FHIR.Reference" description="Individual performing collection" definition="Healthcare professional who is performing the collection."/>
       <element name="source" elementType="FHIR.Reference" description="Who is product from" definition="The patient or entity, such as a hospital or vendor in the case of a processed/manipulated/manufactured product, providing the product."/>
       <element name="collected" description="Time of product collection" definition="Time of product collection.">
@@ -2093,7 +2093,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Manipulation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Manipulation" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of manipulation" definition="Description of manipulation."/>
       <element name="time" description="Time of manipulation" definition="Time of manipulation.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -2102,7 +2102,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Processing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Processing" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of of processing" definition="Description of of processing."/>
       <element name="procedure" elementType="FHIR.CodeableConcept" description="Procesing code" definition="Procesing code.">
          <binding name="BiologicallyDerivedProductProcedure" description="Biologically Derived Product Procedure." strength="Example"/>
@@ -2115,7 +2115,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Storage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="BiologicallyDerivedProduct.Storage" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of storage" definition="Description of storage."/>
       <element name="temperature" elementType="FHIR.decimal" description="Storage temperature" definition="Storage temperature."/>
       <element name="scale" elementType="FHIR.BiologicallyDerivedProductStorageScale" description="farenheit | celsius | kelvin" definition="Temperature scale used.">
@@ -2123,16 +2123,16 @@
       </element>
       <element name="duration" elementType="FHIR.Period" description="Storage timeperiod" definition="Storage timeperiod."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductCategory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductCategory" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductStorageScale" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BiologicallyDerivedProductStorageScale" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="BodyStructure" identifier="http://hl7.org/fhir/StructureDefinition/BodyStructure" label="BodyStructure" retrievable="true" primaryCodePath="location" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="BodyStructure" identifier="http://hl7.org/fhir/StructureDefinition/BodyStructure" label="BodyStructure" retrievable="true" primaryCodePath="location">
       <element name="identifier" description="Bodystructure identifier" definition="Identifier for this instance of the anatomical structure.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2158,7 +2158,7 @@
       <search name="patient" path="patient" type="FHIR.Patient"/>
       <search name="location" path="location" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Resource" namespace="FHIR" name="Bundle" identifier="http://hl7.org/fhir/StructureDefinition/Bundle" label="Bundle" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Resource" namespace="FHIR" name="Bundle" identifier="http://hl7.org/fhir/StructureDefinition/Bundle" label="Bundle" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="Persistent identifier for the bundle" definition="A persistent identifier for the bundle that won't change as a bundle is copied from server to server." comment="Persistent identity generally only matters for batches of type Document, Message, and Collection. It would not normally be populated for search and history results and servers ignore Bundle.identifier when processing batches and transactions. For Documents  the .identifier SHALL be populated such that the .identifier is globally unique."/>
       <element name="type" elementType="FHIR.BundleType" description="document | message | transaction | transaction-response | batch | batch-response | history | searchset | collection" definition="Indicates the purpose of this bundle - how it is intended to be used." comment="It's possible to use a bundle for other purposes (e.g. a document can be accepted as a transaction). This is primarily defined so that there can be specific rules for some of the bundle types.">
          <binding name="BundleType" description="Indicates the purpose of a bundle - how it is intended to be used." strength="Required"/>
@@ -2184,7 +2184,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="timestamp" path="timestamp" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry" retrievable="false">
       <element name="link" description="Links related to this entry" definition="A series of links that provide context to this entry.">
          <elementTypeSpecifier xsi:type="ListTypeSpecifier">
             <elementTypeSpecifier namespace="FHIR" name="Bundle.Link" xsi:type="NamedTypeSpecifier"/>
@@ -2196,7 +2196,7 @@
       <element name="request" elementType="FHIR.Bundle.Entry.Request" description="Additional execution information (transaction/batch/history)" definition="Additional information about how this entry should be processed as part of a transaction or batch.  For history, it shows how the entry was processed to create the version contained in the entry."/>
       <element name="response" elementType="FHIR.Bundle.Entry.Response" description="Results of execution (transaction/batch/history)" definition="Indicates the results of processing the corresponding 'request' entry in the batch or transaction being responded to or what the results of an operation where when returning history."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Request" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Request" retrievable="false">
       <element name="method" elementType="FHIR.HTTPVerb" description="GET | HEAD | POST | PUT | DELETE | PATCH" definition="In a transaction or batch, this is the HTTP action to be executed for this entry. In a history bundle, this indicates the HTTP action that occurred.">
          <binding name="HTTPVerb" description="HTTP verbs (in the HTTP command line). See [HTTP rfc](https://tools.ietf.org/html/rfc7231) for details." strength="Required"/>
       </element>
@@ -2206,27 +2206,27 @@
       <element name="ifMatch" elementType="FHIR.string" description="For managing update contention" definition="Only perform the operation if the Etag value matches. For more information, see the API section [&quot;Managing Resource Contention&quot;](http.html#concurrency)."/>
       <element name="ifNoneExist" elementType="FHIR.string" description="For conditional creates" definition="Instruct the server not to perform the create if a specified resource already exists. For further information, see the API documentation for [&quot;Conditional Create&quot;](http.html#ccreate). This is just the query portion of the URL - what follows the &quot;?&quot; (not including the &quot;?&quot;)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Response" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Response" retrievable="false">
       <element name="status" elementType="FHIR.string" description="Status response code (text optional)" definition="The status code returned by processing this entry. The status SHALL start with a 3 digit HTTP code (e.g. 404) and may contain the standard HTTP description associated with the status code."/>
       <element name="location" elementType="FHIR.uri" description="The location (if the operation returns a location)" definition="The location header created by processing this operation, populated if the operation returns a location."/>
       <element name="etag" elementType="FHIR.string" description="The Etag for the resource (if relevant)" definition="The Etag for the resource, if the operation for the entry produced a versioned resource (see [Resource Metadata and Versioning](http.html#versioning) and [Managing Resource Contention](http.html#concurrency))." comment="Etags match the Resource.meta.versionId. The ETag has to match the version id in the header if a resource is included."/>
       <element name="lastModified" elementType="FHIR.instant" description="Server's date time modified" definition="The date/time that the resource was modified on the server." comment="This has to match the same time in the meta header (meta.lastUpdated) if a resource is included."/>
       <element name="outcome" elementType="FHIR.Resource" description="OperationOutcome with hints and warnings (for batch/transaction)" definition="An OperationOutcome containing hints and warnings produced as part of processing this entry in a batch or transaction." comment="For a POST/PUT operation, this is the equivalent outcome that would be returned for prefer = operationoutcome - except that the resource is always returned whether or not the outcome is returned.&#xa;&#xa;This outcome is not used for error responses in batch/transaction, only for hints and warnings. In a batch operation, the error will be in Bundle.entry.response, and for transaction, there will be a single OperationOutcome instead of a bundle in the case of an error."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Search" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Entry.Search" retrievable="false">
       <element name="mode" elementType="FHIR.SearchEntryMode" description="match | include | outcome - why this is in the result set" definition="Why this entry is in the result set - whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process." comment="There is only one mode. In some corner cases, a resource may be included because it is both a match and an include. In these circumstances, 'match' takes precedence.">
          <binding name="SearchEntryMode" description="Why an entry is in the result set - whether it's included as a match or because of an _include requirement, or to convey information or warning information about the search process." strength="Required"/>
       </element>
       <element name="score" elementType="FHIR.decimal" description="Search ranking (between 0 and 1)" definition="When searching, the server's search ranking score for the entry." comment="Servers are not required to return a ranking score. 1 is most relevant, and 0 is least relevant. Often, search results are sorted by score, but the client may specify a different sort order.&#xa;&#xa;See [Patient Match](patient-operation-match.html) for the EMPI search which relates to this element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Bundle.Link" retrievable="false">
       <element name="relation" elementType="FHIR.string" description="See http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1" definition="A name which details the functional use for this link - see [http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1](http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1)."/>
       <element name="url" elementType="FHIR.uri" description="Reference details for the link" definition="The reference details for the link."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="BundleType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="BundleType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CapabilityStatement" identifier="http://hl7.org/fhir/StructureDefinition/CapabilityStatement" label="CapabilityStatement" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CapabilityStatement" identifier="http://hl7.org/fhir/StructureDefinition/CapabilityStatement" label="CapabilityStatement" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this capability statement, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this capability statement when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this capability statement is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the capability statement is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the capability statement" definition="The identifier that is used to identify this version of the capability statement when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the capability statement author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different capability statement instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the capability statement with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this capability statement (computer friendly)" definition="A natural language name identifying the capability statement. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -2307,19 +2307,19 @@
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Document" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Document" retrievable="false">
       <element name="mode" elementType="FHIR.DocumentMode" description="producer | consumer" definition="Mode of this document declaration - whether an application is a producer or consumer.">
          <binding name="DocumentMode" description="Whether the application produces or consumes documents." strength="Required"/>
       </element>
       <element name="documentation" elementType="FHIR.markdown" description="Description of document support" definition="A description of how the application supports or uses the specified document profile.  For example, when documents are created, what action is taken with consumed documents, etc."/>
       <element name="profile" elementType="FHIR.canonical" description="Constraint on the resources used in the document" definition="A profile on the document Bundle that constrains which resources are present, and their contents." comment="The profile is actually on the Bundle."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Implementation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Implementation" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Describes this specific instance" definition="Information about the specific installation that this capability statement relates to."/>
       <element name="url" elementType="FHIR.url" description="Base URL for the installation" definition="An absolute base URL for the implementation.  This forms the base for REST interfaces as well as the mailbox and document interfaces."/>
       <element name="custodian" elementType="FHIR.Reference" description="Organization that manages the data" definition="The organization responsible for the management of the instance and oversight of the data on the server at the specified URL."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging" retrievable="false">
       <element name="endpoint" description="Where messages should be sent" definition="An endpoint (network accessible address) to which messages and/or replies are to be sent.">
          <elementTypeSpecifier elementType="FHIR.CapabilityStatement.Messaging.Endpoint" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2329,19 +2329,19 @@
          <elementTypeSpecifier elementType="FHIR.CapabilityStatement.Messaging.SupportedMessage" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging.Endpoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging.Endpoint" retrievable="false">
       <element name="protocol" elementType="FHIR.Coding" description="http | ftp | mllp +" definition="A list of the messaging transport protocol(s) identifiers, supported by this endpoint.">
          <binding name="MessageTransport" description="The protocol used for message transport." strength="Extensible"/>
       </element>
       <element name="address" elementType="FHIR.url" description="Network address or identifier of the end-point" definition="The network address of the endpoint. For solutions that do not use network addresses for routing, it can be just an identifier."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging.SupportedMessage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Messaging.SupportedMessage" retrievable="false">
       <element name="mode" elementType="FHIR.EventCapabilityMode" description="sender | receiver" definition="The mode of this event declaration - whether application is sender or receiver.">
          <binding name="EventCapabilityMode" description="The mode of a message capability statement." strength="Required"/>
       </element>
       <element name="definition" elementType="FHIR.canonical" description="Message supported by this system" definition="Points to a message definition that identifies the messaging event, message structure, allowed responses, etc."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest" retrievable="false">
       <element name="mode" elementType="FHIR.RestfulCapabilityMode" description="client | server" definition="Identifies whether this portion of the statement is describing the ability to initiate or receive restful operations.">
          <binding name="RestfulCapabilityMode" description="The mode of a RESTful capability statement." strength="Required"/>
       </element>
@@ -2370,13 +2370,13 @@
          <elementTypeSpecifier elementType="FHIR.canonical" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Interaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Interaction" retrievable="false">
       <element name="code" elementType="FHIR.SystemRestfulInteraction" description="transaction | batch | search-system | history-system" definition="A coded identifier of the operation, supported by the system.">
          <binding name="SystemRestfulInteraction" description="Operations supported by REST at the system level." strength="Required"/>
       </element>
       <element name="documentation" elementType="FHIR.markdown" description="Anything special about operation behavior" definition="Guidance specific to the implementation of this operation, such as limitations on the kind of transactions allowed, or information about system wide search is implemented."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource" retrievable="false">
       <element name="type" elementType="FHIR.ResourceType" description="A resource type that is supported" definition="A type of resource exposed via the restful interface.">
          <binding name="ResourceType" description="One of the resource types defined as part of this version of FHIR." strength="Required"/>
       </element>
@@ -2418,18 +2418,18 @@
          <elementTypeSpecifier elementType="FHIR.CapabilityStatement.Rest.Resource.Operation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.Interaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.Interaction" retrievable="false">
       <element name="code" elementType="FHIR.TypeRestfulInteraction" description="read | vread | update | patch | delete | history-instance | history-type | create | search-type" definition="Coded identifier of the operation, supported by the system resource.">
          <binding name="TypeRestfulInteraction" description="Operations supported by REST at the type or instance level." strength="Required"/>
       </element>
       <element name="documentation" elementType="FHIR.markdown" description="Anything special about operation behavior" definition="Guidance specific to the implementation of this operation, such as 'delete is a logical delete' or 'updates are only allowed with version id' or 'creates permitted from pre-authorized certificates only'."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.Operation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.Operation" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name by which the operation/query is invoked" definition="The name of the operation or query. For an operation, this is the name  prefixed with $ and used in the URL. For a query, this is the name used in the _query parameter when the query is called." comment="The name here SHOULD be the same as the name in the definition, unless there is a name clash and the name cannot be used. The name does not include the &quot;$&quot; portion that is always included in the URL."/>
       <element name="definition" elementType="FHIR.canonical" description="The defined operation/query" definition="Where the formal definition can be found. If a server references the base definition of an Operation (i.e. from the specification itself such as ```http://hl7.org/fhir/OperationDefinition/ValueSet-expand```), that means it supports the full capabilities of the operation - e.g. both GET and POST invocation.  If it only supports a subset, it must define its own custom [OperationDefinition](operationdefinition.html#) with a 'base' of the original OperationDefinition.  The custom definition would describe the specific subset of functionality supported." comment="This can be used to build an HTML form to invoke the operation, for instance."/>
       <element name="documentation" elementType="FHIR.markdown" description="Specific details about operation behavior" definition="Documentation that describes anything special about the operation behavior, possibly detailing different behavior for system, type and instance-level invocation of the operation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.SearchParam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Resource.SearchParam" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name of search parameter" definition="The name of the search parameter used in the interface." comment="Parameter names cannot overlap with standard parameter names, and standard parameters cannot be redefined."/>
       <element name="definition" elementType="FHIR.canonical" description="Source of definition for parameter" definition="An absolute URI that is a formal reference to where this parameter was first defined, so that a client can be confident of the meaning of the search parameter (a reference to [SearchParameter.url](searchparameter-definitions.html#SearchParameter.url)). This element SHALL be populated if the search parameter refers to a SearchParameter defined by the FHIR core specification or externally defined IGs." comment="This SHOULD be present, and matches refers to a SearchParameter by its canonical URL. If systems wish to document their support for modifiers, comparators, target resource types, and chained parameters, they should do using a search parameter resource. This element SHALL be populated if the search parameter refers to a SearchParameter defined by the FHIR core specification or externally defined IGs."/>
       <element name="type" elementType="FHIR.SearchParamType" description="number | date | string | token | reference | composite | quantity | uri | special" definition="The type of value a search parameter refers to, and how the content is interpreted." comment="While this can be looked up from the definition, it is included here as a convenience for systems that autogenerate a query interface based on the server capability statement.  It SHALL be the same as the type in the search parameter definition.">
@@ -2437,7 +2437,7 @@
       </element>
       <element name="documentation" elementType="FHIR.markdown" description="Server-specific usage" definition="This allows documentation of any distinct behaviors about how the search parameter is used.  For example, text matching algorithms."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Security" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Rest.Security" retrievable="false">
       <element name="cors" elementType="FHIR.boolean" description="Adds CORS Headers (http://enable-cors.org/)" definition="Server adds CORS headers when responding to requests - this enables Javascript applications to use the server." comment="The easiest CORS headers to add are Access-Control-Allow-Origin: * &amp; Access-Control-Request-Method: GET, POST, PUT, DELETE. All servers SHOULD support CORS."/>
       <element name="service" description="OAuth | SMART-on-FHIR | NTLM | Basic | Kerberos | Certificates" definition="Types of security services that are supported/required by the system.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -2445,15 +2445,15 @@
       </element>
       <element name="description" elementType="FHIR.markdown" description="General description of how security works" definition="General description of how security works."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Software" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CapabilityStatement.Software" retrievable="false">
       <element name="name" elementType="FHIR.string" description="A name the software is known by" definition="Name the software is known by."/>
       <element name="version" elementType="FHIR.string" description="Version covered by this statement" definition="The version identifier for the software covered by this statement." comment="If possible, a version should be specified, as statements are likely to be different for different versions of software."/>
       <element name="releaseDate" elementType="FHIR.dateTime" description="Date this version was released" definition="Date this version of the software was released."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CapabilityStatementKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CapabilityStatementKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CarePlan" identifier="http://hl7.org/fhir/StructureDefinition/CarePlan" label="CarePlan" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CarePlan" identifier="http://hl7.org/fhir/StructureDefinition/CarePlan" label="CarePlan" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this plan" definition="Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2580,7 +2580,7 @@
       <search name="instantiates-uri" path="instantiatesUri" type="System.String"/>
       <search name="replaces" path="replaces" type="FHIR.CarePlan"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" description="Results of the activity" definition="Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not)." comment="Note that this should not duplicate the activity status (e.g. completed or in progress).">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="CarePlanActivityOutcome" description="Identifies the results of the activity." strength="Example"/>
@@ -2594,7 +2594,7 @@
       <element name="reference" elementType="FHIR.Reference" description="Activity details defined in specific resource" definition="The details of the proposed activity represented in a specific resource." comment="Standard extension exists ([resource-pertainsToGoal](extension-resource-pertainstogoal.html)) that allows goals to be referenced from any of the referenced resources in CarePlan.activity.reference.  &#xd;The goal should be visible when the resource referenced by CarePlan.activity.reference is viewed independently from the CarePlan.  Requests that are pointed to by a CarePlan using this element should *not* point to this CarePlan using the &quot;basedOn&quot; element.  i.e. Requests that are part of a CarePlan are not &quot;based on&quot; the CarePlan."/>
       <element name="detail" elementType="FHIR.CarePlan.Activity.Detail" description="In-line definition of activity" definition="A simple summary of a planned activity suitable for a general care plan system (e.g. form driven) that doesn't know about specific resources such as procedure etc."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="FHIR.CarePlanActivityKind" description="Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription" definition="A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.">
          <binding name="CarePlanActivityKind" description="Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity." strength="Required"/>
       </element>
@@ -2644,19 +2644,19 @@
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="How much to administer/supply/consume" definition="Identifies the quantity expected to be supplied, administered or consumed by the subject."/>
       <element name="description" elementType="FHIR.string" description="Extra info describing activity to perform" definition="This provides a textual description of constraints on the intended activity occurrence, including relation to other activities.  It may also include objectives, pre-conditions and end-conditions.  Finally, it may convey specifics about the activity such as body site, method, route, etc."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CarePlanActivityKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CarePlanActivityStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CarePlanIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CarePlanIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CarePlanStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CarePlanStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CareTeam" identifier="http://hl7.org/fhir/StructureDefinition/CareTeam" label="CareTeam" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CareTeam" identifier="http://hl7.org/fhir/StructureDefinition/CareTeam" label="CareTeam" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this team" definition="Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2726,7 +2726,7 @@
       <search name="encounter" path="encounter" type="FHIR.Encounter"/>
       <search name="category" path="category" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CareTeam.Participant" retrievable="false">
       <element name="role" description="Type of involvement" definition="Indicates specific responsibility of an individual within the care team, such as &quot;Primary care physician&quot;, &quot;Trained social worker counselor&quot;, &quot;Caregiver&quot;, etc." comment="Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="CareTeamParticipantRole" description="Indicates specific responsibility of an individual within the care team, such as &quot;Primary physician&quot;, &quot;Team coordinator&quot;, &quot;Caregiver&quot;, etc." strength="Example"/>
@@ -2735,10 +2735,10 @@
       <element name="onBehalfOf" elementType="FHIR.Reference" description="Organization of the practitioner" definition="The organization of the practitioner."/>
       <element name="period" elementType="FHIR.Period" description="Time period of participant" definition="Indicates when the specific member or organization did (or is intended to) come into effect and end."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CareTeamStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CareTeamStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CatalogEntry" identifier="http://hl7.org/fhir/StructureDefinition/CatalogEntry" label="CatalogEntry" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CatalogEntry" identifier="http://hl7.org/fhir/StructureDefinition/CatalogEntry" label="CatalogEntry" retrievable="true">
       <element name="identifier" description="Unique identifier of the catalog item" definition="Used in supporting different identifiers for the same product, e.g. manufacturer code and retailer code.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2767,16 +2767,16 @@
          <elementTypeSpecifier elementType="FHIR.CatalogEntry.RelatedEntry" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CatalogEntry.RelatedEntry" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CatalogEntry.RelatedEntry" retrievable="false">
       <element name="relationtype" elementType="FHIR.CatalogEntryRelationType" description="triggers | is-replaced-by" definition="The type of relation to the related item: child, parent, packageContent, containerPackage, usedIn, uses, requires, etc.">
          <binding name="CatalogEntryRelationType" description="The type of relations between entries." strength="Required"/>
       </element>
       <element name="item" elementType="FHIR.Reference" description="The reference to the related item" definition="The reference to the related item."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CatalogEntryRelationType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CatalogEntryRelationType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ChargeItem" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItem" label="ChargeItem" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ChargeItem" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItem" label="ChargeItem" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for item" definition="Identifiers assigned to this event performer or other systems.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2909,13 +2909,13 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItem.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItem.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="What type of performance was done" definition="Describes the type of performance or participation(e.g. primary surgeon, anesthesiologiest, etc.).">
          <binding name="ChargeItemPerformerFunction" description="Codes describing the types of functional roles performers can take on when performing events." strength="Example"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="Individual who was performing" definition="The device, practitioner, etc. who performed or participated in the service."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ChargeItemDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItemDefinition" label="ChargeItemDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ChargeItemDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItemDefinition" label="ChargeItemDefinition" retrievable="true" primaryCodePath="code">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this charge item definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this charge item definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this charge item definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the charge item definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the charge item definition" definition="A formal identifier that is used to identify this charge item definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this charge item definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2976,12 +2976,12 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="url" path="url" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.Applicability" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.Applicability" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Natural language description of the condition" definition="A brief, natural language description of the condition that effectively communicates the intended semantics."/>
       <element name="language" elementType="FHIR.string" description="Language of the expression" definition="The media type of the language for the expression, e.g. &quot;text/cql&quot; for Clinical Query Language expressions or &quot;text/fhirpath&quot; for FHIRPath expressions."/>
       <element name="expression" elementType="FHIR.string" description="Boolean-valued expression" definition="An expression that returns true or false, indicating whether the condition is satisfied. When using FHIRPath expressions, the %context environment variable must be replaced at runtime with the ChargeItem resource to which this definition is applied." comment="Please note that FHIRPath Expressions can only be evaluated in the scope of the current ChargeItem resource to which this definition is being applied.&#xa;FHIRPath expressions can traverse into other resources linked from the ChargeItem resource, however, testing rules such as that a billing code may be billed only once per encounter need a wider scope. In such scenarios, CQL may be the appropriate choice."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.PropertyGroup" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.PropertyGroup" retrievable="false">
       <element name="applicability" description="Conditions under which the priceComponent is applicable" definition="Expressions that describe applicability criteria for the priceComponent." comment="The applicability conditions can be used to ascertain whether a billing item is allowed in a specific context. E.g. some billing codes may only be applicable in out-patient settings, only to male/female patients or only to children.">
          <elementTypeSpecifier xsi:type="ListTypeSpecifier">
             <elementTypeSpecifier namespace="FHIR" name="ChargeItemDefinition.Applicability" xsi:type="NamedTypeSpecifier"/>
@@ -2991,7 +2991,7 @@
          <elementTypeSpecifier elementType="FHIR.ChargeItemDefinition.PropertyGroup.PriceComponent" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.PropertyGroup.PriceComponent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ChargeItemDefinition.PropertyGroup.PriceComponent" retrievable="false">
       <element name="type" elementType="FHIR.ChargeItemDefinitionPriceComponentType" description="base | surcharge | deduction | discount | tax | informational" definition="This code identifies the type of the component.">
          <binding name="ChargeItemDefinitionPriceComponentType" description="Codes indicating the kind of the price component." strength="Required"/>
       </element>
@@ -2999,13 +2999,13 @@
       <element name="factor" elementType="FHIR.decimal" description="Factor used for calculating this component" definition="The factor that has been applied on the base price for calculating this component."/>
       <element name="amount" elementType="FHIR.Money" description="Monetary amount associated with this component" definition="The amount calculated for this component."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ChargeItemDefinitionPriceComponentType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ChargeItemDefinitionPriceComponentType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ChargeItemStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ChargeItemStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Claim" identifier="http://hl7.org/fhir/StructureDefinition/Claim" label="Claim" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Claim" identifier="http://hl7.org/fhir/StructureDefinition/Claim" label="Claim" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier for claim" definition="A unique identifier assigned to this claim.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3116,7 +3116,7 @@
       </search>
       <search name="created" path="created" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Accident" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Accident" retrievable="false">
       <element name="date" elementType="FHIR.date" description="When the incident occurred" definition="Date of an accident event  related to the products and services contained in the claim." comment="The date of the accident has to precede the dates of the products and services but within a reasonable timeframe."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="The nature of the accident" definition="The type or context of the accident event for the purposes of selection of potential insurance coverages and determination of coordination between insurers.">
          <binding name="AccidentType" description="Type of accident: work place, auto, etc." strength="Extensible"/>
@@ -3128,7 +3128,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.CareTeam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.CareTeam" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Order of care team" definition="A number to uniquely identify care team entries."/>
       <element name="provider" elementType="FHIR.Reference" description="Practitioner or organization" definition="Member of the team who provided the product or service."/>
       <element name="responsible" elementType="FHIR.boolean" description="Indicator of the lead practitioner" definition="The party who is billing and/or responsible for the claimed products or services." comment="Responsible might not be required when there is only a single provider listed."/>
@@ -3139,7 +3139,7 @@
          <binding name="ProviderQualification" description="Provider professional qualifications." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Diagnosis" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Diagnosis instance identifier" definition="A number to uniquely identify diagnosis entries." comment="Diagnosis are presented in list order to their expected importance: primary, secondary, etc."/>
       <element name="diagnosis" description="Nature of illness or problem" definition="The nature of illness or problem in a coded form or as a reference to an external defined Condition.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -3159,7 +3159,7 @@
          <binding name="DiagnosisRelatedGroup" description="The DRG codes associated with the diagnosis." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Insurance" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Insurance instance identifier" definition="A number to uniquely identify insurance entries and provide a sequence of coverages to convey coordination of benefit order."/>
       <element name="focal" elementType="FHIR.boolean" description="Coverage to be used for adjudication" definition="A flag to indicate that this Coverage is to be used for adjudication of this claim when set to true." comment="A patient may (will) have multiple insurance policies which provide reimbursement for healthcare services and products. For example a person may also be covered by their spouse's policy and both appear in the list (and may be from the same insurer). This flag will be set to true for only one of the listed policies and that policy will be used for adjudicating this claim. Other claims would be created to request adjudication against the other listed policies."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Pre-assigned Claim number" definition="The business identifier to be used when the claim is sent for adjudication against this insurance policy." comment="Only required in jurisdictions where insurers, rather than the provider, are required to send claims to  insurers that appear after them in the list. This element is not required when 'subrogation=true'."/>
@@ -3170,7 +3170,7 @@
       </element>
       <element name="claimResponse" elementType="FHIR.Reference" description="Adjudication results" definition="The result of the adjudication of the line items for the Coverage specified in this insurance." comment="Must not be specified when 'focal=true' for this insurance."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Item instance identifier" definition="A number to uniquely identify item entries."/>
       <element name="careTeamSequence" description="Applicable careTeam members" definition="CareTeam members related to this service or product.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
@@ -3236,7 +3236,7 @@
          <elementTypeSpecifier elementType="FHIR.Claim.Item.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item.Detail" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Item instance identifier" definition="A number to uniquely identify item entries."/>
       <element name="revenue" elementType="FHIR.CodeableConcept" description="Revenue or cost center code" definition="The type of revenue or cost center providing the product and/or service.">
          <binding name="RevenueCenter" description="Codes for the revenue or cost centers supplying the service and/or products." strength="Example"/>
@@ -3266,7 +3266,7 @@
          <elementTypeSpecifier elementType="FHIR.Claim.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Item.Detail.SubDetail" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Item instance identifier" definition="A number to uniquely identify item entries."/>
       <element name="revenue" elementType="FHIR.CodeableConcept" description="Revenue or cost center code" definition="The type of revenue or cost center providing the product and/or service.">
          <binding name="RevenueCenter" description="Codes for the revenue or cost centers supplying the service and/or products." strength="Example"/>
@@ -3293,13 +3293,13 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Payee" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Payee" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Category of recipient" definition="Type of Party to be reimbursed: subscriber, provider, other.">
          <binding name="PayeeType" description="A code for the party to be reimbursed." strength="Example"/>
       </element>
       <element name="party" elementType="FHIR.Reference" description="Recipient reference" definition="Reference to the individual or organization to whom any payment will be made." comment="Not required if the payee is 'subscriber' or 'provider'."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Procedure" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Procedure instance identifier" definition="A number to uniquely identify procedure entries."/>
       <element name="type" description="Category of Procedure" definition="When the condition was observed or the relative ranking." comment="For example: primary, secondary.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -3317,14 +3317,14 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.Related" retrievable="false">
       <element name="claim" elementType="FHIR.Reference" description="Reference to the related claim" definition="Reference to a related claim."/>
       <element name="relationship" elementType="FHIR.CodeableConcept" description="How the reference claim is related" definition="A code to convey how the claims are related." comment="For example, prior claim or umbrella.">
          <binding name="RelatedClaimRelationship" description="Relationship of this claim to a related Claim." strength="Example"/>
       </element>
       <element name="reference" elementType="FHIR.Identifier" description="File or case reference" definition="An alternate organizational reference to the case or file to which this particular claim pertains." comment="For example, Property/Casualty insurer claim # or Workers Compensation case # ."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Claim.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Information instance identifier" definition="A number to uniquely identify supporting information entries."/>
       <element name="category" elementType="FHIR.CodeableConcept" description="Classification of the supplied information" definition="The general class of the information supplied: information; exception; accident, employment; onset, etc." comment="This may contain a category for the local bill type codes.">
          <binding name="InformationCategory" description="The valuset used for additional information category codes." strength="Example"/>
@@ -3351,7 +3351,7 @@
          <binding name="MissingReason" description="Reason codes for the missing teeth." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ClaimResponse" identifier="http://hl7.org/fhir/StructureDefinition/ClaimResponse" label="ClaimResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ClaimResponse" identifier="http://hl7.org/fhir/StructureDefinition/ClaimResponse" label="ClaimResponse" retrievable="true">
       <element name="identifier" description="Business Identifier for a claim response" definition="A unique identifier assigned to this claim response.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3435,7 +3435,7 @@
       <search name="disposition" path="disposition" type="System.String"/>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem" retrievable="false">
       <element name="itemSequence" description="Item sequence number" definition="Claim items which this service line is intended to replace.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3496,7 +3496,7 @@
          <elementTypeSpecifier elementType="FHIR.ClaimResponse.AddItem.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem.Detail" retrievable="false">
       <element name="productOrService" elementType="FHIR.CodeableConcept" description="Billing, service, product, or drug code" definition="When the value is a group code then this item collects a set of related claim details, otherwise this contains the product, service, drug or other billing code for the item." comment="If this is an actual service or product line, i.e. not a Group, then use code to indicate the Professional Service or Product supplied (e.g. CTP, HCPCS, USCLS, ICD10, NCPDP, DIN, RxNorm, ACHI, CCI). If a grouping item then use a group code to indicate the type of thing being grouped e.g. 'glasses' or 'compound'.">
          <binding name="ServiceProduct" description="Allowable service and product codes." strength="Example"/>
       </element>
@@ -3520,7 +3520,7 @@
          <elementTypeSpecifier elementType="FHIR.ClaimResponse.AddItem.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.AddItem.Detail.SubDetail" retrievable="false">
       <element name="productOrService" elementType="FHIR.CodeableConcept" description="Billing, service, product, or drug code" definition="When the value is a group code then this item collects a set of related claim details, otherwise this contains the product, service, drug or other billing code for the item." comment="If this is an actual service or product line, i.e. not a Group, then use code to indicate the Professional Service or Product supplied (e.g. CTP, HCPCS, USCLS, ICD10, NCPDP, DIN, RxNorm, ACHI, CCI). If a grouping item then use a group code to indicate the type of thing being grouped e.g. 'glasses' or 'compound'.">
          <binding name="ServiceProduct" description="Allowable service and product codes." strength="Example"/>
       </element>
@@ -3541,7 +3541,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Error" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Error" retrievable="false">
       <element name="itemSequence" elementType="FHIR.positiveInt" description="Item sequence number" definition="The sequence number of the line item submitted which contains the error. This value is omitted when the error occurs outside of the item structure."/>
       <element name="detailSequence" elementType="FHIR.positiveInt" description="Detail sequence number" definition="The sequence number of the detail within the line item submitted which contains the error. This value is omitted when the error occurs outside of the item structure."/>
       <element name="subDetailSequence" elementType="FHIR.positiveInt" description="Subdetail sequence number" definition="The sequence number of the sub-detail within the detail within the line item submitted which contains the error. This value is omitted when the error occurs outside of the item structure."/>
@@ -3549,14 +3549,14 @@
          <binding name="AdjudicationError" description="The adjudication error codes." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Insurance" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Insurance instance identifier" definition="A number to uniquely identify insurance entries and provide a sequence of coverages to convey coordination of benefit order."/>
       <element name="focal" elementType="FHIR.boolean" description="Coverage to be used for adjudication" definition="A flag to indicate that this Coverage is to be used for adjudication of this claim when set to true." comment="A patient may (will) have multiple insurance policies which provide reimbursement for healthcare services and products. For example a person may also be covered by their spouse's policy and both appear in the list (and may be from the same insurer). This flag will be set to true for only one of the listed policies and that policy will be used for adjudicating this claim. Other claims would be created to request adjudication against the other listed policies."/>
       <element name="coverage" elementType="FHIR.Reference" description="Insurance information" definition="Reference to the insurance card level information contained in the Coverage resource. The coverage issuing insurer will use these details to locate the patient's actual coverage within the insurer's information system."/>
       <element name="businessArrangement" elementType="FHIR.string" description="Additional provider contract number" definition="A business agreement number established between the provider and the insurer for special business processing purposes."/>
       <element name="claimResponse" elementType="FHIR.Reference" description="Adjudication results" definition="The result of the adjudication of the line items for the Coverage specified in this insurance." comment="Must not be specified when 'focal=true' for this insurance."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item" retrievable="false">
       <element name="itemSequence" elementType="FHIR.positiveInt" description="Claim item instance identifier" definition="A number to uniquely reference the claim item entries."/>
       <element name="noteNumber" description="Applicable note numbers" definition="The numbers associated with notes below which apply to the adjudication of this item.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
@@ -3568,7 +3568,7 @@
          <elementTypeSpecifier elementType="FHIR.ClaimResponse.Item.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Adjudication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Adjudication" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Type of adjudication information" definition="A code to indicate the information type of this adjudication record. Information types may include the value submitted, maximum values or percentages allowed or payable under the plan, amounts that: the patient is responsible for in aggregate or pertaining to this item; amounts paid by other coverages; and, the benefit payable for this item." comment="For example codes indicating: Co-Pay, deductible, eligible, benefit, tax, etc.">
          <binding name="Adjudication" description="The adjudication codes." strength="Example"/>
       </element>
@@ -3578,7 +3578,7 @@
       <element name="amount" elementType="FHIR.Money" description="Monetary amount" definition="Monetary amount associated with the category." comment="For example: amount submitted, eligible amount, co-payment, and benefit payable."/>
       <element name="value" elementType="FHIR.decimal" description="Non-monetary value" definition="A non-monetary value associated with the category. Mutually exclusive to the amount element above." comment="For example: eligible percentage or co-payment percentage."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Detail" retrievable="false">
       <element name="detailSequence" elementType="FHIR.positiveInt" description="Claim detail instance identifier" definition="A number to uniquely reference the claim detail entry."/>
       <element name="noteNumber" description="Applicable note numbers" definition="The numbers associated with notes below which apply to the adjudication of this item.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
@@ -3592,7 +3592,7 @@
          <elementTypeSpecifier elementType="FHIR.ClaimResponse.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Item.Detail.SubDetail" retrievable="false">
       <element name="subDetailSequence" elementType="FHIR.positiveInt" description="Claim sub-detail instance identifier" definition="A number to uniquely reference the claim sub-detail entry."/>
       <element name="noteNumber" description="Applicable note numbers" definition="The numbers associated with notes below which apply to the adjudication of this item.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
@@ -3603,7 +3603,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Payment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Payment" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Partial or complete payment" definition="Whether this represents partial or complete payment of the benefits payable.">
          <binding name="PaymentType" description="The type (partial, complete) of the payment." strength="Example"/>
       </element>
@@ -3615,7 +3615,7 @@
       <element name="amount" elementType="FHIR.Money" description="Payable amount after adjustment" definition="Benefits payable less any payment adjustment."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Business identifier for the payment" definition="Issuer's unique identifier for the payment instrument." comment="For example: EFT number or check number."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.ProcessNote" retrievable="false">
       <element name="number" elementType="FHIR.positiveInt" description="Note instance identifier" definition="A number to uniquely identify a note entry."/>
       <element name="type" elementType="FHIR.NoteType" description="display | print | printoper" definition="The business purpose of the note text.">
          <binding name="NoteType" description="The presentation types of notes." strength="Required"/>
@@ -3625,19 +3625,19 @@
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Total" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClaimResponse.Total" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Type of adjudication information" definition="A code to indicate the information type of this adjudication record. Information types may include: the value submitted, maximum values or percentages allowed or payable under the plan, amounts that the patient is responsible for in aggregate or pertaining to this item, amounts paid by other coverages, and the benefit payable for this item." comment="For example codes indicating: Co-Pay, deductible, eligible, benefit, tax, etc.">
          <binding name="Adjudication" description="The adjudication codes." strength="Example"/>
       </element>
       <element name="amount" elementType="FHIR.Money" description="Financial total for the category" definition="Monetary total amount associated with the category."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ClaimResponseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ClaimResponseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ClaimStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ClaimStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ClinicalImpression" identifier="http://hl7.org/fhir/StructureDefinition/ClinicalImpression" label="ClinicalImpression" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ClinicalImpression" identifier="http://hl7.org/fhir/StructureDefinition/ClinicalImpression" label="ClinicalImpression" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Business identifiers assigned to this clinical impression by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3889,14 +3889,14 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClinicalImpression.Finding" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClinicalImpression.Finding" retrievable="false">
       <element name="itemCodeableConcept" elementType="FHIR.CodeableConcept" description="What was found" definition="Specific text or code for finding or diagnosis, which may include ruled-out or resolved conditions.">
          <binding name="ConditionKind" description="Identification of the Condition or diagnosis." strength="Example"/>
       </element>
       <element name="itemReference" elementType="FHIR.Reference" description="What was found" definition="Specific reference for finding or diagnosis, which may include ruled-out or resolved conditions."/>
       <element name="basis" elementType="FHIR.string" description="Which investigations support finding" definition="Which investigations support finding or diagnosis."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ClinicalImpression.Investigation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ClinicalImpression.Investigation" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="A name/code for the set" definition="A name/code for the group (&quot;set&quot;) of investigations. Typically, this will be something like &quot;signs&quot;, &quot;symptoms&quot;, &quot;clinical&quot;, &quot;diagnostic&quot;, but the list is not constrained, and others such groups such as (exposure|family|travel|nutritional) history may be used.">
          <binding name="InvestigationGroupType" description="A name/code for a set of investigations." strength="Example"/>
       </element>
@@ -3904,13 +3904,13 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ClinicalImpressionStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ClinicalImpressionStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CodeSearchSupport" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CodeSearchSupport" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CodeSystem" identifier="http://hl7.org/fhir/StructureDefinition/CodeSystem" label="CodeSystem" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CodeSystem" identifier="http://hl7.org/fhir/StructureDefinition/CodeSystem" label="CodeSystem" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this code system, represented as a URI (globally unique) (Coding.system)" definition="An absolute URI that is used to identify this code system when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this code system is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the code system is stored on different servers. This is used in [Coding](datatypes.html#Coding).system." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the code system (business identifier)" definition="A formal identifier that is used to identify this code system when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this code system outside of FHIR, where it is not possible to use the logical URI.  Note that HL7 defines at least three identifiers for many of its code systems - the FHIR canonical URL, the OID and the V2 Table 0396 mnemonic code.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -3975,7 +3975,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Code that identifies concept" definition="A code - a text symbol - that uniquely identifies the concept within the code system."/>
       <element name="display" elementType="FHIR.string" description="Text to display to the user" definition="A human readable string that is the recommended default way to present this concept to a user."/>
       <element name="definition" elementType="FHIR.string" description="Formal definition" definition="The formal definition of the concept. The code system resource does not make formal definitions required, because of the prevalence of legacy systems. However, they are highly recommended, as without them there is no formal meaning associated with the concept."/>
@@ -3991,7 +3991,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept.Designation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept.Designation" retrievable="false">
       <element name="language" elementType="FHIR.code" description="Human language of the designation" definition="The language this designation is defined for." comment="In the absence of a language, the resource language applies.">
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
@@ -4000,7 +4000,7 @@
       </element>
       <element name="value" elementType="FHIR.string" description="The text value for this designation" definition="The text value for this designation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Concept.Property" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Reference to CodeSystem.property.code" definition="A code that is a reference to CodeSystem.property.code."/>
       <element name="value" description="Value of the property for this concept" definition="The value of this property.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4014,7 +4014,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Filter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Filter" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Code that identifies the filter" definition="The code that identifies this filter when it is used as a filter in [ValueSet](valueset.html#).compose.include.filter."/>
       <element name="description" elementType="FHIR.string" description="How or why the filter is used" definition="A description of how or why the filter is used."/>
       <element name="operator" description="= | is-a | descendent-of | is-not-a | regex | in | not-in | generalizes | exists" definition="A list of operators that can be used with the filter.">
@@ -4023,7 +4023,7 @@
       </element>
       <element name="value" elementType="FHIR.string" description="What to use for the value" definition="A description of what the value for the filter should be."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CodeSystem.Property" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Identifies the property on the concepts, and when referred to in operations" definition="A code that is used to identify the property. The code is used internally (in CodeSystem.concept.property.code) and also externally, such as in property filters."/>
       <element name="uri" elementType="FHIR.uri" description="Formal identifier for the property" definition="Reference to the formal meaning of the property. One possible source of meaning is the [Concept Properties](codesystem-concept-properties.html) code system."/>
       <element name="description" elementType="FHIR.string" description="Why the property is defined, and/or what it conveys" definition="A description of the property- why it is defined, and how its value might be used."/>
@@ -4031,26 +4031,26 @@
          <binding name="PropertyType" description="The type of a property value." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CodeSystemContentMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CodeSystemContentMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CodeSystemHierarchyMeaning" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CodeSystemHierarchyMeaning" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CodeableConcept" identifier="http://hl7.org/fhir/StructureDefinition/CodeableConcept" label="CodeableConcept" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CodeableConcept" identifier="http://hl7.org/fhir/StructureDefinition/CodeableConcept" label="CodeableConcept" retrievable="false">
       <element name="coding" description="Code defined by a terminology system" definition="A reference to a code defined by a terminology system." comment="Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.">
          <elementTypeSpecifier elementType="FHIR.Coding" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="text" elementType="FHIR.string" description="Plain text representation of the concept" definition="A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user." comment="Very often the text is the same as a displayName of one of the codings."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Coding" identifier="http://hl7.org/fhir/StructureDefinition/Coding" label="Coding" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Coding" identifier="http://hl7.org/fhir/StructureDefinition/Coding" label="Coding" retrievable="false" primaryCodePath="code">
       <element name="system" elementType="FHIR.uri" description="Identity of the terminology system" definition="The identification of the code system that defines the meaning of the symbol in the code." comment="The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously."/>
       <element name="version" elementType="FHIR.string" description="Version of the system - if relevant" definition="The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged." comment="Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date."/>
       <element name="code" elementType="FHIR.code" description="Symbol in syntax defined by the system" definition="A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)."/>
       <element name="display" elementType="FHIR.string" description="Representation defined by the system" definition="A representation of the meaning of the code in the system, following the rules of the system."/>
       <element name="userSelected" elementType="FHIR.boolean" description="If this coding was chosen directly by the user" definition="Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays)." comment="Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Communication" identifier="http://hl7.org/fhir/StructureDefinition/Communication" label="Communication" retrievable="true" primaryCodePath="reasonCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Communication" identifier="http://hl7.org/fhir/StructureDefinition/Communication" label="Communication" retrievable="true" primaryCodePath="reasonCode">
       <element name="identifier" description="Unique identifier" definition="Business identifiers assigned to this communication by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4470,7 +4470,7 @@
       <search name="medium" path="medium" type="System.Code"/>
       <search name="sent" path="sent" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Communication.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Communication.Payload" retrievable="false">
       <element name="content" description="Message part content" definition="A communicated content (or for multi-part communications, one portion of the communication).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="string" xsi:type="NamedTypeSpecifier"/>
@@ -4479,10 +4479,10 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CommunicationPriority" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CommunicationPriority" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CommunicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/CommunicationRequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CommunicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/CommunicationRequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="Unique identifier" definition="Business identifiers assigned to this communication request by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4754,7 +4754,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CommunicationRequest.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CommunicationRequest.Payload" retrievable="false">
       <element name="content" description="Message part content" definition="The communicated content (or for multi-part communications, one portion of the communication).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="string" xsi:type="NamedTypeSpecifier"/>
@@ -4763,16 +4763,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CommunicationRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CommunicationRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CommunicationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CommunicationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CompartmentCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CompartmentCode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CompartmentDefinition" identifier="http://hl7.org/fhir/StructureDefinition/CompartmentDefinition" label="CompartmentDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CompartmentDefinition" identifier="http://hl7.org/fhir/StructureDefinition/CompartmentDefinition" label="CompartmentDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this compartment definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this compartment definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this compartment definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the compartment definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the compartment definition" definition="The identifier that is used to identify this version of the compartment definition when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the compartment definition author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different compartment definition instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the compartment definition with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this compartment definition (computer friendly)" definition="A natural language name identifying the compartment definition. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly.This is often the same as the code for the parameter, but does not need to be."/>
@@ -4808,7 +4808,7 @@
       <search name="name" path="name" type="System.String"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CompartmentDefinition.Resource" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CompartmentDefinition.Resource" retrievable="false">
       <element name="code" elementType="FHIR.ResourceType" description="Name of resource type" definition="The name of a resource supported by the server.">
          <binding name="ResourceType" description="One of the resource types defined as part of this version of FHIR." strength="Required"/>
       </element>
@@ -4817,10 +4817,10 @@
       </element>
       <element name="documentation" elementType="FHIR.string" description="Additional documentation about the resource and compartment" definition="Additional documentation about the resource and compartment."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CompartmentType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CompartmentType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Composition" identifier="http://hl7.org/fhir/StructureDefinition/Composition" label="Composition" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Composition" identifier="http://hl7.org/fhir/StructureDefinition/Composition" label="Composition" retrievable="true" primaryCodePath="type">
       <element name="identifier" elementType="FHIR.Identifier" description="Version-independent identifier for the Composition" definition="A version-independent identifier for the Composition. This identifier stays constant as the composition is changed over time." comment="Similar to ClinicalDocument/setId in CDA. See discussion in resource definition for how these relate."/>
       <element name="status" elementType="FHIR.CompositionStatus" description="preliminary | final | amended | entered-in-error" definition="The workflow/clinical status of this composition. The status is a marker for the clinical standing of the document." comment="If a composition is marked as withdrawn, the compositions/documents in the series, or data from the composition or document series, should never be displayed to a user without being clearly marked as untrustworthy. The flag &quot;entered-in-error&quot; is why this element is labeled as a modifier of other elements.   &#xa;&#xa;Some reporting work flows require that the original narrative of a final document never be altered; instead, only new narrative can be added. The composition resource has no explicit status for explicitly noting whether this business rule is in effect. This would be handled by an extension if required.">
          <binding name="CompositionStatus" description="The workflow/clinical status of the composition." strength="Required"/>
@@ -5210,14 +5210,14 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Attester" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Attester" retrievable="false">
       <element name="mode" elementType="FHIR.CompositionAttestationMode" description="personal | professional | legal | official" definition="The type of attestation the authenticator offers.">
          <binding name="CompositionAttestationMode" description="The way in which a person authenticated a composition." strength="Required"/>
       </element>
       <element name="time" elementType="FHIR.dateTime" description="When the composition was attested" definition="When the composition was attested by the party."/>
       <element name="party" elementType="FHIR.Reference" description="Who attested the composition" definition="Who attested the composition in the specified way."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Event" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Event" retrievable="false">
       <element name="code" description="Code(s) that apply to the event being documented" definition="This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the typeCode, such as a &quot;History and Physical Report&quot; in which the procedure being documented is necessarily a &quot;History and Physical&quot; act." comment="An event can further specialize the act inherent in the typeCode, such as where it is simply &quot;Procedure Report&quot; and the procedure was a &quot;colonoscopy&quot;. If one or more eventCodes are included, they SHALL NOT conflict with the values inherent in the classCode, practiceSettingCode or typeCode, as such a conflict would create an ambiguous situation. This short list of codes is provided to be used as key words for certain types of queries.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="DocumentEventType" description="This list of codes represents the main clinical acts being documented." strength="Example"/>
@@ -5227,7 +5227,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.RelatesTo" retrievable="false">
       <element name="code" elementType="FHIR.DocumentRelationshipType" description="replaces | transforms | signs | appends" definition="The type of relationship that this composition has with anther composition or document." comment="If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.">
          <binding name="DocumentRelationshipType" description="The type of relationship between documents." strength="Required"/>
       </element>
@@ -5238,7 +5238,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Section" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Composition.Section" retrievable="false">
       <element name="title" elementType="FHIR.string" description="Label for section (e.g. for ToC)" definition="The label for this particular section.  This will be part of the rendered content for the document, and is often used to build a table of contents." comment="The title identifies the section for a human reader. The title must be consistent with the narrative of the resource that is the target of the section.content reference. Generally, sections SHOULD have titles, but in some documents, it is unnecessary or inappropriate. Typically, this is where a section has subsections that have their own adequately distinguishing title,  or documents that only have a single section. Most Implementation Guides will make section title to be a required element."/>
       <element name="code" elementType="FHIR.CodeableConcept" description="Classification of section (recommended)" definition="A code identifying the kind of content contained within the section. This must be consistent with the section title." comment="The code identifies the section for an automated processor of the document. This is particularly relevant when using profiles to control the structure of the document.   &#xa;&#xa;If the section has content (instead of sub-sections), the section.code does not change the meaning or interpretation of the resource that is the content of the section in the comments for the section.code.">
          <binding name="CompositionSectionType" description="Classification of a section of a composition/document." strength="Example"/>
@@ -5266,13 +5266,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CompositionAttestationMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CompositionAttestationMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CompositionStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CompositionStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ConceptMap" identifier="http://hl7.org/fhir/StructureDefinition/ConceptMap" label="ConceptMap" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ConceptMap" identifier="http://hl7.org/fhir/StructureDefinition/ConceptMap" label="ConceptMap" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this concept map, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this concept map when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this concept map is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the concept map is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Additional identifier for the concept map" definition="A formal identifier that is used to identify this concept map when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this concept map outside of FHIR, where it is not possible to use the logical URI."/>
       <element name="version" elementType="FHIR.string" description="Business version of the concept map" definition="The identifier that is used to identify this version of the concept map when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the concept map author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different concept map instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the concept map with the format [url]|[version]."/>
@@ -5331,7 +5331,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group" retrievable="false">
       <element name="source" elementType="FHIR.uri" description="Source system where concepts to be mapped are defined" definition="An absolute URI that identifies the source system where the concepts to be mapped are defined." comment="This is not needed if the source value set is specified and it contains concepts from only a single system."/>
       <element name="sourceVersion" elementType="FHIR.string" description="Specific version of the  code system" definition="The specific version of the code system, as determined by the code system authority." comment="The specification of a particular code system version may be required for code systems which lack concept permanence."/>
       <element name="target" elementType="FHIR.uri" description="Target system that the concepts are to be mapped to" definition="An absolute URI that identifies the target system that the concepts will be mapped to." comment="This is not needed if the target value set is specified and it contains concepts from only a single system. The group target may also be omitted if all of the target element equivalence values are 'unmatched'."/>
@@ -5348,7 +5348,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Identifies element being mapped" definition="Identity (code or path) or the element/item being mapped."/>
       <element name="display" elementType="FHIR.string" description="Display for the code" definition="The display for the code. The display is only provided to help editors when editing the concept map." comment="The display is ignored when processing the map."/>
       <element name="target" description="Concept in target system for element" definition="A concept from the target value set that this concept maps to." comment="Ideally there would only be one map, with equal or equivalent mapping. But multiple maps are allowed for several narrower options, or to assert that other concepts are unmatched.">
@@ -5358,7 +5358,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element.Target" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Code that identifies the target element" definition="Identity (code or path) or the element/item that the map refers to."/>
       <element name="display" elementType="FHIR.string" description="Display for the code" definition="The display for the code. The display is only provided to help editors when editing the concept map." comment="The display is ignored when processing the map."/>
       <element name="equivalence" elementType="FHIR.ConceptMapEquivalence" description="relatedto | equivalent | equal | wider | subsumes | narrower | specializes | inexact | unmatched | disjoint" definition="The equivalence between the source and target concepts (counting for the dependencies and products). The equivalence is read from target to source (e.g. the target is 'wider' than the source)." comment="This element is labeled as a modifier because it may indicate that a target does not apply.">
@@ -5374,13 +5374,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element.Target.DependsOn" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Element.Target.DependsOn" retrievable="false">
       <element name="property" elementType="FHIR.uri" description="Reference to property mapping depends on" definition="A reference to an element that holds a coded value that corresponds to a code system property. The idea is that the information model carries an element somewhere that is labeled to correspond with a code system property."/>
       <element name="system" elementType="FHIR.canonical" description="Code System (if necessary)" definition="An absolute URI that identifies the code system of the dependency code (if the source/dependency is a value set that crosses code systems)."/>
       <element name="value" elementType="FHIR.string" description="Value of the referenced element" definition="Identity (code or path) or the element/item/ValueSet/text that the map depends on / refers to."/>
       <element name="display" elementType="FHIR.string" description="Display for the code (if value is a code)" definition="The display for the code. The display is only provided to help editors when editing the concept map." comment="The display is ignored when processing the map."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Unmapped" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ConceptMap.Group.Unmapped" retrievable="false">
       <element name="mode" elementType="FHIR.ConceptMapGroupUnmappedMode" description="provided | fixed | other-map" definition="Defines which action to take if there is no match for the source concept in the target system designated for the group. One of 3 actions are possible: use the unmapped code (this is useful when doing a mapping between versions, and only a few codes have changed), use a fixed code (a default code), or alternatively, a reference to a different concept map can be provided (by canonical URL).">
          <binding name="ConceptMapGroupUnmappedMode" description="Defines which action to take if there is no match in the group." strength="Required"/>
       </element>
@@ -5388,13 +5388,13 @@
       <element name="display" elementType="FHIR.string" description="Display for the code" definition="The display for the code. The display is only provided to help editors when editing the concept map." comment="The display is ignored when processing the map."/>
       <element name="url" elementType="FHIR.canonical" description="canonical reference to an additional ConceptMap to use for mapping if the source concept is unmapped" definition="The canonical reference to an additional ConceptMap resource instance to use for mapping if this ConceptMap resource contains no matching mapping for the source concept."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConceptMapEquivalence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConceptMapEquivalence" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConceptMapGroupUnmappedMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConceptMapGroupUnmappedMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Condition" identifier="http://hl7.org/fhir/StructureDefinition/Condition" label="Condition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Condition" identifier="http://hl7.org/fhir/StructureDefinition/Condition" label="Condition" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External Ids for this condition" definition="Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5648,7 +5648,7 @@
       <search name="stage" path="stage.summary" type="System.Code"/>
       <search name="onset-info" path="onset.as(string)" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Condition.Evidence" retrievable="false">
       <element name="code" description="Manifestation/symptom" definition="A manifestation or symptom that led to the recording of this condition.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="ManifestationOrSymptom" description="Codes that describe the manifestation or symptoms of a condition." strength="Example"/>
@@ -5657,7 +5657,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="FHIR.CodeableConcept" description="Simple summary (disease specific)" definition="A simple summary of the stage such as &quot;Stage 3&quot;. The determination of the stage is disease-specific.">
          <binding name="ConditionStage" description="Codes describing condition stages (e.g. Cancer stages)." strength="Example"/>
       </element>
@@ -5668,13 +5668,13 @@
          <binding name="ConditionStageType" description="Codes describing the kind of condition staging (e.g. clinical or pathological)." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConditionalDeleteStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConditionalDeleteStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConditionalReadStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConditionalReadStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Consent" identifier="http://hl7.org/fhir/StructureDefinition/Consent" label="Consent" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Consent" identifier="http://hl7.org/fhir/StructureDefinition/Consent" label="Consent" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="Identifier for this record (external references)" definition="Unique identifier for this copy of the Consent Statement." comment="This identifier identifies this copy of the consent. Where this identifier is also used elsewhere as the identifier for a consent record (e.g. a CDA consent document) then the consent details are expected to be the same.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5908,11 +5908,11 @@
       </search>
       <search name="security-label" path="provision.securityLabel" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Policy" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Policy" retrievable="false">
       <element name="authority" elementType="FHIR.uri" description="Enforcement source for policy" definition="Entity or Organization having regulatory jurisdiction or accountability for  enforcing policies pertaining to Consent Directives."/>
       <element name="uri" elementType="FHIR.uri" description="Specific policy covered by this consent" definition="The references to the policies that are included in this consent scope. Policies may be organizational, but are often defined jurisdictionally, or in law." comment="This element is for discoverability / documentation and does not modify or qualify the policy rules."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision" retrievable="false">
       <element name="type" elementType="FHIR.ConsentProvisionType" description="deny | permit" definition="Action  to take - permit or deny - when the rule conditions are met.  Not permitted in root rule, required in all nested rules.">
          <binding name="ConsentProvisionType" description="How a rule statement is applied, such as adding additional consent or removing consent." strength="Required"/>
       </element>
@@ -5950,42 +5950,42 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision.Actor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision.Actor" retrievable="false">
       <element name="role" elementType="FHIR.CodeableConcept" description="How the actor is involved" definition="How the individual is involved in the resources content that is described in the exception.">
          <binding name="ConsentActorRole" description="How an actor is involved in the consent considerations." strength="Extensible"/>
       </element>
       <element name="reference" elementType="FHIR.Reference" description="Resource for the actor (or group, by role)" definition="The resource that identifies the actor. To identify actors by type, use group to identify a set of actors by some property they share (e.g. 'admitting officers')."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision.Data" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Provision.Data" retrievable="false">
       <element name="meaning" elementType="FHIR.ConsentDataMeaning" description="instance | related | dependents | authoredby" definition="How the resource reference is interpreted when testing consent restrictions.">
          <binding name="ConsentDataMeaning" description="How a resource reference is interpreted when testing consent restrictions." strength="Required"/>
       </element>
       <element name="reference" elementType="FHIR.Reference" description="The actual data reference" definition="A reference to a specific resource that defines which resources are covered by this consent."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Verification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Consent.Verification" retrievable="false">
       <element name="verified" elementType="FHIR.boolean" description="Has been verified" definition="Has the instruction been verified."/>
       <element name="verifiedWith" elementType="FHIR.Reference" description="Person who verified" definition="Who verified the instruction (Patient, Relative or other Authorized Person)."/>
       <element name="verificationDate" elementType="FHIR.dateTime" description="When consent verified" definition="Date verification was collected."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConsentDataMeaning" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConsentDataMeaning" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConsentProvisionType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConsentProvisionType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConsentState" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConsentState" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ConstraintSeverity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ConstraintSeverity" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name of an individual to contact" definition="The name of an individual to contact." comment="If there is no named individual, the telecom information is for the organization as a whole."/>
       <element name="telecom" description="Contact details for individual or organization" definition="The contact details for the individual (if a name was provided) or the organization.">
          <elementTypeSpecifier elementType="FHIR.ContactPoint" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="FHIR.ContactPointSystem" description="phone | fax | email | pager | url | sms | other" definition="Telecommunications form for contact point - what communications system is required to make use of the contact.">
          <binding name="ContactPointSystem" description="Telecommunications form for contact point." strength="Required"/>
       </element>
@@ -5996,13 +5996,13 @@
       <element name="rank" elementType="FHIR.positiveInt" description="Specify preferred order of use (1 = highest)" definition="Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values." comment="Note that rank does not necessarily follow the order in which the contacts are represented in the instance."/>
       <element name="period" elementType="FHIR.Period" description="Time period when the contact point was/is in use" definition="Time period when the contact point was/is in use."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContactPointSystem" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContactPointUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Contract" identifier="http://hl7.org/fhir/StructureDefinition/Contract" label="Contract" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Contract" identifier="http://hl7.org/fhir/StructureDefinition/Contract" label="Contract" retrievable="true">
       <element name="identifier" description="Contract number" definition="Unique identifier for this Contract or a derivative that references a Source Contract.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6254,7 +6254,7 @@
       <search name="instantiates" path="instantiatesUri" type="System.String"/>
       <search name="authority" path="authority" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.ContentDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.ContentDefinition" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Content structure and use" definition="Precusory content structure and use, i.e., a boilerplate, template, application for a contract such as an insurance policy or benefits under a program, e.g., workers compensation.">
          <binding name="ContractDefinitionType" description="Detailed codes for the definition of contracts." strength="Example"/>
       </element>
@@ -6268,7 +6268,7 @@
       </element>
       <element name="copyright" elementType="FHIR.markdown" description="Publication Ownership" definition="A copyright statement relating to Contract precursor content. Copyright statements are generally legal restrictions on the use and publishing of the Contract precursor content."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Friendly" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Friendly" retrievable="false">
       <element name="content" description="Easily comprehended representation of this Contract" definition="Human readable rendering of this Contract in a format and representation intended to enhance comprehension and ensure understandability.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Attachment" xsi:type="NamedTypeSpecifier"/>
@@ -6276,7 +6276,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Legal" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Legal" retrievable="false">
       <element name="content" description="Contract Legal Text" definition="Contract legal text in human renderable form.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Attachment" xsi:type="NamedTypeSpecifier"/>
@@ -6284,7 +6284,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Rule" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Rule" retrievable="false">
       <element name="content" description="Computable Contract Rules" definition="Computable Contract conveyed using a policy rule language (e.g. XACML, DKAL, SecPal).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Attachment" xsi:type="NamedTypeSpecifier"/>
@@ -6292,7 +6292,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Signer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Signer" retrievable="false">
       <element name="type" elementType="FHIR.Coding" description="Contract Signatory Role" definition="Role of this Contract signer, e.g. notary, grantee.">
          <binding name="ContractSignerType" description="List of parties who may be signing." strength="Preferred"/>
       </element>
@@ -6301,7 +6301,7 @@
          <elementTypeSpecifier elementType="FHIR.Signature" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Contract Term Number" definition="Unique identifier for this particular Contract Provision."/>
       <element name="issued" elementType="FHIR.dateTime" description="Contract Term Issue Date Time" definition="When this Contract Provision was issued."/>
       <element name="applies" elementType="FHIR.Period" description="Contract Term Effective Time" definition="Relevant time or time-period when this Contract Provision is applicable."/>
@@ -6334,7 +6334,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Action" retrievable="false">
       <element name="doNotPerform" elementType="FHIR.boolean" description="True if the term prohibits the  action" definition="True if the term prohibits the  action."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type or form of the action" definition="Activity or service obligation to be done or not done, performed or not performed, effectuated or not by this Contract term.">
          <binding name="ContractAction" description="Detailed codes for the contract action." strength="Example"/>
@@ -6399,7 +6399,7 @@
          <elementTypeSpecifier elementType="FHIR.unsignedInt" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Action.Subject" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Action.Subject" retrievable="false">
       <element name="reference" description="Entity of the action" definition="The entity the action is performed or not performed on or for.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6407,7 +6407,7 @@
          <binding name="ContractActorRole" description="Detailed codes for the contract actor role." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset" retrievable="false">
       <element name="scope" elementType="FHIR.CodeableConcept" description="Range of asset" definition="Differentiates the kind of the asset .">
          <binding name="ContractAssetScope" description="Codes for scoping an asset." strength="Example"/>
       </element>
@@ -6455,7 +6455,7 @@
          <elementTypeSpecifier elementType="FHIR.Contract.Term.Asset.ValuedItem" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset.Context" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset.Context" retrievable="false">
       <element name="reference" elementType="FHIR.Reference" description="Creator,custodian or owner" definition="Asset context reference may include the creator, custodian, or owning Person or Organization (e.g., bank, repository),  location held, e.g., building,  jurisdiction."/>
       <element name="code" description="Codeable asset context" definition="Coded representation of the context generally or of the Referenced entity, such as the asset holder type or location.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -6463,7 +6463,7 @@
       </element>
       <element name="text" elementType="FHIR.string" description="Context description" definition="Context description."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset.ValuedItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Asset.ValuedItem" retrievable="false">
       <element name="entity" description="Contract Valued Item Type" definition="Specific type of Contract Valued Item that may be priced.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -6488,7 +6488,7 @@
          <elementTypeSpecifier elementType="FHIR.unsignedInt" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer" retrievable="false">
       <element name="identifier" description="Offer business ID" definition="Unique identifier for this particular Contract Provision.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6517,7 +6517,7 @@
          <elementTypeSpecifier elementType="FHIR.unsignedInt" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer.Answer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer.Answer" retrievable="false">
       <element name="value" description="The actual answer response" definition="Response to an offer clause or question text,  which enables selection of values to be agreed to, e.g., the period of participation, the date of occupancy of a rental, warrently duration, or whether biospecimen may be used for further research.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="boolean" xsi:type="NamedTypeSpecifier"/>
@@ -6535,7 +6535,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer.Party" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.Offer.Party" retrievable="false">
       <element name="reference" description="Referenced entity" definition="Participant in the offer.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6543,7 +6543,7 @@
          <binding name="ContractPartyRole" description="Codes for offer participant roles." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.SecurityLabel" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Contract.Term.SecurityLabel" retrievable="false">
       <element name="number" description="Link to Security Labels" definition="Number used to link this term or term element to the applicable Security Label.">
          <elementTypeSpecifier elementType="FHIR.unsignedInt" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6559,13 +6559,13 @@
          <binding name="ContractSecurityControl" description="Codes for handling instructions." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContractPublicationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContractPublicationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContractStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContractStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="FHIR.ContributorType" description="author | editor | reviewer | endorser" definition="The type of contributor.">
          <binding name="ContributorType" description="The type of contributor." strength="Required"/>
       </element>
@@ -6574,11 +6574,11 @@
          <elementTypeSpecifier elementType="FHIR.ContactDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ContributorType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ContributorType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="Count" identifier="http://hl7.org/fhir/StructureDefinition/Count" label="Count" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Coverage" identifier="http://hl7.org/fhir/StructureDefinition/Coverage" label="Coverage" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Coverage" identifier="http://hl7.org/fhir/StructureDefinition/Coverage" label="Coverage" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier for the coverage" definition="A unique identifier assigned to this coverage." comment="The main (and possibly only) identifier for the coverage - often referred to as a Member Id, Certificate number, Personal Health Number or Case ID. May be constructed as the concatenation of the Coverage.SubscriberID and the Coverage.dependant.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6648,14 +6648,14 @@
       </search>
       <search name="dependent" path="dependent" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.Class" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.Class" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of class such as 'group' or 'plan'" definition="The type of classification for which an insurer-specific class label or number and optional name is provided, for example may be used to identify a class of coverage or employer group, Policy, Plan.">
          <binding name="CoverageClass" description="The policy classifications, eg. Group, Plan, Class, etc." strength="Extensible"/>
       </element>
       <element name="value" elementType="FHIR.string" description="Value associated with the type" definition="The alphanumeric string value associated with the insurer issued label." comment="For example, the Group or Plan number."/>
       <element name="name" elementType="FHIR.string" description="Human readable description of the type and value" definition="A short description for the class."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.CostToBeneficiary" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.CostToBeneficiary" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Cost category" definition="The category of patient centric costs associated with treatment." comment="For example visit, specialist visits, emergency, inpatient care, etc.">
          <binding name="CopayTypes" description="The types of services to which patient copayments are specified." strength="Extensible"/>
       </element>
@@ -6669,13 +6669,13 @@
          <elementTypeSpecifier elementType="FHIR.Coverage.CostToBeneficiary.Exception" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.CostToBeneficiary.Exception" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Coverage.CostToBeneficiary.Exception" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Exception category" definition="The code for the specific exception.">
          <binding name="CoverageFinancialException" description="The types of exceptions from the part or full value of financial obligations such as copays." strength="Example"/>
       </element>
       <element name="period" elementType="FHIR.Period" description="The effective period of the exception" definition="The timeframe during when the exception is in force."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CoverageEligibilityRequest" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest" label="CoverageEligibilityRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CoverageEligibilityRequest" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest" label="CoverageEligibilityRequest" retrievable="true">
       <element name="identifier" description="Business Identifier for coverage eligiblity request" definition="A unique identifier assigned to this coverage eligiblity request.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6732,12 +6732,12 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Insurance" retrievable="false">
       <element name="focal" elementType="FHIR.boolean" description="Applicable coverage" definition="A flag to indicate that this Coverage is to be used for evaluation of this request when set to true." comment="A patient may (will) have multiple insurance policies which provide reimburement for healthcare services and products. For example a person may also be covered by their spouse's policy and both appear in the list (and may be from the same insurer). This flag will be set to true for only one of the listed policies and that policy will be used for evaluating this request. Other requests would be created to request evaluation against the other listed policies."/>
       <element name="coverage" elementType="FHIR.Reference" description="Insurance information" definition="Reference to the insurance card level information contained in the Coverage resource. The coverage issuing insurer will use these details to locate the patient's actual coverage within the insurer's information system."/>
       <element name="businessArrangement" elementType="FHIR.string" description="Additional provider contract number" definition="A business agreement number established between the provider and the insurer for special business processing purposes."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Item" retrievable="false">
       <element name="supportingInfoSequence" description="Applicable exception or supporting information" definition="Exceptions, special conditions and supporting information applicable for this service or product line.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6762,7 +6762,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Item.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.Item.Diagnosis" retrievable="false">
       <element name="diagnosis" description="Nature of illness or problem" definition="The nature of illness or problem in a coded form or as a reference to an external defined Condition.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -6771,12 +6771,12 @@
          <binding name="ICD10" description="ICD10 Diagnostic codes." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityRequest.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Information instance identifier" definition="A number to uniquely identify supporting information entries."/>
       <element name="information" elementType="FHIR.Reference" description="Data to be provided" definition="Additional data or information such as resources, documents, images etc. including references to the data or the actual inclusion of the data." comment="Could be used to provide references to other resources, document. For example could contain a PDF in an Attachment of the Police Report for an Accident."/>
       <element name="appliesToAll" elementType="FHIR.boolean" description="Applies to all items" definition="The supporting materials are applicable for all detail items, product/servce categories and specific billing codes."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="CoverageEligibilityResponse" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityResponse" label="CoverageEligibilityResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="CoverageEligibilityResponse" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityResponse" label="CoverageEligibilityResponse" retrievable="true">
       <element name="identifier" description="Business Identifier for coverage eligiblity request" definition="A unique identifier assigned to this coverage eligiblity request.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -6830,12 +6830,12 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Error" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Error" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Error code detailing processing issues" definition="An error code,from a specified code system, which details why the eligibility check could not be performed.">
          <binding name="AdjudicationError" description="The error codes for adjudication processing." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance" retrievable="false">
       <element name="coverage" elementType="FHIR.Reference" description="Insurance information" definition="Reference to the insurance card level information contained in the Coverage resource. The coverage issuing insurer will use these details to locate the patient's actual coverage within the insurer's information system."/>
       <element name="inforce" elementType="FHIR.boolean" description="Coverage inforce indicator" definition="Flag indicating if the coverage provided is inforce currently if no service date(s) specified or for the whole duration of the service dates."/>
       <element name="benefitPeriod" elementType="FHIR.Period" description="When the benefits are applicable" definition="The term of the benefits documented in this response."/>
@@ -6846,7 +6846,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance.Item" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Benefit classification" definition="Code to identify the general type of benefits under which products and services are provided." comment="Examples include Medical Care, Periodontics, Renal Dialysis, Vision Coverage.">
          <binding name="BenefitCategory" description="Benefit categories such as: oral, medical, vision etc." strength="Example"/>
       </element>
@@ -6880,7 +6880,7 @@
       </element>
       <element name="authorizationUrl" elementType="FHIR.uri" description="Preauthorization requirements endpoint" definition="A web location for obtaining requirements or descriptive information regarding the preauthorization."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance.Item.Benefit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="CoverageEligibilityResponse.Insurance.Item.Benefit" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Benefit classification" definition="Classification of benefit being provided." comment="For example: deductible, visits, benefit amount.">
          <binding name="BenefitType" description="Deductable, visits, co-pay, etc." strength="Example"/>
       </element>
@@ -6899,13 +6899,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CoverageStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CoverageStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="CurrencyCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="CurrencyCode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="FHIR.FHIRAllTypes" description="The type of the required data" definition="The type of the required data, specified as the type name of a resource. For profiles, this value is set to the type of the base resource of the profile.">
          <binding name="FHIRAllTypes" description="A list of all the concrete types defined in this version of the FHIR specification - Abstract Types, Data Types and Resource Types." strength="Required"/>
       </element>
@@ -6939,7 +6939,7 @@
          <elementTypeSpecifier elementType="FHIR.DataRequirement.Sort" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="FHIR.string" description="A code-valued attribute to filter on" definition="The code-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type code, Coding, or CodeableConcept." comment="The path attribute contains a [Simple FHIRPath Subset](fhirpath.html#simple) that allows path traversal, but not calculation."/>
       <element name="searchParam" elementType="FHIR.string" description="A coded (token) parameter to search on" definition="A token parameter that refers to a search parameter defined on the specified type of the DataRequirement, and which searches on elements of type code, Coding, or CodeableConcept."/>
       <element name="valueSet" elementType="FHIR.canonical" description="Valueset for the filter" definition="The valueset for the code filter. The valueSet and code elements are additive. If valueSet is specified, the filter will return only those data items for which the value of the code-valued element specified in the path is a member of the specified valueset."/>
@@ -6947,7 +6947,7 @@
          <elementTypeSpecifier elementType="FHIR.Coding" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="FHIR.string" description="A date-valued attribute to filter on" definition="The date-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type date, dateTime, Period, Schedule, or Timing." comment="The path attribute contains a [Simple FHIR Subset](fhirpath.html#simple) that allows path traversal, but not calculation."/>
       <element name="searchParam" elementType="FHIR.string" description="A date valued parameter to search on" definition="A date parameter that refers to a search parameter defined on the specified type of the DataRequirement, and which searches on elements of type date, dateTime, Period, Schedule, or Timing."/>
       <element name="value" description="The value of the filter, as a Period, DateTime, or Duration value" definition="The value of the filter. If period is specified, the filter will return only those data items that fall within the bounds determined by the Period, inclusive of the period boundaries. If dateTime is specified, the filter will return only those data items that are equal to the specified dateTime. If a Duration is specified, the filter will return only those data items that fall within Duration before now.">
@@ -6958,19 +6958,19 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="FHIR.string" description="The name of the attribute to perform the sort" definition="The attribute of the sort. The specified path must be resolvable from the type of the required data. The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements. Note that the index must be an integer constant."/>
       <element name="direction" elementType="FHIR.SortDirection" description="ascending | descending" definition="The direction of the sort, ascending or descending.">
          <binding name="SortDirection" description="The possible sort directions, ascending or descending." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DayOfWeek" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DaysOfWeek" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DetectedIssue" identifier="http://hl7.org/fhir/StructureDefinition/DetectedIssue" label="DetectedIssue" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DetectedIssue" identifier="http://hl7.org/fhir/StructureDefinition/DetectedIssue" label="DetectedIssue" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Unique id for the detected issue" definition="Business identifier associated with the detected issue record.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7171,7 +7171,7 @@
       <search name="identified" path="identified" type="System.DateTime"/>
       <search name="code" path="code" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DetectedIssue.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DetectedIssue.Evidence" retrievable="false">
       <element name="code" description="Manifestation" definition="A manifestation that led to the recording of this detected issue.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="DetectedIssueEvidenceCode" description="Codes that describes the types of evidence for a detected issue." strength="Example"/>
@@ -7180,20 +7180,20 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DetectedIssue.Mitigation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DetectedIssue.Mitigation" retrievable="false">
       <element name="action" elementType="FHIR.CodeableConcept" description="What mitigation?" definition="Describes the action that was taken or the observation that was made that reduces/eliminates the risk associated with the identified issue." comment="The &quot;text&quot; component can be used for detail or when no appropriate code exists.">
          <binding name="DetectedIssueMitigationAction" description="Codes describing steps taken to resolve the issue or other circumstances that mitigate the risk associated with the issue; e.g. 'added concurrent therapy', 'prior therapy documented', etc." strength="Preferred"/>
       </element>
       <element name="date" elementType="FHIR.dateTime" description="Date committed" definition="Indicates when the mitigating action was documented." comment="This might not be the same as when the mitigating step was actually taken."/>
       <element name="author" elementType="FHIR.Reference" description="Who is committing?" definition="Identifies the practitioner who determined the mitigation and takes responsibility for the mitigation step occurring."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DetectedIssueSeverity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DetectedIssueSeverity" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DetectedIssueStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DetectedIssueStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Device" identifier="http://hl7.org/fhir/StructureDefinition/Device" label="Device" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Device" identifier="http://hl7.org/fhir/StructureDefinition/Device" label="Device" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by manufacturers other organizations or owners." comment="The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7258,13 +7258,13 @@
       <search name="status" path="status" type="System.Code"/>
       <search name="organization" path="owner" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="FHIR.string" description="The name of the device" definition="The name of the device."/>
       <element name="type" elementType="FHIR.DeviceNameType" description="udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other" definition="The type of deviceName.&#xa;UDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.">
          <binding name="DeviceNameType" description="The type of name the device is referred by." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Property" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)" definition="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)."/>
       <element name="valueQuantity" description="Property value as a quantity" definition="Property value as a quantity.">
          <elementTypeSpecifier elementType="FHIR.Quantity" xsi:type="ListTypeSpecifier"/>
@@ -7273,11 +7273,11 @@
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="FHIR.CodeableConcept" description="The standard that is used to operate and communicate" definition="The standard that is used to operate and communicate."/>
       <element name="version" elementType="FHIR.string" description="The version of the standard that is used to operate and communicate" definition="The version of the standard that is used to operate and communicate."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="FHIR.string" description="Mandatory fixed portion of UDI" definition="The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device."/>
       <element name="issuer" elementType="FHIR.uri" description="UDI Issuing Organization" definition="Organization that is charged with issuing UDIs for devices.  For example, the US FDA issuers include :&#xa;1) GS1: &#xa;http://hl7.org/fhir/NamingSystem/gs1-di, &#xa;2) HIBCC:&#xa;http://hl7.org/fhir/NamingSystem/hibcc-dI, &#xa;3) ICCBBA for blood containers:&#xa;http://hl7.org/fhir/NamingSystem/iccbba-blood-di, &#xa;4) ICCBA for other devices:&#xa;http://hl7.org/fhir/NamingSystem/iccbba-other-di."/>
       <element name="jurisdiction" elementType="FHIR.uri" description="Regional UDI authority" definition="The identity of the authoritative source for UDI generation within a  jurisdiction.  All UDIs are globally unique within a single namespace with the appropriate repository uri as the system.  For example,  UDIs of devices managed in the U.S. by the FDA, the value is  http://hl7.org/fhir/NamingSystem/fda-udi."/>
@@ -7287,12 +7287,12 @@
          <binding name="UDIEntryType" description="Codes to identify how UDI data was entered." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Device.Version" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The type of the device version" definition="The type of the device version."/>
       <element name="component" elementType="FHIR.Identifier" description="A single component of the device version" definition="A single component of the device version."/>
       <element name="value" elementType="FHIR.string" description="The version text" definition="The version text."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceDefinition" identifier="http://hl7.org/fhir/StructureDefinition/DeviceDefinition" label="DeviceDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceDefinition" identifier="http://hl7.org/fhir/StructureDefinition/DeviceDefinition" label="DeviceDefinition" retrievable="true">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by the software, manufacturers, other organizations or owners. For example: handle ID.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7353,24 +7353,24 @@
       <search name="parent" path="parentDevice" type="FHIR.DeviceDefinition"/>
       <search name="type" path="type" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Capability" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Capability" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of capability" definition="Type of capability."/>
       <element name="description" description="Description of capability" definition="Description of capability.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.DeviceName" retrievable="false">
       <element name="name" elementType="FHIR.string" description="The name of the device" definition="The name of the device."/>
       <element name="type" elementType="FHIR.DeviceNameType" description="udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other" definition="The type of deviceName.&#xa;UDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.">
          <binding name="DeviceNameType" description="The type of name the device is referred by." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Material" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Material" retrievable="false">
       <element name="substance" elementType="FHIR.CodeableConcept" description="The substance" definition="The substance."/>
       <element name="alternate" elementType="FHIR.boolean" description="Indicates an alternative material of the device" definition="Indicates an alternative material of the device."/>
       <element name="allergenicIndicator" elementType="FHIR.boolean" description="Whether the substance is a known or suspected allergen" definition="Whether the substance is a known or suspected allergen."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Property" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)" definition="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)."/>
       <element name="valueQuantity" description="Property value as a quantity" definition="Property value as a quantity.">
          <elementTypeSpecifier elementType="FHIR.Quantity" xsi:type="ListTypeSpecifier"/>
@@ -7379,16 +7379,16 @@
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.Specialization" retrievable="false">
       <element name="systemType" elementType="FHIR.string" description="The standard that is used to operate and communicate" definition="The standard that is used to operate and communicate."/>
       <element name="version" elementType="FHIR.string" description="The version of the standard that is used to operate and communicate" definition="The version of the standard that is used to operate and communicate."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.UdiDeviceIdentifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceDefinition.UdiDeviceIdentifier" retrievable="false">
       <element name="deviceIdentifier" elementType="FHIR.string" description="The identifier that is to be associated with every Device that references this DeviceDefintiion for the issuer and jurisdication porvided in the DeviceDefinition.udiDeviceIdentifier" definition="The identifier that is to be associated with every Device that references this DeviceDefintiion for the issuer and jurisdication porvided in the DeviceDefinition.udiDeviceIdentifier."/>
       <element name="issuer" elementType="FHIR.uri" description="The organization that assigns the identifier algorithm" definition="The organization that assigns the identifier algorithm."/>
       <element name="jurisdiction" elementType="FHIR.uri" description="The jurisdiction to which the deviceIdentifier applies" definition="The jurisdiction to which the deviceIdentifier applies."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceMetric" identifier="http://hl7.org/fhir/StructureDefinition/DeviceMetric" label="DeviceMetric" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceMetric" identifier="http://hl7.org/fhir/StructureDefinition/DeviceMetric" label="DeviceMetric" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by the device or gateway software, manufacturers, other organizations or owners. For example: handle ID." comment="For identifiers assigned to a device by the device or gateway software, the `system` element of the identifier should be set to the unique identifier of the device.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7419,7 +7419,7 @@
       <search name="source" path="source" type="FHIR.Device"/>
       <search name="parent" path="parent" type="FHIR.Device"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceMetric.Calibration" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceMetric.Calibration" retrievable="false">
       <element name="type" elementType="FHIR.DeviceMetricCalibrationType" description="unspecified | offset | gain | two-point" definition="Describes the type of the calibration method.">
          <binding name="DeviceMetricCalibrationType" description="Describes the type of a metric calibration." strength="Required"/>
       </element>
@@ -7428,25 +7428,25 @@
       </element>
       <element name="time" elementType="FHIR.instant" description="Describes the time last calibration has been performed" definition="Describes the time last calibration has been performed."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCalibrationState" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCalibrationState" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCalibrationType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCalibrationType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCategory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricCategory" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricColor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricColor" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricOperationalStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceMetricOperationalStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceNameType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceRequest" identifier="http://hl7.org/fhir/StructureDefinition/DeviceRequest" label="DeviceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceRequest" identifier="http://hl7.org/fhir/StructureDefinition/DeviceRequest" label="DeviceRequest" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External Request identifier" definition="Identifiers assigned to this order by the orderer or by the receiver.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7882,7 +7882,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DeviceRequest.Parameter" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Device detail" definition="A code or string that identifies the device detail being asserted.">
          <binding name="ParameterCode" description="A code that identifies the device detail." strength="Example"/>
       </element>
@@ -7895,10 +7895,10 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceUseStatement" identifier="http://hl7.org/fhir/StructureDefinition/DeviceUseStatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DeviceUseStatement" identifier="http://hl7.org/fhir/StructureDefinition/DeviceUseStatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code">
       <element name="identifier" description="External identifier for this record" definition="An external identifier for this statement such as an IRI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -7951,10 +7951,10 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="device" path="device" type="FHIR.Device"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DeviceUseStatementStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DeviceUseStatementStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DiagnosticReport" identifier="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" label="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DiagnosticReport" identifier="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" label="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for report" definition="Identifiers assigned to this report by the performer or other systems." comment="Usually assigned by the Information System of the diagnostic service provider (filler id).">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -8066,21 +8066,21 @@
       </search>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="FHIR.string" description="Comment about the image (e.g. explanation)" definition="A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features." comment="The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion."/>
       <element name="link" elementType="FHIR.Reference" description="Reference to the image source" definition="Reference to the image source."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DiagnosticReportStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DiagnosticReportStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DiscriminatorType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DiscriminatorType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="Distance" identifier="http://hl7.org/fhir/StructureDefinition/Distance" label="Distance" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DocumentConfidentiality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DocumentConfidentiality" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DocumentManifest" identifier="http://hl7.org/fhir/StructureDefinition/DocumentManifest" label="DocumentManifest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DocumentManifest" identifier="http://hl7.org/fhir/StructureDefinition/DocumentManifest" label="DocumentManifest" retrievable="true">
       <element name="masterIdentifier" elementType="FHIR.Identifier" description="Unique Identifier for the set of documents" definition="A single identifier that uniquely identifies this manifest. Principally used to refer to the manifest in non-FHIR contexts."/>
       <element name="identifier" description="Other identifiers for the manifest" definition="Other identifiers associated with the document manifest, including version independent  identifiers.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -8457,14 +8457,14 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentManifest.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentManifest.Related" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Identifiers of things that are related" definition="Related identifier to this DocumentManifest.  For example, Order numbers, accession numbers, XDW workflow numbers." comment="If both identifier and ref elements are present they shall refer to the same thing."/>
       <element name="ref" elementType="FHIR.Reference" description="Related Resource" definition="Related Resource to this DocumentManifest. For example, Order, ServiceRequest,  Procedure, EligibilityRequest, etc." comment="If both identifier and ref elements are present they shall refer to the same thing."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DocumentMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DocumentMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="DocumentReference" identifier="http://hl7.org/fhir/StructureDefinition/DocumentReference" label="DocumentReference" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="DocumentReference" identifier="http://hl7.org/fhir/StructureDefinition/DocumentReference" label="DocumentReference" retrievable="true">
       <element name="masterIdentifier" elementType="FHIR.Identifier" description="Master Version Specific Identifier" definition="Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document." comment="CDA Document Id extension and root."/>
       <element name="identifier" description="Other identifiers for the document" definition="Other identifiers associated with the document, including version independent identifiers.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -8715,13 +8715,13 @@
       <search name="language" path="content.attachment.language" type="System.Code"/>
       <search name="period" path="context.period" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.Content" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.Content" retrievable="false">
       <element name="attachment" elementType="FHIR.Attachment" description="Where to access the document" definition="The document or URL of the document along with critical metadata to prove content has integrity."/>
       <element name="format" elementType="FHIR.Coding" description="Format/content rules for the document" definition="An identifier of the document encoding, structure, and template that the document conforms to beyond the base format indicated in the mimeType." comment="Note that while IHE mostly issues URNs for format types, not all documents can be identified by a URI.">
          <binding name="DocumentFormat" description="Document Format Codes." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.Context" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.Context" retrievable="false">
       <element name="encounter" description="Context of the document  content" definition="Describes the clinical encounter or type of care that the document content is associated with.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -8741,19 +8741,19 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="DocumentReference.RelatesTo" retrievable="false">
       <element name="code" elementType="FHIR.DocumentRelationshipType" description="replaces | transforms | signs | appends" definition="The type of relationship that this document has with anther document." comment="If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.">
          <binding name="DocumentRelationshipType" description="The type of relationship between documents." strength="Required"/>
       </element>
       <element name="target" elementType="FHIR.Reference" description="Target of the relationship" definition="The target document of this relationship."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DocumentReferenceStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DocumentReferenceStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="DocumentRelationshipType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="DocumentRelationshipType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Resource" namespace="FHIR" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Resource" namespace="FHIR" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="FHIR.Narrative" description="Text summary of the resource, for human interpretation" definition="A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." comment="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a &quot;text blob&quot; or where text is additionally entered raw or narrated and encoded information is added later."/>
       <element name="contained" description="Contained, inline Resources" definition="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope." comment="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.">
          <elementTypeSpecifier elementType="FHIR.Resource" xsi:type="ListTypeSpecifier"/>
@@ -8765,7 +8765,7 @@
          <elementTypeSpecifier elementType="FHIR.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="FHIR.integer" description="The order of the dosage instructions" definition="Indicates the order in which the dosage instructions should be applied or interpreted."/>
       <element name="text" elementType="FHIR.string" description="Free text dosage instructions e.g. SIG" definition="Free text dosage instructions e.g. SIG."/>
       <element name="additionalInstruction" description="Supplemental instruction or warnings to the patient - e.g. &quot;with meals&quot;, &quot;may cause drowsiness&quot;" definition="Supplemental instructions to the patient on how to take the medication  (e.g. &quot;with meals&quot; or&quot;take half to one hour before food&quot;) or warnings for the patient about the medication (e.g. &quot;may cause drowsiness&quot; or &quot;avoid exposure of skin to direct sunlight or sunlamps&quot;)." comment="Information about administration or preparation of the medication (e.g. &quot;infuse as rapidly as possibly via intraperitoneal port&quot; or &quot;immediately following drug x&quot;) should be populated in dosage.text.">
@@ -8797,7 +8797,7 @@
       <element name="maxDosePerAdministration" elementType="FHIR.SimpleQuantity" description="Upper limit on medication per administration" definition="Upper limit on medication per administration." comment="This is intended for use as an adjunct to the dosage when there is an upper cap.  For example, a body surface area related dose with a maximum amount, such as 1.5 mg/m2 (maximum 2 mg) IV over 5 – 10 minutes would have doseQuantity of 1.5 mg/m2 and maxDosePerAdministration of 2 mg."/>
       <element name="maxDosePerLifetime" elementType="FHIR.SimpleQuantity" description="Upper limit on medication per lifetime of the patient" definition="Upper limit on medication per lifetime of the patient."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The kind of dose or rate specified" definition="The kind of dose or rate specified, for example, ordered or calculated.">
          <binding name="DoseAndRateType" description="The kind of dose or rate specified." strength="Example"/>
       </element>
@@ -8816,7 +8816,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="Duration" identifier="http://hl7.org/fhir/StructureDefinition/Duration" label="Duration" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EffectEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/EffectEvidenceSynthesis" label="EffectEvidenceSynthesis" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EffectEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/EffectEvidenceSynthesis" label="EffectEvidenceSynthesis" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this effect evidence synthesis, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this effect evidence synthesis when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this effect evidence synthesis is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the effect evidence synthesis is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the effect evidence synthesis" definition="A formal identifier that is used to identify this effect evidence synthesis when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this effect evidence synthesis outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -8899,7 +8899,7 @@
       <search name="version" path="version" type="System.Code"/>
       <search name="date" path="date" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.Certainty" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.Certainty" retrievable="false">
       <element name="rating" description="Certainty rating" definition="A rating of the certainty of the effect estimate.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="QualityOfEvidenceRating" description="The quality of the evidence described. The code system used specifies the quality scale used to grade this evidence source while the code specifies the actual quality score (represented as a coded value) associated with the evidence." strength="Extensible"/>
@@ -8911,7 +8911,7 @@
          <elementTypeSpecifier elementType="FHIR.EffectEvidenceSynthesis.Certainty.CertaintySubcomponent" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of subcomponent of certainty rating" definition="Type of subcomponent of certainty rating.">
          <binding name="CertaintySubcomponentType" description="The subcomponent classification of quality of evidence rating systems." strength="Extensible"/>
       </element>
@@ -8923,7 +8923,7 @@
          <elementTypeSpecifier elementType="FHIR.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.EffectEstimate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.EffectEstimate" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of effect estimate" definition="Human-readable summary of effect estimate."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of efffect estimate" definition="Examples include relative risk and mean difference.">
          <binding name="EffectEstimateType" description="Whether the effect estimate is an absolute effect estimate (absolute difference) or a relative effect estimate (relative difference), and the specific type of effect estimate (eg relative risk or median difference)." strength="Extensible"/>
@@ -8939,7 +8939,7 @@
          <elementTypeSpecifier elementType="FHIR.EffectEvidenceSynthesis.EffectEstimate.PrecisionEstimate" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.EffectEstimate.PrecisionEstimate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.EffectEstimate.PrecisionEstimate" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of precision estimate" definition="Examples include confidence interval and interquartile range.">
          <binding name="PrecisionEstimateType" description="Method of reporting variability of estimates, such as confidence intervals, interquartile range or standard deviation." strength="Extensible"/>
       </element>
@@ -8947,7 +8947,7 @@
       <element name="from" elementType="FHIR.decimal" description="Lower bound" definition="Lower bound of confidence interval."/>
       <element name="to" elementType="FHIR.decimal" description="Upper bound" definition="Upper bound of confidence interval."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.ResultsByExposure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.ResultsByExposure" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of results by exposure" definition="Human-readable summary of results by exposure state."/>
       <element name="exposureState" elementType="FHIR.ExposureState" description="exposure | exposure-alternative" definition="Whether these results are for the exposure state or alternative exposure state.">
          <binding name="ExposureState" description="Whether the results by exposure is describing the results for the primary exposure of interest (exposure) or the alternative state (exposureAlternative)." strength="Required"/>
@@ -8957,18 +8957,18 @@
       </element>
       <element name="riskEvidenceSynthesis" elementType="FHIR.Reference" description="Risk evidence synthesis" definition="Reference to a RiskEvidenceSynthesis resource."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.SampleSize" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EffectEvidenceSynthesis.SampleSize" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of sample size" definition="Human-readable summary of sample size."/>
       <element name="numberOfStudies" elementType="FHIR.integer" description="How many studies?" definition="Number of studies included in this evidence synthesis."/>
       <element name="numberOfParticipants" elementType="FHIR.integer" description="How many participants?" definition="Number of participants included in this evidence synthesis."/>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="FHIR" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="FHIR" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" description="Unique id for inter-element referencing" definition="Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces."/>
       <element name="extension" description="Additional content defined by implementations" definition="May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="FHIR.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ElementDefinition" label="ElementDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ElementDefinition" label="ElementDefinition" retrievable="false">
       <element name="path" elementType="FHIR.string" description="Path of the element in the hierarchy of elements" definition="The path identifies the element and is expressed as a &quot;.&quot;-separated list of ancestor elements, beginning with the name of the resource or extension."/>
       <element name="representation" description="xmlAttr | xmlText | typeAttr | cdaText | xhtml" definition="Codes that define how this element is represented in instances, when the deviation varies from the normal case." comment="In resources, this is rarely used except for special cases where the representation deviates from the normal, and can only be done in the base standard (and profiles must reproduce what the base standard does). This element is used quite commonly in Logical models when the logical models represent a specific serialization format (e.g. CDA, v2 etc.).">
          <elementTypeSpecifier elementType="FHIR.PropertyRepresentation" xsi:type="ListTypeSpecifier"/>
@@ -9226,19 +9226,19 @@
          <elementTypeSpecifier elementType="FHIR.ElementDefinition.Mapping" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Base" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Base" retrievable="false">
       <element name="path" elementType="FHIR.string" description="Path that identifies the base element" definition="The Path that identifies the base element - this matches the ElementDefinition.path for that element. Across FHIR, there is only one base definition of any element - that is, an element definition on a [StructureDefinition](structuredefinition.html#) without a StructureDefinition.base."/>
       <element name="min" elementType="FHIR.unsignedInt" description="Min cardinality of the base element" definition="Minimum cardinality of the base element identified by the path." comment="This is provided for consistency with max, and may affect code generation of mandatory elements of the base resource are generated differently (some reference implementations have done this)."/>
       <element name="max" elementType="FHIR.string" description="Max cardinality of the base element" definition="Maximum cardinality of the base element identified by the path." comment="This is provided to code generation, since the serialization representation in JSON differs depending on whether the base element has max > 1. Also, some forms of code generation may differ."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Binding" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Binding" retrievable="false">
       <element name="strength" elementType="FHIR.BindingStrength" description="required | extensible | preferred | example" definition="Indicates the degree of conformance expectations associated with this binding - that is, the degree to which the provided value set must be adhered to in the instances." comment="For further discussion, see [Using Terminologies](terminologies.html).">
          <binding name="BindingStrength" description="Indication of the degree of conformance expectations associated with a binding." strength="Required"/>
       </element>
       <element name="description" elementType="FHIR.string" description="Human explanation of the value set" definition="Describes the intended use of this particular set of codes."/>
       <element name="valueSet" elementType="FHIR.canonical" description="Source of value set" definition="Refers to the value set that identifies the set of codes the binding refers to." comment="The reference may be version-specific or not (e.g. have a |[version] at the end of the canonical URL)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Constraint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Constraint" retrievable="false">
       <element name="key" elementType="FHIR.id" description="Target of 'condition' reference above" definition="Allows identification of which elements have their cardinalities impacted by the constraint.  Will not be referenced for constraints that do not affect cardinality."/>
       <element name="requirements" elementType="FHIR.string" description="Why this constraint is necessary or appropriate" definition="Description of why this constraint is necessary or appropriate." comment="To be used if the reason for the constraint might not be intuitive to all implementers."/>
       <element name="severity" elementType="FHIR.ConstraintSeverity" description="error | warning" definition="Identifies the impact constraint violation has on the conformance of the instance." comment="This allows constraints to be asserted as &quot;shall&quot; (error) and &quot;should&quot; (warning).">
@@ -9249,7 +9249,7 @@
       <element name="xpath" elementType="FHIR.string" description="XPath expression of constraint" definition="An XPath expression of constraint that can be executed to see if this constraint is met." comment="Elements SHALL use &quot;f&quot; as the namespace prefix for the FHIR namespace, and &quot;x&quot; for the xhtml namespace, and SHALL NOT use any other prefixes.     Note: XPath is generally considered not useful because it does not apply to JSON and other formats and because of XSLT implementation issues, and may be removed in the future."/>
       <element name="source" elementType="FHIR.canonical" description="Reference to original source of constraint" definition="A reference to the original source of the constraint, for traceability purposes." comment="This is used when, e.g. rendering, where it is not useful to present inherited constraints when rendering the snapshot."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Example" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Example" retrievable="false">
       <element name="label" elementType="FHIR.string" description="Describes the purpose of this example" definition="Describes the purpose of this example amoung the set of examples."/>
       <element name="value" description="Value of Example (one of allowed types)" definition="The actual value for the element, which must be one of the types allowed for this element.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -9306,7 +9306,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Mapping" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Mapping" retrievable="false">
       <element name="identity" elementType="FHIR.id" description="Reference to mapping declaration" definition="An internal reference to the definition of a mapping."/>
       <element name="language" elementType="FHIR.MimeType" description="Computable language of mapping" definition="Identifies the computable language in which mapping.map is expressed." comment="If omitted, then there can be no expectation of computational interpretation of the mapping.">
          <binding name="MimeType" description="The mime type of an attachment. Any valid mime type is allowed." strength="Required"/>
@@ -9314,7 +9314,7 @@
       <element name="map" elementType="FHIR.string" description="Details of the mapping" definition="Expresses what part of the target specification corresponds to this element." comment="For most mappings, the syntax is undefined.  Syntax will be provided for mappings to the RIM.  Multiple mappings may be possible and may include constraints on other resource elements that identify when a particular mapping applies."/>
       <element name="comment" elementType="FHIR.string" description="Comments about the mapping or its use" definition="Comments that provide information about the mapping or its use."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Slicing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Slicing" retrievable="false">
       <element name="discriminator" description="Element values that are used to distinguish the slices" definition="Designates which child elements are used to discriminate between the slices when processing an instance. If one or more discriminators are provided, the value of the child elements in the instance data SHALL completely distinguish which slice the element in the resource matches based on the allowed values for those elements in each of the slices." comment="If there is no discriminator, the content is hard to process, so this should be avoided.">
          <elementTypeSpecifier elementType="FHIR.ElementDefinition.Slicing.Discriminator" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9324,13 +9324,13 @@
          <binding name="SlicingRules" description="How slices are interpreted when evaluating an instance." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Slicing.Discriminator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Slicing.Discriminator" retrievable="false">
       <element name="type" elementType="FHIR.DiscriminatorType" description="value | exists | pattern | type | profile" definition="How the element value is interpreted when discrimination is evaluated.">
          <binding name="DiscriminatorType" description="How an element value is interpreted when discrimination is evaluated." strength="Required"/>
       </element>
       <element name="path" elementType="FHIR.string" description="Path to element value" definition="A FHIRPath expression, using [the simple subset of FHIRPath](fhirpath.html#simple), that is used to identify the element on which discrimination is based." comment="The only FHIRPath functions that are allowed are as(type), resolve(), and extension(url)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Type" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ElementDefinition.Type" retrievable="false">
       <element name="code" elementType="FHIR.uri" description="Data type or Resource (reference to definition)" definition="URL of Data type or Resource that is a(or the) type used for this element. References are URLs that are relative to http://hl7.org/fhir/StructureDefinition e.g. &quot;string&quot; is a reference to http://hl7.org/fhir/StructureDefinition/string. Absolute URLs are only allowed in logical models." comment="If the element is a reference to another resource, this element contains &quot;Reference&quot;, and the targetProfile element defines what resources can be referenced. The targetProfile may be a reference to the general definition of a resource (e.g. http://hl7.org/fhir/StructureDefinition/Patient).">
          <binding name="FHIRDefinedTypeExt" description="Either a resource or a data type, including logical model types." strength="Extensible"/>
       </element>
@@ -9348,22 +9348,22 @@
          <binding name="ReferenceVersionRules" description="Whether a reference needs to be version specific or version independent, or whether either can be used." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EligibilityRequestPurpose" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EligibilityRequestPurpose" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EligibilityRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EligibilityRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EligibilityResponsePurpose" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EligibilityResponsePurpose" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EligibilityResponseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EligibilityResponseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EnableWhenBehavior" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EnableWhenBehavior" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Encounter" identifier="http://hl7.org/fhir/StructureDefinition/Encounter" label="Encounter" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Encounter" identifier="http://hl7.org/fhir/StructureDefinition/Encounter" label="Encounter" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Identifier(s) by which this encounter is known" definition="Identifier(s) by which this encounter is known.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9479,20 +9479,20 @@
       <search name="part-of" path="partOf" type="FHIR.Encounter"/>
       <search name="length" path="length" type="System.Quantity"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="FHIR.Coding" description="inpatient | outpatient | ambulatory | emergency +" definition="inpatient | outpatient | ambulatory | emergency +.">
          <binding name="EncounterClass" description="Classification of the encounter." strength="Extensible"/>
       </element>
       <element name="period" elementType="FHIR.Period" description="The time that the episode was in the specified class" definition="The time that the episode was in the specified class."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="FHIR.Reference" description="The diagnosis or procedure relevant to the encounter" definition="Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure." comment="For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis)."/>
       <element name="use" elementType="FHIR.CodeableConcept" description="Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …)" definition="Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …).">
          <binding name="DiagnosisRole" description="The type of diagnosis this condition represents." strength="Preferred"/>
       </element>
       <element name="rank" elementType="FHIR.positiveInt" description="Ranking of the diagnosis (for each role type)" definition="Ranking of the diagnosis (for each role type)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="FHIR.Identifier" description="Pre-admission identifier" definition="Pre-admission identifier."/>
       <element name="origin" elementType="FHIR.Reference" description="The location/organization from which the patient came before admission" definition="The location/organization from which the patient came before admission."/>
       <element name="admitSource" elementType="FHIR.CodeableConcept" description="From where patient was admitted (physician referral, transfer)" definition="From where patient was admitted (physician referral, transfer).">
@@ -9518,7 +9518,7 @@
          <binding name="DischargeDisp" description="Discharge Disposition." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="FHIR.Reference" description="Location the encounter takes place" definition="The location where the encounter takes place."/>
       <element name="status" elementType="FHIR.EncounterLocationStatus" description="planned | active | reserved | completed" definition="The status of the participants' presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time." comment="When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed.">
          <binding name="EncounterLocationStatus" description="The status of the location." strength="Required"/>
@@ -9528,7 +9528,7 @@
       </element>
       <element name="period" elementType="FHIR.Period" description="Time period during which the patient was present at the location" definition="Time period during which the patient was present at the location."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.Participant" retrievable="false">
       <element name="type" description="Role of participant in encounter" definition="Role of participant in encounter." comment="The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="ParticipantType" description="Role of participant in encounter." strength="Extensible"/>
@@ -9536,19 +9536,19 @@
       <element name="period" elementType="FHIR.Period" description="Period of time during the encounter that the participant participated" definition="The period of time that the specified participant participated in the encounter. These can overlap or be sub-sets of the overall encounter's period."/>
       <element name="individual" elementType="FHIR.Reference" description="Persons involved in the encounter other than the patient" definition="Persons involved in the encounter other than the patient."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="FHIR.EncounterStatus" description="planned | arrived | triaged | in-progress | onleave | finished | cancelled +" definition="planned | arrived | triaged | in-progress | onleave | finished | cancelled +.">
          <binding name="EncounterStatus" description="Current state of the encounter." strength="Required"/>
       </element>
       <element name="period" elementType="FHIR.Period" description="The time that the episode was in the specified status" definition="The time that the episode was in the specified status."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EncounterLocationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EncounterStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Endpoint" identifier="http://hl7.org/fhir/StructureDefinition/Endpoint" label="Endpoint" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Endpoint" identifier="http://hl7.org/fhir/StructureDefinition/Endpoint" label="Endpoint" retrievable="true">
       <element name="identifier" description="Identifies this endpoint across multiple systems" definition="Identifier for the organization that is used to identify the endpoint across multiple disparate systems.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9583,10 +9583,10 @@
       <search name="connection-type" path="connectionType" type="System.Code"/>
       <search name="organization" path="managingOrganization" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EndpointStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EndpointStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EnrollmentRequest" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentRequest" label="EnrollmentRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EnrollmentRequest" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentRequest" label="EnrollmentRequest" retrievable="true">
       <element name="identifier" description="Business Identifier" definition="The Response business identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9604,10 +9604,10 @@
       <search name="subject" path="candidate" type="FHIR.Patient"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EnrollmentRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EnrollmentRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EnrollmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentResponse" label="EnrollmentResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EnrollmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentResponse" label="EnrollmentResponse" retrievable="true">
       <element name="identifier" description="Business Identifier" definition="The Response business identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9626,10 +9626,10 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EnrollmentResponseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EnrollmentResponseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EpisodeOfCare" identifier="http://hl7.org/fhir/StructureDefinition/EpisodeOfCare" label="EpisodeOfCare" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EpisodeOfCare" identifier="http://hl7.org/fhir/StructureDefinition/EpisodeOfCare" label="EpisodeOfCare" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier(s) relevant for this EpisodeOfCare" definition="The EpisodeOfCare may be known by different identifiers for different contexts of use, such as when an external agency is tracking the Episode for funding purposes.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -9676,26 +9676,26 @@
       <search name="care-manager" path="careManager.where(resolve() is Practitioner)" type="FHIR.Practitioner"/>
       <search name="incoming-referral" path="referralRequest" type="FHIR.ServiceRequest"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EpisodeOfCare.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EpisodeOfCare.Diagnosis" retrievable="false">
       <element name="condition" elementType="FHIR.Reference" description="Conditions/problems/diagnoses this episode of care is for" definition="A list of conditions/problems/diagnoses that this episode of care is intended to be providing care for."/>
       <element name="role" elementType="FHIR.CodeableConcept" description="Role that this diagnosis has within the episode of care (e.g. admission, billing, discharge …)" definition="Role that this diagnosis has within the episode of care (e.g. admission, billing, discharge …).">
          <binding name="DiagnosisRole" description="The type of diagnosis this condition represents." strength="Preferred"/>
       </element>
       <element name="rank" elementType="FHIR.positiveInt" description="Ranking of the diagnosis (for each role type)" definition="Ranking of the diagnosis (for each role type)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EpisodeOfCare.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EpisodeOfCare.StatusHistory" retrievable="false">
       <element name="status" elementType="FHIR.EpisodeOfCareStatus" description="planned | waitlist | active | onhold | finished | cancelled | entered-in-error" definition="planned | waitlist | active | onhold | finished | cancelled.">
          <binding name="EpisodeOfCareStatus" description="The status of the episode of care." strength="Required"/>
       </element>
       <element name="period" elementType="FHIR.Period" description="Duration the EpisodeOfCare was in the specified status" definition="The period during this EpisodeOfCare that the specific status applied."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EpisodeOfCareStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EpisodeOfCareStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EventCapabilityMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EventCapabilityMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EventDefinition" identifier="http://hl7.org/fhir/StructureDefinition/EventDefinition" label="EventDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EventDefinition" identifier="http://hl7.org/fhir/StructureDefinition/EventDefinition" label="EventDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this event definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this event definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this event definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the event definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the event definition" definition="A formal identifier that is used to identify this event definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this event definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -10515,10 +10515,10 @@
       </search>
       <search name="title" path="title" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EventTiming" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EventTiming" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Evidence" identifier="http://hl7.org/fhir/StructureDefinition/Evidence" label="Evidence" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Evidence" identifier="http://hl7.org/fhir/StructureDefinition/Evidence" label="Evidence" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this evidence, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this evidence when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this evidence is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the evidence is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the evidence" definition="A formal identifier that is used to identify this evidence when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this evidence outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -11336,7 +11336,7 @@
       <search name="url" path="url" type="System.String"/>
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="EvidenceVariable" identifier="http://hl7.org/fhir/StructureDefinition/EvidenceVariable" label="EvidenceVariable" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="EvidenceVariable" identifier="http://hl7.org/fhir/StructureDefinition/EvidenceVariable" label="EvidenceVariable" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this evidence variable, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this evidence variable when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this evidence variable is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the evidence variable is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the evidence variable" definition="A formal identifier that is used to identify this evidence variable when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this evidence variable outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -12153,7 +12153,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="EvidenceVariable.Characteristic" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="EvidenceVariable.Characteristic" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Natural language description of the characteristic" definition="A short, natural language description of the characteristic that could be used to communicate the criteria to an end-user."/>
       <element name="definition" description="What code or expression defines members?" definition="Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -12182,10 +12182,10 @@
          <binding name="GroupMeasure" description="Possible group measure aggregates (E.g. Mean, Median)." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="EvidenceVariableType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="EvidenceVariableType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ExampleScenario" identifier="http://hl7.org/fhir/StructureDefinition/ExampleScenario" label="ExampleScenario" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ExampleScenario" identifier="http://hl7.org/fhir/StructureDefinition/ExampleScenario" label="ExampleScenario" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this example scenario, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this example scenario when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this example scenario is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the example scenario is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the example scenario" definition="A formal identifier that is used to identify this example scenario when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this example scenario outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -12232,7 +12232,7 @@
       <search name="context-type" path="useContext.code" type="System.Code"/>
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Actor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Actor" retrievable="false">
       <element name="actorId" elementType="FHIR.string" description="ID or acronym of the actor" definition="ID or acronym of actor." comment="should this be called ID or acronym?"/>
       <element name="type" elementType="FHIR.ExampleScenarioActorType" description="person | entity" definition="The type of actor - person or system.">
          <binding name="ExampleScenarioActorType" description="The type of actor - system or human." strength="Required"/>
@@ -12240,7 +12240,7 @@
       <element name="name" elementType="FHIR.string" description="The name of the actor as shown in the page" definition="The name of the actor as shown in the page." comment="Cardinality: is name and description 1..1?"/>
       <element name="description" elementType="FHIR.markdown" description="The description of the actor" definition="The description of the actor." comment="Cardinality: is name and description 1..1?"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance" retrievable="false">
       <element name="resourceId" elementType="FHIR.string" description="The id of the resource for referencing" definition="The id of the resource for referencing."/>
       <element name="resourceType" elementType="FHIR.FHIRResourceType" description="The type of the resource" definition="The type of the resource.">
          <binding name="FHIRResourceType" description="The type of resource." strength="Required"/>
@@ -12254,15 +12254,15 @@
          <elementTypeSpecifier elementType="FHIR.ExampleScenario.Instance.ContainedInstance" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance.ContainedInstance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance.ContainedInstance" retrievable="false">
       <element name="resourceId" elementType="FHIR.string" description="Each resource contained in the instance" definition="Each resource contained in the instance."/>
       <element name="versionId" elementType="FHIR.string" description="A specific version of a resource contained in the instance" definition="A specific version of a resource contained in the instance."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Instance.Version" retrievable="false">
       <element name="versionId" elementType="FHIR.string" description="The identifier of a specific version of a resource" definition="The identifier of a specific version of a resource."/>
       <element name="description" elementType="FHIR.markdown" description="The description of the resource version" definition="The description of the resource version."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process" retrievable="false">
       <element name="title" elementType="FHIR.string" description="The diagram title of the group of operations" definition="The diagram title of the group of operations."/>
       <element name="description" elementType="FHIR.markdown" description="A longer description of the group of operations" definition="A longer description of the group of operations."/>
       <element name="preConditions" elementType="FHIR.markdown" description="Description of initial status before the process starts" definition="Description of initial status before the process starts."/>
@@ -12271,7 +12271,7 @@
          <elementTypeSpecifier elementType="FHIR.ExampleScenario.Process.Step" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step" retrievable="false">
       <element name="process" description="Nested process" definition="Nested process.">
          <elementTypeSpecifier xsi:type="ListTypeSpecifier">
             <elementTypeSpecifier namespace="FHIR" name="ExampleScenario.Process" xsi:type="NamedTypeSpecifier"/>
@@ -12283,7 +12283,7 @@
          <elementTypeSpecifier elementType="FHIR.ExampleScenario.Process.Step.Alternative" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step.Alternative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step.Alternative" retrievable="false">
       <element name="title" elementType="FHIR.string" description="Label for alternative" definition="The label to display for the alternative that gives a sense of the circumstance in which the alternative should be invoked."/>
       <element name="description" elementType="FHIR.markdown" description="A human-readable description of each option" definition="A human-readable description of the alternative explaining when the alternative should occur rather than the base step."/>
       <element name="step" description="What happens in each alternative option" definition="What happens in each alternative option.">
@@ -12292,7 +12292,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step.Operation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExampleScenario.Process.Step.Operation" retrievable="false">
       <element name="number" elementType="FHIR.string" description="The sequential number of the interaction" definition="The sequential number of the interaction, e.g. 1.2.5."/>
       <element name="type" elementType="FHIR.string" description="The type of operation - CRUD" definition="The type of operation - CRUD."/>
       <element name="name" elementType="FHIR.string" description="The human-friendly name of the interaction" definition="The human-friendly name of the interaction."/>
@@ -12304,10 +12304,10 @@
       <element name="request" elementType="FHIR.ExampleScenario.Instance.ContainedInstance" description="Each resource instance used by the initiator" definition="Each resource instance used by the initiator."/>
       <element name="response" elementType="FHIR.ExampleScenario.Instance.ContainedInstance" description="Each resource instance used by the responder" definition="Each resource instance used by the responder."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ExampleScenarioActorType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ExampleScenarioActorType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ExplanationOfBenefit" identifier="http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit" label="ExplanationOfBenefit" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ExplanationOfBenefit" identifier="http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit" label="ExplanationOfBenefit" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier for the resource" definition="A unique identifier assigned to this explanation of benefit.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -12456,7 +12456,7 @@
       <search name="coverage" path="insurance.coverage" type="FHIR.Coverage"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Accident" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Accident" retrievable="false">
       <element name="date" elementType="FHIR.date" description="When the incident occurred" definition="Date of an accident event  related to the products and services contained in the claim." comment="The date of the accident has to precede the dates of the products and services but within a reasonable timeframe."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="The nature of the accident" definition="The type or context of the accident event for the purposes of selection of potential insurance coverages and determination of coordination between insurers.">
          <binding name="AccidentType" description="Type of accident: work place, auto, etc." strength="Extensible"/>
@@ -12468,7 +12468,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem" retrievable="false">
       <element name="itemSequence" description="Item sequence number" definition="Claim items which this service line is intended to replace.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -12529,7 +12529,7 @@
          <elementTypeSpecifier elementType="FHIR.ExplanationOfBenefit.AddItem.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem.Detail" retrievable="false">
       <element name="productOrService" elementType="FHIR.CodeableConcept" description="Billing, service, product, or drug code" definition="When the value is a group code then this item collects a set of related claim details, otherwise this contains the product, service, drug or other billing code for the item." comment="If this is an actual service or product line, i.e. not a Group, then use code to indicate the Professional Service or Product supplied (e.g. CTP, HCPCS, USCLS, ICD10, NCPDP, DIN, RxNorm, ACHI, CCI). If a grouping item then use a group code to indicate the type of thing being grouped e.g. 'glasses' or 'compound'.">
          <binding name="ServiceProduct" description="Allowable service and product codes." strength="Example"/>
       </element>
@@ -12553,7 +12553,7 @@
          <elementTypeSpecifier elementType="FHIR.ExplanationOfBenefit.AddItem.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.AddItem.Detail.SubDetail" retrievable="false">
       <element name="productOrService" elementType="FHIR.CodeableConcept" description="Billing, service, product, or drug code" definition="When the value is a group code then this item collects a set of related claim details, otherwise this contains the product, service, drug or other billing code for the item." comment="If this is an actual service or product line, i.e. not a Group, then use code to indicate the Professional Service or Product supplied (e.g. CTP, HCPCS, USCLS, ICD10, NCPDP, DIN, RxNorm, ACHI, CCI). If a grouping item then use a group code to indicate the type of thing being grouped e.g. 'glasses' or 'compound'.">
          <binding name="ServiceProduct" description="Allowable service and product codes." strength="Example"/>
       </element>
@@ -12574,7 +12574,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.BenefitBalance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.BenefitBalance" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Benefit classification" definition="Code to identify the general type of benefits under which products and services are provided." comment="Examples include Medical Care, Periodontics, Renal Dialysis, Vision Coverage.">
          <binding name="BenefitCategory" description="Benefit categories such as: oral, medical, vision, oral-basic etc." strength="Example"/>
       </element>
@@ -12594,7 +12594,7 @@
          <elementTypeSpecifier elementType="FHIR.ExplanationOfBenefit.BenefitBalance.Financial" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.BenefitBalance.Financial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.BenefitBalance.Financial" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Benefit classification" definition="Classification of benefit being provided." comment="For example: deductible, visits, benefit amount.">
          <binding name="BenefitType" description="Deductable, visits, co-pay, etc." strength="Example"/>
       </element>
@@ -12612,7 +12612,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.CareTeam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.CareTeam" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Order of care team" definition="A number to uniquely identify care team entries."/>
       <element name="provider" elementType="FHIR.Reference" description="Practitioner or organization" definition="Member of the team who provided the product or service."/>
       <element name="responsible" elementType="FHIR.boolean" description="Indicator of the lead practitioner" definition="The party who is billing and/or responsible for the claimed products or services." comment="Responsible might not be required when there is only a single provider listed."/>
@@ -12623,7 +12623,7 @@
          <binding name="ProviderQualification" description="Provider professional qualifications." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Diagnosis" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Diagnosis instance identifier" definition="A number to uniquely identify diagnosis entries." comment="Diagnosis are presented in list order to their expected importance: primary, secondary, etc."/>
       <element name="diagnosis" description="Nature of illness or problem" definition="The nature of illness or problem in a coded form or as a reference to an external defined Condition.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -12643,14 +12643,14 @@
          <binding name="DiagnosisRelatedGroup" description="The DRG codes associated with the diagnosis." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Insurance" retrievable="false">
       <element name="focal" elementType="FHIR.boolean" description="Coverage to be used for adjudication" definition="A flag to indicate that this Coverage is to be used for adjudication of this claim when set to true." comment="A patient may (will) have multiple insurance policies which provide reimbursement for healthcare services and products. For example, a person may also be covered by their spouse's policy and both appear in the list (and may be from the same insurer). This flag will be set to true for only one of the listed policies and that policy will be used for adjudicating this claim. Other claims would be created to request adjudication against the other listed policies."/>
       <element name="coverage" elementType="FHIR.Reference" description="Insurance information" definition="Reference to the insurance card level information contained in the Coverage resource. The coverage issuing insurer will use these details to locate the patient's actual coverage within the insurer's information system."/>
       <element name="preAuthRef" description="Prior authorization reference number" definition="Reference numbers previously provided by the insurer to the provider to be quoted on subsequent claims containing services or products related to the prior authorization." comment="This value is an alphanumeric string that may be provided over the phone, via text, via paper, or within a ClaimResponse resource and is not a FHIR Identifier.">
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Item instance identifier" definition="A number to uniquely identify item entries."/>
       <element name="careTeamSequence" description="Applicable care team members" definition="Care team members related to this service or product.">
          <elementTypeSpecifier elementType="FHIR.positiveInt" xsi:type="ListTypeSpecifier"/>
@@ -12722,7 +12722,7 @@
          <elementTypeSpecifier elementType="FHIR.ExplanationOfBenefit.Item.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Adjudication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Adjudication" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Type of adjudication information" definition="A code to indicate the information type of this adjudication record. Information types may include: the value submitted, maximum values or percentages allowed or payable under the plan, amounts that the patient is responsible for in-aggregate or pertaining to this item, amounts paid by other coverages, and the benefit payable for this item." comment="For example, codes indicating: Co-Pay, deductible, eligible, benefit, tax, etc.">
          <binding name="Adjudication" description="The adjudication codes." strength="Example"/>
       </element>
@@ -12732,7 +12732,7 @@
       <element name="amount" elementType="FHIR.Money" description="Monetary amount" definition="Monetary amount associated with the category." comment="For example, amount submitted, eligible amount, co-payment, and benefit payable."/>
       <element name="value" elementType="FHIR.decimal" description="Non-monitary value" definition="A non-monetary value associated with the category. Mutually exclusive to the amount element above." comment="For example: eligible percentage or co-payment percentage."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Detail" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Product or service provided" definition="A claim detail line. Either a simple (a product or service) or a 'group' of sub-details which are simple items."/>
       <element name="revenue" elementType="FHIR.CodeableConcept" description="Revenue or cost center code" definition="The type of revenue or cost center providing the product and/or service.">
          <binding name="RevenueCenter" description="Codes for the revenue or cost centers supplying the service and/or products." strength="Example"/>
@@ -12770,7 +12770,7 @@
          <elementTypeSpecifier elementType="FHIR.ExplanationOfBenefit.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Item.Detail.SubDetail" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Product or service provided" definition="A claim detail line. Either a simple (a product or service) or a 'group' of sub-details which are simple items."/>
       <element name="revenue" elementType="FHIR.CodeableConcept" description="Revenue or cost center code" definition="The type of revenue or cost center providing the product and/or service.">
          <binding name="RevenueCenter" description="Codes for the revenue or cost centers supplying the service and/or products." strength="Example"/>
@@ -12805,13 +12805,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Payee" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Payee" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Category of recipient" definition="Type of Party to be reimbursed: Subscriber, provider, other.">
          <binding name="PayeeType" description="A code for the party to be reimbursed." strength="Example"/>
       </element>
       <element name="party" elementType="FHIR.Reference" description="Recipient reference" definition="Reference to the individual or organization to whom any payment will be made." comment="Not required if the payee is 'subscriber' or 'provider'."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Payment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Payment" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Partial or complete payment" definition="Whether this represents partial or complete payment of the benefits payable.">
          <binding name="PaymentType" description="The type (partial, complete) of the payment." strength="Example"/>
       </element>
@@ -12823,7 +12823,7 @@
       <element name="amount" elementType="FHIR.Money" description="Payable amount after adjustment" definition="Benefits payable less any payment adjustment."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Business identifier for the payment" definition="Issuer's unique identifier for the payment instrument." comment="For example: EFT number or check number."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Procedure" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Procedure instance identifier" definition="A number to uniquely identify procedure entries."/>
       <element name="type" description="Category of Procedure" definition="When the condition was observed or the relative ranking.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -12841,7 +12841,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.ProcessNote" retrievable="false">
       <element name="number" elementType="FHIR.positiveInt" description="Note instance identifier" definition="A number to uniquely identify a note entry."/>
       <element name="type" elementType="FHIR.NoteType" description="display | print | printoper" definition="The business purpose of the note text.">
          <binding name="NoteType" description="The presentation types of notes." strength="Required"/>
@@ -12851,14 +12851,14 @@
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Related" retrievable="false">
       <element name="claim" elementType="FHIR.Reference" description="Reference to the related claim" definition="Reference to a related claim."/>
       <element name="relationship" elementType="FHIR.CodeableConcept" description="How the reference claim is related" definition="A code to convey how the claims are related." comment="For example, prior claim or umbrella.">
          <binding name="RelatedClaimRelationship" description="Relationship of this claim to a related Claim." strength="Example"/>
       </element>
       <element name="reference" elementType="FHIR.Identifier" description="File or case reference" definition="An alternate organizational reference to the case or file to which this particular claim pertains." comment="For example, Property/Casualty insurer claim number or Workers Compensation case number."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Information instance identifier" definition="A number to uniquely identify supporting information entries."/>
       <element name="category" elementType="FHIR.CodeableConcept" description="Classification of the supplied information" definition="The general class of the information supplied: information; exception; accident, employment; onset, etc." comment="This may contain a category for the local bill type codes.">
          <binding name="InformationCategory" description="The valuset used for additional information category codes." strength="Example"/>
@@ -12885,19 +12885,19 @@
          <binding name="MissingReason" description="Reason codes for the missing teeth." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Total" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ExplanationOfBenefit.Total" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="Type of adjudication information" definition="A code to indicate the information type of this adjudication record. Information types may include: the value submitted, maximum values or percentages allowed or payable under the plan, amounts that the patient is responsible for in aggregate or pertaining to this item, amounts paid by other coverages, and the benefit payable for this item." comment="For example, codes indicating: Co-Pay, deductible, eligible, benefit, tax, etc.">
          <binding name="Adjudication" description="The adjudication codes." strength="Example"/>
       </element>
       <element name="amount" elementType="FHIR.Money" description="Financial total for the category" definition="Monetary total amount associated with the category."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ExplanationOfBenefitStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ExplanationOfBenefitStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ExposureState" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ExposureState" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Natural language description of the condition" definition="A brief, natural language description of the condition that effectively communicates the intended semantics."/>
       <element name="name" elementType="FHIR.id" description="Short name assigned to expression for reuse" definition="A short name assigned to the expression to allow for multiple reuse of the expression in the context where it is defined."/>
       <element name="language" elementType="FHIR.code" description="text/cql | text/fhirpath | application/x-fhir-query | etc." definition="The media type of the language for the expression.">
@@ -12906,7 +12906,7 @@
       <element name="expression" elementType="FHIR.string" description="Expression in specified language" definition="An expression in the specified language that returns a value."/>
       <element name="reference" elementType="FHIR.uri" description="Where the expression is found" definition="A URI that defines where the expression is found." comment="If both a reference and an expression is found, the reference SHALL point to the same expression."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="FHIR.uri" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
       <element name="value" description="Value of extension" definition="Value of extension - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -12963,31 +12963,31 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ExtensionContextType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ExtensionContextType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRAllTypes" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRAllTypes" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRDefinedType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRDefinedType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRDeviceStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRResourceType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRResourceType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRSubstanceStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRSubstanceStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FHIRVersion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FHIRVersion" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FamilyHistoryStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FamilyHistoryStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory" label="FamilyMemberHistory" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory" label="FamilyMemberHistory" retrievable="true">
       <element name="identifier" description="External Id(s) for this record" definition="Business identifiers assigned to this family member history by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13073,7 +13073,7 @@
       <search name="status" path="status" type="System.Code"/>
       <search name="instantiates-uri" path="instantiatesUri" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="FamilyMemberHistory.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="FamilyMemberHistory.Condition" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Condition suffered by relation" definition="The actual condition specified. Could be a coded condition (like MI or Diabetes) or a less specific string like 'cancer' depending on how much is known about the condition and the capabilities of the creating system.">
          <binding name="ConditionCode" description="Identification of the Condition or diagnosis." strength="Example"/>
       </element>
@@ -13093,10 +13093,10 @@
          <elementTypeSpecifier elementType="FHIR.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FilterOperator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FilterOperator" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Flag" identifier="http://hl7.org/fhir/StructureDefinition/Flag" label="Flag" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Flag" identifier="http://hl7.org/fhir/StructureDefinition/Flag" label="Flag" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Business identifiers assigned to this flag by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13153,10 +13153,10 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="FlagStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="FlagStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Goal" identifier="http://hl7.org/fhir/StructureDefinition/Goal" label="Goal" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Goal" identifier="http://hl7.org/fhir/StructureDefinition/Goal" label="Goal" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this goal" definition="Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13225,7 +13225,7 @@
       </search>
       <search name="category" path="category" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="FHIR.CodeableConcept" description="The parameter whose value is being tracked" definition="The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.">
          <binding name="GoalTargetMeasure" description="Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level." strength="Example"/>
       </element>
@@ -13248,16 +13248,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GoalLifecycleStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GoalLifecycleStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GraphCompartmentRule" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GraphCompartmentRule" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GraphCompartmentUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GraphCompartmentUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="GraphDefinition" identifier="http://hl7.org/fhir/StructureDefinition/GraphDefinition" label="GraphDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="GraphDefinition" identifier="http://hl7.org/fhir/StructureDefinition/GraphDefinition" label="GraphDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this graph definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this graph definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this graph definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the graph definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the graph definition" definition="The identifier that is used to identify this version of the graph definition when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the graph definition author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different graph definition instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the graph definition with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this graph definition (computer friendly)" definition="A natural language name identifying the graph definition. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -13297,7 +13297,7 @@
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link" retrievable="false">
       <element name="path" elementType="FHIR.string" description="Path in the resource that contains the link" definition="A FHIR expression that identifies one of FHIR References to other resources." comment="The path expression cannot contain a resolve() function. If there is no path, the link is a reverse lookup, using target.params. If the path is &quot;*&quot; then this means all references in the resource."/>
       <element name="sliceName" elementType="FHIR.string" description="Which slice (if profiled)" definition="Which slice (if profiled)."/>
       <element name="min" elementType="FHIR.integer" description="Minimum occurrences for this link" definition="Minimum occurrences for this link."/>
@@ -13307,7 +13307,7 @@
          <elementTypeSpecifier elementType="FHIR.GraphDefinition.Link.Target" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link.Target" retrievable="false">
       <element name="type" elementType="FHIR.ResourceType" description="Type of resource this link refers to" definition="Type of resource this link refers to.">
          <binding name="ResourceType" description="One of the resource types defined as part of this version of FHIR." strength="Required"/>
       </element>
@@ -13322,7 +13322,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link.Target.Compartment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="GraphDefinition.Link.Target.Compartment" retrievable="false">
       <element name="use" elementType="FHIR.GraphCompartmentUse" description="condition | requirement" definition="Defines how the compartment rule is used - whether it it is used to test whether resources are subject to the rule, or whether it is a rule that must be followed." comment="All conditional rules are evaluated; if they are true, then the rules are evaluated.">
          <binding name="GraphCompartmentUse" description="Defines how a compartment rule is used." strength="Required"/>
       </element>
@@ -13335,7 +13335,7 @@
       <element name="expression" elementType="FHIR.string" description="Custom rule, as a FHIRPath expression" definition="Custom rule, as a FHIRPath expression."/>
       <element name="description" elementType="FHIR.string" description="Documentation for FHIRPath expression" definition="Documentation for FHIRPath expression."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Group" identifier="http://hl7.org/fhir/StructureDefinition/Group" label="Group" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Group" identifier="http://hl7.org/fhir/StructureDefinition/Group" label="Group" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Unique id" definition="A unique business identifier for this group.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13385,7 +13385,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Group.Characteristic" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Group.Characteristic" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Kind of characteristic" definition="A code that identifies the kind of trait being asserted.">
          <binding name="GroupCharacteristicKind" description="List of characteristics used to describe group members; e.g. gender, age, owner, location, etc." strength="Example"/>
       </element>
@@ -13402,18 +13402,18 @@
       <element name="exclude" elementType="FHIR.boolean" description="Group includes or excludes" definition="If true, indicates the characteristic is one that is NOT held by members of the group." comment="This is labeled as &quot;Is Modifier&quot; because applications cannot wrongly include excluded members as included or vice versa."/>
       <element name="period" elementType="FHIR.Period" description="Period over which characteristic is tested" definition="The period over which the characteristic is tested; e.g. the patient had an operation during the month of June."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Group.Member" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Group.Member" retrievable="false">
       <element name="entity" elementType="FHIR.Reference" description="Reference to the group member" definition="A reference to the entity that is a member of the group. Must be consistent with Group.type. If the entity is another group, then the type must be the same."/>
       <element name="period" elementType="FHIR.Period" description="Period member belonged to the group" definition="The period that the member was in the group, if known."/>
       <element name="inactive" elementType="FHIR.boolean" description="If member is no longer in group" definition="A flag to indicate that the member is no longer in the group, but previously may have been a member."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GroupMeasure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GroupMeasure" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GroupType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GroupType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="GuidanceResponse" identifier="http://hl7.org/fhir/StructureDefinition/GuidanceResponse" label="GuidanceResponse" retrievable="true" primaryCodePath="module" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="GuidanceResponse" identifier="http://hl7.org/fhir/StructureDefinition/GuidanceResponse" label="GuidanceResponse" retrievable="true" primaryCodePath="module">
       <element name="requestIdentifier" elementType="FHIR.Identifier" description="The identifier of the request associated with this response, if any" definition="The identifier of the request associated with this response. If an identifier was given as part of the request, it will be reproduced here to enable the requester to more easily identify the response in a multi-request scenario."/>
       <element name="identifier" description="Business identifier" definition="Allows a service to provide  unique, business identifiers for the response.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -13459,19 +13459,19 @@
       </search>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GuidanceResponseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GuidanceResponseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GuidePageGeneration" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GuidePageGeneration" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="GuideParameterCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="GuideParameterCode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="HTTPVerb" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="HTTPVerb" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="HealthcareService" identifier="http://hl7.org/fhir/StructureDefinition/HealthcareService" label="HealthcareService" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="HealthcareService" identifier="http://hl7.org/fhir/StructureDefinition/HealthcareService" label="HealthcareService" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="External identifiers for this item" definition="External identifiers for this item.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13549,7 +13549,7 @@
       <search name="endpoint" path="endpoint" type="FHIR.Endpoint"/>
       <search name="organization" path="providedBy" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.AvailableTime" retrievable="false">
       <element name="daysOfWeek" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="FHIR.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -13558,17 +13558,17 @@
       <element name="availableStartTime" elementType="FHIR.time" description="Opening time of day (ignored if allDay = true)" definition="The opening time of day. Note: If the AllDay flag is set, then this time is ignored." comment="The time zone is expected to be for where this HealthcareService is provided at."/>
       <element name="availableEndTime" elementType="FHIR.time" description="Closing time of day (ignored if allDay = true)" definition="The closing time of day. Note: If the AllDay flag is set, then this time is ignored." comment="The time zone is expected to be for where this HealthcareService is provided at."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.Eligibility" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.Eligibility" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Coded value for the eligibility" definition="Coded value for the eligibility.">
          <binding name="ServiceEligibility" description="Coded values underwhich a specific service is made available." strength="Example"/>
       </element>
       <element name="comment" elementType="FHIR.markdown" description="Describes the eligibility conditions for the service" definition="Describes the eligibility conditions for the service." comment="The description of service eligibility should, in general, not exceed one or two paragraphs. It should be sufficient for a prospective consumer to determine if they are likely to be eligible or not. Where eligibility requirements and conditions are complex, it may simply be noted that an eligibility assessment is required. Where eligibility is determined by an outside source, such as an Act of Parliament, this should be noted, preferably with a reference to a commonly available copy of the source document such as a web page."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="HealthcareService.NotAvailable" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Reason presented to the user explaining why time not available" definition="The reason that can be presented to the user as to why this time is not available."/>
       <element name="during" elementType="FHIR.Period" description="Service not available from this date" definition="Service is not available (seasonally or for a public holiday) from this date."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="FHIR.NameUse" description="usual | official | temp | nickname | anonymous | old | maiden" definition="Identifies the purpose for this name." comment="Applications can assume that a name is current unless it explicitly says that it is temporary or old.">
          <binding name="NameUse" description="The use of a human name." strength="Required"/>
       </element>
@@ -13585,7 +13585,7 @@
       </element>
       <element name="period" elementType="FHIR.Period" description="Time period when name was/is in use" definition="Indicates the period of time when this name was valid for the named person."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="FHIR.IdentifierUse" description="usual | official | temp | secondary | old (If known)" definition="The purpose of this identifier." comment="Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.">
          <binding name="IdentifierUse" description="Identifies the purpose for this identifier, if known ." strength="Required"/>
       </element>
@@ -13597,13 +13597,13 @@
       <element name="period" elementType="FHIR.Period" description="Time period when id is/was valid for use" definition="Time period during which identifier is/was valid for use."/>
       <element name="assigner" elementType="FHIR.Reference" description="Organization that issued id (may be just text)" definition="Organization that issued/manages the identifier." comment="The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="IdentifierUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="IdentityAssuranceLevel" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="IdentityAssuranceLevel" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ImagingStudy" identifier="http://hl7.org/fhir/StructureDefinition/ImagingStudy" label="ImagingStudy" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ImagingStudy" identifier="http://hl7.org/fhir/StructureDefinition/ImagingStudy" label="ImagingStudy" retrievable="true">
       <element name="identifier" description="Identifiers for the whole study" definition="Identifiers for the ImagingStudy such as DICOM Study Instance UID, and Accession Number." comment="See discussion under [Imaging Study Implementation Notes](imagingstudy.html#notes) for encoding of DICOM Study Instance UID. Accession Number should use ACSN Identifier type.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13707,7 +13707,7 @@
       <search name="encounter" path="encounter" type="FHIR.Encounter"/>
       <search name="started" path="started" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series" retrievable="false">
       <element name="uid" elementType="FHIR.id" description="DICOM Series Instance UID for the series" definition="The DICOM Series Instance UID for the series." comment="See [DICOM PS3.3 C.7.3](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.3.html)."/>
       <element name="number" elementType="FHIR.unsignedInt" description="Numeric identifier of this series" definition="The numeric identifier of this series in the study."/>
       <element name="modality" elementType="FHIR.Coding" description="The modality of the instances in the series" definition="The modality of this series sequence.">
@@ -13735,7 +13735,7 @@
          <elementTypeSpecifier elementType="FHIR.ImagingStudy.Series.Instance" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series.Instance" retrievable="false">
       <element name="uid" elementType="FHIR.id" description="DICOM SOP Instance UID" definition="The DICOM SOP Instance UID for this image or other DICOM content." comment="See  [DICOM PS3.3 C.12.1](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1)."/>
       <element name="sopClass" elementType="FHIR.Coding" description="DICOM class type" definition="DICOM instance  type.">
          <binding name="sopClass" description="The sopClass for the instance." strength="Extensible"/>
@@ -13743,16 +13743,16 @@
       <element name="number" elementType="FHIR.unsignedInt" description="The number of this instance in the series" definition="The number of instance in the series."/>
       <element name="title" elementType="FHIR.string" description="Description of instance" definition="The description of the instance." comment="Particularly for post-acquisition analytic objects, such as SR, presentation states, value mapping, etc."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImagingStudy.Series.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the series.">
          <binding name="EventPerformerFunction" description="The type of involvement of the performer." strength="Extensible"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="Who performed the series" definition="Indicates who or what performed the series."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ImagingStudyStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ImagingStudyStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Immunization" identifier="http://hl7.org/fhir/StructureDefinition/Immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Immunization" identifier="http://hl7.org/fhir/StructureDefinition/Immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization record.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13862,19 +13862,19 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="FHIR.string" description="Educational material document identifier" definition="Identifier of the material presented to the patient."/>
       <element name="reference" elementType="FHIR.uri" description="Educational material reference pointer" definition="Reference pointer to the educational material given to the patient if the information was on line."/>
       <element name="publicationDate" elementType="FHIR.dateTime" description="Educational material publication date" definition="Date the educational material was published."/>
       <element name="presentationDate" elementType="FHIR.dateTime" description="Educational material presentation date" definition="Date the educational material was given to the patient."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="What type of performance was done" definition="Describes the type of performance (e.g. ordering provider, administering provider, etc.).">
          <binding name="ImmunizationFunction" description="The role a practitioner or organization plays in the immunization event." strength="Extensible"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="Individual or organization who was performing" definition="The practitioner or organization who performed the action." comment="When the individual practitioner who performed the action is known, it is best to send."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="FHIR.string" description="Name of vaccine series" definition="One possible path to achieve presumed immunity against a disease - within the context of an authority."/>
       <element name="authority" elementType="FHIR.Reference" description="Who is responsible for publishing the recommendations" definition="Indicates the authority who published the protocol (e.g. ACIP) that is being followed."/>
       <element name="targetDisease" description="Vaccine preventatable disease being targetted" definition="The vaccine preventable disease the dose is being administered against.">
@@ -13894,12 +13894,12 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="FHIR.dateTime" description="When reaction started" definition="Date of reaction to the immunization."/>
       <element name="detail" elementType="FHIR.Reference" description="Additional information on reaction" definition="Details of the reaction."/>
       <element name="reported" elementType="FHIR.boolean" description="Indicates self-reported reaction" definition="Self-reported indicator."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationEvaluation" label="ImmunizationEvaluation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationEvaluation" label="ImmunizationEvaluation" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization evaluation record.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -13943,10 +13943,10 @@
       <search name="target-disease" path="targetDisease" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ImmunizationEvaluationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ImmunizationEvaluationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation" label="ImmunizationRecommendation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation" label="ImmunizationRecommendation" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this particular recommendation record.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -14122,7 +14122,7 @@
       </search>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImmunizationRecommendation.Recommendation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImmunizationRecommendation.Recommendation" retrievable="false">
       <element name="vaccineCode" description="Vaccine  or vaccine group recommendation applies to" definition="Vaccine(s) or vaccine group that pertain to the recommendation.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="VaccineCode" description="The type of vaccine administered." strength="Example"/>
@@ -14165,16 +14165,16 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Type of date" definition="Date classification of recommendation.  For example, earliest date to give, latest date to give, etc.">
          <binding name="ImmunizationRecommendationDateCriterion" description="Classifies date criterion with respect to conveying information about a patient's vaccination status (e.g. due date, latest to give date, etc.)." strength="Example"/>
       </element>
       <element name="value" elementType="FHIR.dateTime" description="Recommended date" definition="The date whose meaning is specified by dateCriterion.code."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ImmunizationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ImmunizationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ImplementationGuide" identifier="http://hl7.org/fhir/StructureDefinition/ImplementationGuide" label="ImplementationGuide" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ImplementationGuide" identifier="http://hl7.org/fhir/StructureDefinition/ImplementationGuide" label="ImplementationGuide" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this implementation guide, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this implementation guide when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this implementation guide is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the implementation guide is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the implementation guide" definition="The identifier that is used to identify this version of the implementation guide when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the implementation guide author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different implementation guide instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the implementation guide with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this implementation guide (computer friendly)" definition="A natural language name identifying the implementation guide. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -14380,7 +14380,7 @@
       <search name="global" path="global.profile" type="FHIR.StructureDefinition"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition" retrievable="false">
       <element name="grouping" description="Grouping used to present related resources in the IG" definition="A logical group of resources. Logical groups can be used when building pages." comment="Groupings are arbitrary sub-divisions of content. Typically, they are used to help build Table of Contents automatically.">
          <elementTypeSpecifier elementType="FHIR.ImplementationGuide.Definition.Grouping" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -14395,11 +14395,11 @@
          <elementTypeSpecifier elementType="FHIR.ImplementationGuide.Definition.Template" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Grouping" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Grouping" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Descriptive name for the package" definition="The human-readable title to display for the package of resources when rendering the implementation guide."/>
       <element name="description" elementType="FHIR.string" description="Human readable text describing the package" definition="Human readable text describing the package."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Page" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Page" retrievable="false">
       <element name="name" description="Where to find that page" definition="The source address for the page." comment="The publishing tool will autogenerate source for list (source = n/a) and inject included implementations for include (source = uri of guide to include).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="url" xsi:type="NamedTypeSpecifier"/>
@@ -14416,13 +14416,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Parameter" retrievable="false">
       <element name="code" elementType="FHIR.GuideParameterCode" description="apply | path-resource | path-pages | path-tx-cache | expansion-parameter | rule-broken-links | generate-xml | generate-json | generate-turtle | html-template" definition="apply | path-resource | path-pages | path-tx-cache | expansion-parameter | rule-broken-links | generate-xml | generate-json | generate-turtle | html-template.">
          <binding name="GuideParameterCode" description="Code of parameter that is input to the guide." strength="Required"/>
       </element>
       <element name="value" elementType="FHIR.string" description="Value for named type" definition="Value for named type."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Resource" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Resource" retrievable="false">
       <element name="reference" elementType="FHIR.Reference" description="Location of the resource" definition="Where this resource is found." comment="Usually this is a relative URL that locates the resource within the implementation guide. If you authoring an implementation guide, and will publish it using the FHIR publication tooling, use a URI that may point to a resource, or to one of various alternative representations (e.g. spreadsheet). The tooling will convert this when it publishes it."/>
       <element name="fhirVersion" description="Versions this applies to (if different to IG)" definition="Indicates the FHIR Version(s) this artifact is intended to apply to. If no versions are specified, the resource is assumed to apply to all the versions stated in ImplementationGuide.fhirVersion." comment="The resource SHALL be valid against all the versions it is specified to apply to. If the resource referred to is a StructureDefinition, the fhirVersion stated in the StructureDefinition cannot disagree with the version specified here; the specified versions SHALL include the version specified by the StructureDefinition, and may include additional versions using the [applicable-version](extension-structuredefinition-applicable-version.html) extension.">
          <elementTypeSpecifier elementType="FHIR.FHIRVersion" xsi:type="ListTypeSpecifier"/>
@@ -14438,23 +14438,23 @@
       </element>
       <element name="groupingId" elementType="FHIR.id" description="Grouping this is part of" definition="Reference to the id of the grouping this resource appears in." comment="This must correspond to a package.id element within this implementation guide."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Template" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Definition.Template" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Type of template specified" definition="Type of template specified."/>
       <element name="source" elementType="FHIR.string" description="The source location for the template" definition="The source location for the template."/>
       <element name="scope" elementType="FHIR.string" description="The scope in which the template applies" definition="The scope in which the template applies."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.DependsOn" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.DependsOn" retrievable="false">
       <element name="uri" elementType="FHIR.canonical" description="Identity of the IG that this depends on" definition="A canonical reference to the Implementation guide for the dependency." comment="Usually, A canonical reference to the implementation guide is the same as the master location at which the implementation guide is published."/>
       <element name="packageId" elementType="FHIR.id" description="NPM Package name for IG this depends on" definition="The NPM package name for the Implementation Guide that this IG depends on."/>
       <element name="version" elementType="FHIR.string" description="Version of the IG" definition="The version of the IG that is depended on, when the correct version is required to understand the IG correctly." comment="This follows the syntax of the NPM packaging version field - see [[reference]]."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Global" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Global" retrievable="false">
       <element name="type" elementType="FHIR.ResourceType" description="Type this profile applies to" definition="The type of resource that all instances must conform to." comment="The type must match that of the profile that is referred to but is made explicit here as a denormalization so that a system processing the implementation guide resource knows which resources the profile applies to even if the profile itself is not available.">
          <binding name="ResourceType" description="One of the resource types defined as part of this version of FHIR." strength="Required"/>
       </element>
       <element name="profile" elementType="FHIR.canonical" description="Profile that all resources must conform to" definition="A reference to the profile that all instances must conform to."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest" retrievable="false">
       <element name="rendering" elementType="FHIR.url" description="Location of rendered implementation guide" definition="A pointer to official web page, PDF or other rendering of the implementation guide."/>
       <element name="resource" description="Resource in the implementation guide" definition="A resource that is part of the implementation guide. Conformance resources (value set, structure definition, capability statements etc.) are obvious candidates for inclusion, but any kind of resource can be included as an example resource.">
          <elementTypeSpecifier elementType="FHIR.ImplementationGuide.Manifest.Resource" xsi:type="ListTypeSpecifier"/>
@@ -14469,14 +14469,14 @@
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest.Page" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest.Page" retrievable="false">
       <element name="name" elementType="FHIR.string" description="HTML page name" definition="Relative path to the page." comment="Appending 'rendering' + &quot;/&quot; + this should resolve to the page."/>
       <element name="title" elementType="FHIR.string" description="Title of the page, for references" definition="Label for the page intended for human display."/>
       <element name="anchor" description="Anchor available on the page" definition="The name of an anchor available on the page." comment="Appending 'rendering' + &quot;/&quot; + page.name + &quot;#&quot; + page.anchor should resolve to the anchor.">
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest.Resource" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ImplementationGuide.Manifest.Resource" retrievable="false">
       <element name="reference" elementType="FHIR.Reference" description="Location of the resource" definition="Where this resource is found." comment="Usually this is a relative URL that locates the resource within the implementation guide. If you authoring an implementation guide, and will publish it using the FHIR publication tooling, use a URI that may point to a resource, or to one of various alternative representations (e.g. spreadsheet). The tooling will convert this when it publishes it."/>
       <element name="example" description="Is an example/What is this an example of?" definition="If true or a reference, indicates the resource is an example instance.  If a reference is present, indicates that the example is an example of the specified profile." comment="Typically, conformance resources and knowledge resources are directly part of the implementation guide, with their normal meaning, and patient linked resources are usually examples. However this is not always true.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -14486,7 +14486,7 @@
       </element>
       <element name="relativePath" elementType="FHIR.url" description="Relative path for page in IG" definition="The relative path for primary page for this resource within the IG." comment="Appending 'rendering' + &quot;/&quot; + this should resolve to the resource page."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="InsurancePlan" identifier="http://hl7.org/fhir/StructureDefinition/InsurancePlan" label="InsurancePlan" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="InsurancePlan" identifier="http://hl7.org/fhir/StructureDefinition/InsurancePlan" label="InsurancePlan" retrievable="true">
       <element name="identifier" description="Business Identifier for Product" definition="Business identifiers assigned to this health insurance product which remain constant as the resource is updated and propagates from server to server.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -14536,7 +14536,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Contact" retrievable="false">
       <element name="purpose" elementType="FHIR.CodeableConcept" description="The type of contact" definition="Indicates a purpose for which the contact can be reached.">
          <binding name="ContactPartyType" description="The purpose for which you would contact a contact party." strength="Extensible"/>
       </element>
@@ -14546,7 +14546,7 @@
       </element>
       <element name="address" elementType="FHIR.Address" description="Visiting or postal addresses for the contact" definition="Visiting or postal addresses for the contact."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of coverage" definition="Type of coverage  (Medical; Dental; Mental Health; Substance Abuse; Vision; Drug; Short Term; Long Term Care; Hospice; Home Health)."/>
       <element name="network" description="What networks provide coverage" definition="Reference to the network that providing the type of coverage." comment="Networks are represented as a hierarchy of organization resources.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
@@ -14555,18 +14555,18 @@
          <elementTypeSpecifier elementType="FHIR.InsurancePlan.Coverage.Benefit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage.Benefit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage.Benefit" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of benefit" definition="Type of benefit (primary care; speciality care; inpatient; outpatient)."/>
       <element name="requirement" elementType="FHIR.string" description="Referral requirements" definition="The referral requirements to have access/coverage for this benefit."/>
       <element name="limit" description="Benefit limits" definition="The specific limits on the benefit.">
          <elementTypeSpecifier elementType="FHIR.InsurancePlan.Coverage.Benefit.Limit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage.Benefit.Limit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Coverage.Benefit.Limit" retrievable="false">
       <element name="value" elementType="FHIR.Quantity" description="Maximum value allowed" definition="The maximum amount of a service item a plan will pay for a covered benefit.  For examples. wellness visits, or eyeglasses." comment="May also be called “eligible expense,” “payment allowance,” or “negotiated rate.”."/>
       <element name="code" elementType="FHIR.CodeableConcept" description="Benefit limit details" definition="The specific limit on the benefit." comment="Use `CodeableConcept.text` element if the data is free (uncoded) text."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan" retrievable="false">
       <element name="identifier" description="Business Identifier for Product" definition="Business identifiers assigned to this health insurance plan which remain constant as the resource is updated and propagates from server to server.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -14584,25 +14584,25 @@
          <elementTypeSpecifier elementType="FHIR.InsurancePlan.Plan.SpecificCost" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.GeneralCost" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.GeneralCost" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of cost" definition="Type of cost."/>
       <element name="groupSize" elementType="FHIR.positiveInt" description="Number of enrollees" definition="Number of participants enrolled in the plan."/>
       <element name="cost" elementType="FHIR.Money" description="Cost value" definition="Value of the cost."/>
       <element name="comment" elementType="FHIR.string" description="Additional cost information" definition="Additional information about the general costs associated with this plan."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="General category of benefit" definition="General category of benefit (Medical; Dental; Vision; Drug; Mental Health; Substance Abuse; Hospice, Home Health)."/>
       <element name="benefit" description="Benefits list" definition="List of the specific benefits under this category of benefit.">
          <elementTypeSpecifier elementType="FHIR.InsurancePlan.Plan.SpecificCost.Benefit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost.Benefit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost.Benefit" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of specific benefit" definition="Type of specific benefit (preventative; primary care office visit; speciality office visit; hospitalization; emergency room; urgent care)."/>
       <element name="cost" description="List of the costs" definition="List of the costs associated with a specific benefit.">
          <elementTypeSpecifier elementType="FHIR.InsurancePlan.Plan.SpecificCost.Benefit.Cost" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost.Benefit.Cost" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="InsurancePlan.Plan.SpecificCost.Benefit.Cost" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of cost" definition="Type of cost (copay; individual cap; family cap; coinsurance; deductible)."/>
       <element name="applicability" elementType="FHIR.CodeableConcept" description="in-network | out-of-network | other" definition="Whether the cost applies to in-network or out-of-network providers (in-network; out-of-network; other).">
          <binding name="BenefitCostApplicability" description="Whether the cost applies to in-network or out-of-network providers." strength="Required"/>
@@ -14612,7 +14612,7 @@
       </element>
       <element name="value" elementType="FHIR.Quantity" description="The actual cost value" definition="The actual cost value. (some of the costs may be represented as percentages rather than currency, e.g. 10% coinsurance)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Invoice" identifier="http://hl7.org/fhir/StructureDefinition/Invoice" label="Invoice" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Invoice" identifier="http://hl7.org/fhir/StructureDefinition/Invoice" label="Invoice" retrievable="true">
       <element name="identifier" description="Business Identifier for item" definition="Identifier of this Invoice, often used for reference in correspondence about this invoice or for tracking of payments.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -14683,7 +14683,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.LineItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.LineItem" retrievable="false">
       <element name="sequence" elementType="FHIR.positiveInt" description="Sequence number of line item" definition="Sequence in which the items appear on the invoice."/>
       <element name="chargeItem" description="Reference to ChargeItem containing details of this line item or an inline billing code" definition="The ChargeItem contains information such as the billing code, date, amount etc. If no further details are required for the lineItem, inline billing codes can be added using the CodeableConcept data type instead of the Reference.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -14695,7 +14695,7 @@
          <elementTypeSpecifier elementType="FHIR.Invoice.LineItem.PriceComponent" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.LineItem.PriceComponent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.LineItem.PriceComponent" retrievable="false">
       <element name="type" elementType="FHIR.InvoicePriceComponentType" description="base | surcharge | deduction | discount | tax | informational" definition="This code identifies the type of the component.">
          <binding name="InvoicePriceComponentType" description="Codes indicating the kind of the price component." strength="Required"/>
       </element>
@@ -14703,23 +14703,23 @@
       <element name="factor" elementType="FHIR.decimal" description="Factor used for calculating this component" definition="The factor that has been applied on the base price for calculating this component." comment="There is no reason to carry the price in the instance of a ChargeItem unless circumstances require a manual override. The list prices or are usually defined in a back catalogue of the billing codes  (see ChargeItem.definition). Derived profiles may require a ChargeItem.overrideReason to be provided if either factor or price are manually overridden."/>
       <element name="amount" elementType="FHIR.Money" description="Monetary amount associated with this component" definition="The amount calculated for this component." comment="There is no reason to carry the price in the instance of a ChargeItem unless circumstances require a manual override. The list prices or are usually defined in a back catalogue of the billing codes  (see ChargeItem.definition). Derived profiles may require a ChargeItem.overrideReason to be provided if either factor or price are manually overridden."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Invoice.Participant" retrievable="false">
       <element name="role" elementType="FHIR.CodeableConcept" description="Type of involvement in creation of this Invoice" definition="Describes the type of involvement (e.g. transcriptionist, creator etc.). If the invoice has been created automatically, the Participant may be a billing engine or another kind of device."/>
       <element name="actor" elementType="FHIR.Reference" description="Individual who was involved" definition="The device, practitioner, etc. who performed or participated in the service."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="InvoicePriceComponentType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="InvoicePriceComponentType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="InvoiceStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="InvoiceStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="IssueSeverity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="IssueSeverity" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="IssueType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="IssueType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Library" identifier="http://hl7.org/fhir/StructureDefinition/Library" label="Library" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Library" identifier="http://hl7.org/fhir/StructureDefinition/Library" label="Library" retrievable="true" primaryCodePath="topic">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this library, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this library when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this library is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the library is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the library" definition="A formal identifier that is used to identify this library when it is represented in other formats, or referenced in a specification, model, design or an instance. e.g. CMS or NQF identifiers for a measure artifact. Note that at least one identifier is required for non-experimental active artifacts." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this library outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -15550,10 +15550,10 @@
       <search name="topic" path="topic" type="System.Code"/>
       <search name="url" path="url" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="LinkType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="LinkType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Linkage" identifier="http://hl7.org/fhir/StructureDefinition/Linkage" label="Linkage" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Linkage" identifier="http://hl7.org/fhir/StructureDefinition/Linkage" label="Linkage" retrievable="true">
       <element name="active" elementType="FHIR.boolean" description="Whether this linkage assertion is active or not" definition="Indicates whether the asserted set of linkages are considered to be &quot;in effect&quot;." comment="If false, any asserted linkages should not be considered current/relevant/applicable."/>
       <element name="author" elementType="FHIR.Reference" description="Who is responsible for linkages" definition="Identifies the user or organization responsible for asserting the linkages as well as the user or organization who establishes the context in which the nature of each linkage is evaluated."/>
       <element name="item" description="Item to be linked" definition="Identifies which record considered as the reference to the same real-world occurrence as well as how the items should be evaluated within the collection of linked items.">
@@ -15866,16 +15866,16 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Linkage.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Linkage.Item" retrievable="false">
       <element name="type" elementType="FHIR.LinkageType" description="source | alternate | historical" definition="Distinguishes which item is &quot;source of truth&quot; (if any) and which items are no longer considered to be current representations.">
          <binding name="LinkageType" description="Used to distinguish different roles a resource can play within a set of linked resources." strength="Required"/>
       </element>
       <element name="resource" elementType="FHIR.Reference" description="Resource being linked" definition="The resource instance being linked as part of the group."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="LinkageType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="LinkageType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="List" identifier="http://hl7.org/fhir/StructureDefinition/List" label="List" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="List" identifier="http://hl7.org/fhir/StructureDefinition/List" label="List" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Identifier for the List assigned for business purposes outside the context of FHIR.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -16095,7 +16095,7 @@
       </search>
       <search name="title" path="title" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="List.Entry" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="List.Entry" retrievable="false">
       <element name="flag" elementType="FHIR.CodeableConcept" description="Status/Workflow information about this item" definition="The flag allows the system constructing the list to indicate the role and significance of the item in the list." comment="The flag can only be understood in the context of the List.code. If the flag means that the entry has actually been deleted from the list, the deleted element SHALL be true. Deleted can only be used if the List.mode is &quot;changes&quot;.">
          <binding name="ListItemFlag" description="Codes that provide further information about the reason and meaning of the item in the list." strength="Example"/>
       </element>
@@ -16103,13 +16103,13 @@
       <element name="date" elementType="FHIR.dateTime" description="When item added to list" definition="When this item was added to the list."/>
       <element name="item" elementType="FHIR.Reference" description="Actual entry" definition="A reference to the actual resource from which data was derived."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ListMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ListMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ListStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ListStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Location" identifier="http://hl7.org/fhir/StructureDefinition/Location" label="Location" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Location" identifier="http://hl7.org/fhir/StructureDefinition/Location" label="Location" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Unique code or number identifying the location to its users" definition="Unique code or number identifying the location to its users.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -16164,7 +16164,7 @@
       <search name="address" path="address" type="System.String"/>
       <search name="address-country" path="address.country" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="FHIR.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -16173,25 +16173,25 @@
       <element name="openingTime" elementType="FHIR.time" description="Time that the Location opens" definition="Time that the Location opens."/>
       <element name="closingTime" elementType="FHIR.time" description="Time that the Location closes" definition="Time that the Location closes."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="FHIR.decimal" description="Longitude with WGS84 datum" definition="Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below)."/>
       <element name="latitude" elementType="FHIR.decimal" description="Latitude with WGS84 datum" definition="Latitude. The value domain and the interpretation are the same as for the text of the latitude element in KML (see notes below)."/>
       <element name="altitude" elementType="FHIR.decimal" description="Altitude with WGS84 datum" definition="Altitude. The value domain and the interpretation are the same as for the text of the altitude element in KML (see notes below)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="LocationMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="LocationMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="LocationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="LocationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MarketingStatus" identifier="http://hl7.org/fhir/StructureDefinition/MarketingStatus" label="MarketingStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MarketingStatus" identifier="http://hl7.org/fhir/StructureDefinition/MarketingStatus" label="MarketingStatus" retrievable="false">
       <element name="country" elementType="FHIR.CodeableConcept" description="The country in which the marketing authorisation has been granted shall be specified It should be specified using the ISO 3166 ‑ 1 alpha-2 code elements" definition="The country in which the marketing authorisation has been granted shall be specified It should be specified using the ISO 3166 ‑ 1 alpha-2 code elements."/>
       <element name="jurisdiction" elementType="FHIR.CodeableConcept" description="Where a Medicines Regulatory Agency has granted a marketing authorisation for which specific provisions within a jurisdiction apply, the jurisdiction can be specified using an appropriate controlled terminology The controlled term and the controlled term identifier shall be specified" definition="Where a Medicines Regulatory Agency has granted a marketing authorisation for which specific provisions within a jurisdiction apply, the jurisdiction can be specified using an appropriate controlled terminology The controlled term and the controlled term identifier shall be specified."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="This attribute provides information on the status of the marketing of the medicinal product See ISO/TS 20443 for more information and examples" definition="This attribute provides information on the status of the marketing of the medicinal product See ISO/TS 20443 for more information and examples."/>
       <element name="dateRange" elementType="FHIR.Period" description="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE “Placed on the market” refers to the release of the Medicinal Product into the distribution chain" definition="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE “Placed on the market” refers to the release of the Medicinal Product into the distribution chain."/>
       <element name="restoreDate" elementType="FHIR.dateTime" description="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE “Placed on the market” refers to the release of the Medicinal Product into the distribution chain" definition="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE “Placed on the market” refers to the release of the Medicinal Product into the distribution chain."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Measure" identifier="http://hl7.org/fhir/StructureDefinition/Measure" label="Measure" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Measure" identifier="http://hl7.org/fhir/StructureDefinition/Measure" label="Measure" retrievable="true" primaryCodePath="topic">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this measure, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this measure when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this measure is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the measure is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the measure" definition="A formal identifier that is used to identify this measure when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this measure outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -17039,7 +17039,7 @@
       <search name="status" path="status" type="System.Code"/>
       <search name="url" path="url" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Meaning of the group" definition="Indicates a meaning for the group. This can be as simple as a unique identifier, or it can establish meaning in a broader context by drawing from a terminology, allowing groups to be correlated across measures."/>
       <element name="description" elementType="FHIR.string" description="Summary description" definition="The human readable description of this population group."/>
       <element name="population" description="Population criteria" definition="A population criteria for the measure.">
@@ -17049,14 +17049,14 @@
          <elementTypeSpecifier elementType="FHIR.Measure.Group.Stratifier" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Population" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Population" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="initial-population | numerator | numerator-exclusion | denominator | denominator-exclusion | denominator-exception | measure-population | measure-population-exclusion | measure-observation" definition="The type of population criteria.">
          <binding name="MeasurePopulationType" description="The type of population." strength="Extensible"/>
       </element>
       <element name="description" elementType="FHIR.string" description="The human readable description of this population criteria" definition="The human readable description of this population criteria."/>
       <element name="criteria" elementType="FHIR.Expression" description="The criteria that defines this population" definition="An expression that specifies the criteria for the population, typically the name of an expression in a library." comment="In the case of a continuous-variable or ratio measure, this may be the name of a function that calculates the value of the individual observation for each patient or event in the population. For these types of measures, individual observations are reported as observation resources included in the evaluatedResources bundle for each patient. See the MeasureReport resource or the Quality Reporting topic for more information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Stratifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Stratifier" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Meaning of the stratifier" definition="Indicates a meaning for the stratifier. This can be as simple as a unique identifier, or it can establish meaning in a broader context by drawing from a terminology, allowing stratifiers to be correlated across measures."/>
       <element name="description" elementType="FHIR.string" description="The human readable description of this stratifier" definition="The human readable description of this stratifier criteria."/>
       <element name="criteria" elementType="FHIR.Expression" description="How the measure should be stratified" definition="An expression that specifies the criteria for the stratifier. This is typically the name of an expression defined within a referenced library, but it may also be a path to a stratifier element."/>
@@ -17064,12 +17064,12 @@
          <elementTypeSpecifier elementType="FHIR.Measure.Group.Stratifier.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Stratifier.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.Group.Stratifier.Component" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Meaning of the stratifier component" definition="Indicates a meaning for the stratifier component. This can be as simple as a unique identifier, or it can establish meaning in a broader context by drawing from a terminology, allowing stratifiers to be correlated across measures."/>
       <element name="description" elementType="FHIR.string" description="The human readable description of this stratifier component" definition="The human readable description of this stratifier criteria component."/>
       <element name="criteria" elementType="FHIR.Expression" description="Component of how the measure should be stratified" definition="An expression that specifies the criteria for this component of the stratifier. This is typically the name of an expression defined within a referenced library, but it may also be a path to a stratifier element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.SupplementalData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Measure.SupplementalData" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Meaning of the supplemental data" definition="Indicates a meaning for the supplemental data. This can be as simple as a unique identifier, or it can establish meaning in a broader context by drawing from a terminology, allowing supplemental data to be correlated across measures."/>
       <element name="usage" description="supplemental-data | risk-adjustment-factor" definition="An indicator of the intended usage for the supplemental data element. Supplemental data indicates the data is additional information requested to augment the measure information. Risk adjustment factor indicates the data is additional information used to calculate risk adjustment factors when applying a risk model to the measure calculation.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -17078,7 +17078,7 @@
       <element name="description" elementType="FHIR.string" description="The human readable description of this supplemental data" definition="The human readable description of this supplemental data."/>
       <element name="criteria" elementType="FHIR.Expression" description="Expression describing additional data to be reported" definition="The criteria for the supplemental data. This is typically the name of a valid expression defined within a referenced library, but it may also be a path to a specific data element. The criteria defines the data to be returned for this element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MeasureReport" identifier="http://hl7.org/fhir/StructureDefinition/MeasureReport" label="MeasureReport" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MeasureReport" identifier="http://hl7.org/fhir/StructureDefinition/MeasureReport" label="MeasureReport" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Additional identifier for the MeasureReport" definition="A formal identifier that is used to identify this MeasureReport when it is represented in other formats or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II data type - e.g. to identify this {{title}} outside of FHIR, where the logical URL is not possible to use.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17278,7 +17278,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="period" path="period" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Meaning of the group" definition="The meaning of the population group as defined in the measure definition."/>
       <element name="population" description="The populations in the group" definition="The populations that make up the population group, one for each type of population appropriate for the measure.">
          <elementTypeSpecifier elementType="FHIR.MeasureReport.Group.Population" xsi:type="ListTypeSpecifier"/>
@@ -17288,14 +17288,14 @@
          <elementTypeSpecifier elementType="FHIR.MeasureReport.Group.Stratifier" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Population" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Population" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="initial-population | numerator | numerator-exclusion | denominator | denominator-exclusion | denominator-exception | measure-population | measure-population-exclusion | measure-observation" definition="The type of the population.">
          <binding name="MeasurePopulation" description="The type of population (e.g. initial, numerator, denominator, etc.)." strength="Extensible"/>
       </element>
       <element name="count" elementType="FHIR.integer" description="Size of the population" definition="The number of members of the population."/>
       <element name="subjectResults" elementType="FHIR.Reference" description="For subject-list reports, the subject results in this population" definition="This element refers to a List of subject level MeasureReport resources, one for each subject in this population."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier" retrievable="false">
       <element name="code" description="What stratifier of the group" definition="The meaning of this stratifier, as defined in the measure definition.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17303,7 +17303,7 @@
          <elementTypeSpecifier elementType="FHIR.MeasureReport.Group.Stratifier.Stratum" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum" retrievable="false">
       <element name="value" elementType="FHIR.CodeableConcept" description="The stratum value, e.g. male" definition="The value for this stratum, expressed as a CodeableConcept. When defining stratifiers on complex values, the value must be rendered such that the value for each stratum within the stratifier is unique."/>
       <element name="component" description="Stratifier component values" definition="A stratifier component value.">
          <elementTypeSpecifier elementType="FHIR.MeasureReport.Group.Stratifier.Stratum.Component" xsi:type="ListTypeSpecifier"/>
@@ -17313,24 +17313,24 @@
       </element>
       <element name="measureScore" elementType="FHIR.Quantity" description="What score this stratum achieved" definition="The measure score for this stratum, calculated as appropriate for the measure type and scoring method, and based on only the members of this stratum."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum.Component" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="What stratifier component of the group" definition="The code for the stratum component value."/>
       <element name="value" elementType="FHIR.CodeableConcept" description="The stratum component value, e.g. male" definition="The stratum component value."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum.Population" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MeasureReport.Group.Stratifier.Stratum.Population" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="initial-population | numerator | numerator-exclusion | denominator | denominator-exclusion | denominator-exception | measure-population | measure-population-exclusion | measure-observation" definition="The type of the population.">
          <binding name="MeasurePopulation" description="The type of population (e.g. initial, numerator, denominator, etc.)." strength="Extensible"/>
       </element>
       <element name="count" elementType="FHIR.integer" description="Size of the population" definition="The number of members of the population in this stratum."/>
       <element name="subjectResults" elementType="FHIR.Reference" description="For subject-list reports, the subject results in this population" definition="This element refers to a List of subject level MeasureReport resources, one for each subject in this population in this stratum."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MeasureReportStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MeasureReportStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MeasureReportType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MeasureReportType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Media" identifier="http://hl7.org/fhir/StructureDefinition/Media" label="Media" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Media" identifier="http://hl7.org/fhir/StructureDefinition/Media" label="Media" retrievable="true">
       <element name="identifier" description="Identifier(s) for the image" definition="Identifiers associated with the image - these may include identifiers for the image itself, identifiers for the context of its collection (e.g. series ids) and context ids such as accession numbers or other workflow identifiers." comment="The identifier label and use can be used to determine what kind of identifier it is.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17428,10 +17428,10 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MediaStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MediaStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Medication" identifier="http://hl7.org/fhir/StructureDefinition/Medication" label="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Medication" identifier="http://hl7.org/fhir/StructureDefinition/Medication" label="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for this medication" definition="Business identifier for this medication." comment="The serial number could be included as an identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17458,11 +17458,11 @@
       <search name="manufacturer" path="manufacturer" type="FHIR.Organization"/>
       <search name="form" path="form" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="FHIR.string" description="Identifier assigned to batch" definition="The assigned lot number of a batch of the specified product."/>
       <element name="expirationDate" elementType="FHIR.dateTime" description="When batch will expire" definition="When this specific batch of product will expire."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Medication.Ingredient" retrievable="false">
       <element name="item" description="The actual ingredient or content" definition="The actual ingredient - either a substance (simple ingredient) or another medication of a medication.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -17472,7 +17472,7 @@
       <element name="isActive" elementType="FHIR.boolean" description="Active ingredient indicator" definition="Indication of whether this ingredient affects the therapeutic action of the drug."/>
       <element name="strength" elementType="FHIR.Ratio" description="Quantity of ingredient present" definition="Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationAdministration" identifier="http://hl7.org/fhir/StructureDefinition/MedicationAdministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationAdministration" identifier="http://hl7.org/fhir/StructureDefinition/MedicationAdministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Administration that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17577,7 +17577,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationAdministration.Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationAdministration.Dosage" retrievable="false">
       <element name="text" elementType="FHIR.string" description="Free text dosage instructions e.g. SIG" definition="Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.&#xd;&#xd;The dosage instructions should reflect the dosage of the medication that was administered."/>
       <element name="site" elementType="FHIR.CodeableConcept" description="Body site administered to" definition="A coded specification of the anatomic site where the medication first entered the body.  For example, &quot;left arm&quot;." comment="If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.">
          <binding name="MedicationAdministrationSite" description="A coded concept describing the site location the medicine enters into or onto the body." strength="Example"/>
@@ -17596,16 +17596,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationAdministration.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationAdministration.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the medication administration.">
          <binding name="MedicationAdministrationPerformerFunction" description="A code describing the role an individual played in administering the medication." strength="Example"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="Who performed the medication administration" definition="Indicates who or what performed the medication administration."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationAdministrationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationAdministrationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationDispense" identifier="http://hl7.org/fhir/StructureDefinition/MedicationDispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationDispense" identifier="http://hl7.org/fhir/StructureDefinition/MedicationDispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Dispense that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17721,13 +17721,13 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationDispense.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationDispense.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="Who performed the dispense and what they did" definition="Distinguishes the type of performer in the dispense.  For example, date enterer, packager, final checker.">
          <binding name="MedicationDispensePerformerFunction" description="A code describing the role an individual played in dispensing a medication." strength="Example"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="Individual who was performing" definition="The device, practitioner, etc. who performed the action.  It should be assumed that the actor is the dispenser of the medication."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationDispense.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationDispense.Substitution" retrievable="false">
       <element name="wasSubstituted" elementType="FHIR.boolean" description="Whether a substitution was or was not performed on the dispense" definition="True if the dispenser dispensed a different drug or product from what was prescribed."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Code signifying whether a different drug was dispensed from what was prescribed" definition="A code signifying whether a different drug was dispensed from what was prescribed.">
          <binding name="MedicationIntendedSubstitutionType" description="A coded concept describing whether a different medicinal product may be dispensed other than the product as specified exactly in the prescription." strength="Example"/>
@@ -17740,10 +17740,10 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationDispenseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationDispenseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationKnowledge" identifier="http://hl7.org/fhir/StructureDefinition/MedicationKnowledge" label="MedicationKnowledge" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationKnowledge" identifier="http://hl7.org/fhir/StructureDefinition/MedicationKnowledge" label="MedicationKnowledge" retrievable="true" primaryCodePath="code">
       <element name="code" elementType="FHIR.CodeableConcept" description="Code that identifies this medication" definition="A code that specifies this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems." comment="Depending on the context of use, the code that was actually selected by the user (prescriber, dispenser, etc.) will have the coding.userSelected set to true.  As described in the coding datatype: &quot;A coding may be marked as a &quot;userSelected&quot; if a user selected the particular coded value in a user interface (e.g. the user selects an item in a pick-list). If a user selected coding exists, it is the preferred choice for performing translations etc. Other codes can only be literal translations to alternative code systems, or codes at a lower level of granularity (e.g. a generic code for a vendor-specific primary one).">
          <binding name="MedicationFormalRepresentation" description="A coded concept that defines the type of a medication." strength="Example"/>
       </element>
@@ -17820,7 +17820,7 @@
       <search name="manufacturer" path="manufacturer" type="FHIR.Organization"/>
       <search name="monograph-type" path="monograph.type" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines" retrievable="false">
       <element name="dosage" description="Dosage for the medication for the specific guidelines" definition="Dosage for the medication for the specific guidelines.">
          <elementTypeSpecifier elementType="FHIR.MedicationKnowledge.AdministrationGuidelines.Dosage" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17834,13 +17834,13 @@
          <elementTypeSpecifier elementType="FHIR.MedicationKnowledge.AdministrationGuidelines.PatientCharacteristics" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines.Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines.Dosage" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of dosage" definition="The type of dosage (for example, prophylaxis, maintenance, therapeutic, etc.)."/>
       <element name="dosage" description="Dosage for the medication for the specific guidelines" definition="Dosage for the medication for the specific guidelines.">
          <elementTypeSpecifier elementType="FHIR.Dosage" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines.PatientCharacteristics" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.AdministrationGuidelines.PatientCharacteristics" retrievable="false">
       <element name="characteristic" description="Specific characteristic that is relevant to the administration guideline" definition="Specific characteristic that is relevant to the administration guideline (e.g. height, weight, gender).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -17851,12 +17851,12 @@
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Cost" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Cost" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The category of the cost information" definition="The category of the cost information.  For example, manufacturers' cost, patient cost, claim reimbursement cost, actual acquisition cost."/>
       <element name="source" elementType="FHIR.string" description="The source or owner for the price information" definition="The source or owner that assigns the price to the medication."/>
       <element name="cost" elementType="FHIR.Money" description="The price of the medication" definition="The price of the medication."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.DrugCharacteristic" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.DrugCharacteristic" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Code specifying the type of characteristic of medication" definition="A code specifying which characteristic of the medicine is being described (for example, colour, shape, imprint).">
          <binding name="MedicationCharacteristic" description="A coded concept defining the characteristic types of a medication." strength="Example"/>
       </element>
@@ -17869,7 +17869,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Ingredient" retrievable="false">
       <element name="item" description="Medication(s) or substance(s) contained in the medication" definition="The actual ingredient - either a substance (simple ingredient) or another medication.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -17879,7 +17879,7 @@
       <element name="isActive" elementType="FHIR.boolean" description="Active ingredient indicator" definition="Indication of whether this ingredient affects the therapeutic action of the drug."/>
       <element name="strength" elementType="FHIR.Ratio" description="Quantity of ingredient present" definition="Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Kinetics" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Kinetics" retrievable="false">
       <element name="areaUnderCurve" description="The drug concentration measured at certain discrete points in time" definition="The drug concentration measured at certain discrete points in time.">
          <elementTypeSpecifier elementType="FHIR.SimpleQuantity" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -17888,27 +17888,27 @@
       </element>
       <element name="halfLifePeriod" elementType="FHIR.Duration" description="Time required for concentration in the body to decrease by half" definition="The time required for any specified property (e.g., the concentration of a substance in the body) to decrease by half."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.MedicineClassification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.MedicineClassification" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The type of category for the medication (for example, therapeutic classification, therapeutic sub-classification)" definition="The type of category for the medication (for example, therapeutic classification, therapeutic sub-classification)."/>
       <element name="classification" description="Specific category assigned to the medication" definition="Specific category assigned to the medication (e.g. anti-infective, anti-hypertensive, antibiotic, etc.).">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.MonitoringProgram" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.MonitoringProgram" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of program under which the medication is monitored" definition="Type of program under which the medication is monitored."/>
       <element name="name" elementType="FHIR.string" description="Name of the reviewing program" definition="Name of the reviewing program."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Monograph" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Monograph" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The category of medication document" definition="The category of documentation about the medication. (e.g. professional monograph, patient education monograph)."/>
       <element name="source" elementType="FHIR.Reference" description="Associated documentation about the medication" definition="Associated documentation about the medication."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Packaging" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Packaging" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="A code that defines the specific type of packaging that the medication can be found in" definition="A code that defines the specific type of packaging that the medication can be found in (e.g. blister sleeve, tube, bottle).">
          <binding name="MedicationPackageType" description="A coded concept defining the type of packaging of a medication." strength="Example"/>
       </element>
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="The number of product units the package would contain if fully loaded" definition="The number of product units the package would contain if fully loaded."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory" retrievable="false">
       <element name="regulatoryAuthority" elementType="FHIR.Reference" description="Specifies the authority of the regulation" definition="The authority that is specifying the regulations."/>
       <element name="substitution" description="Specifies if changes are allowed when dispensing a medication from a regulatory perspective" definition="Specifies if changes are allowed when dispensing a medication from a regulatory perspective.">
          <elementTypeSpecifier elementType="FHIR.MedicationKnowledge.Regulatory.Substitution" xsi:type="ListTypeSpecifier"/>
@@ -17918,27 +17918,27 @@
       </element>
       <element name="maxDispense" elementType="FHIR.MedicationKnowledge.Regulatory.MaxDispense" description="The maximum number of units of the medication that can be dispensed in a period" definition="The maximum number of units of the medication that can be dispensed in a period."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.MaxDispense" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.MaxDispense" retrievable="false">
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="The maximum number of units of the medication that can be dispensed" definition="The maximum number of units of the medication that can be dispensed."/>
       <element name="period" elementType="FHIR.Duration" description="The period that applies to the maximum number of units" definition="The period that applies to the maximum number of units."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.Schedule" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.Schedule" retrievable="false">
       <element name="schedule" elementType="FHIR.CodeableConcept" description="Specifies the specific drug schedule" definition="Specifies the specific drug schedule."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.Regulatory.Substitution" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Specifies the type of substitution allowed" definition="Specifies the type of substitution allowed."/>
       <element name="allowed" elementType="FHIR.boolean" description="Specifies if regulation allows for changes in the medication when dispensing" definition="Specifies if regulation allows for changes in the medication when dispensing."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.RelatedMedicationKnowledge" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationKnowledge.RelatedMedicationKnowledge" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Category of medicationKnowledge" definition="The category of the associated medication knowledge reference."/>
       <element name="reference" description="Associated documentation about the associated medication knowledge" definition="Associated documentation about the associated medication knowledge.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationKnowledgeStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationKnowledgeStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/MedicationRequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/MedicationRequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External ids for this request" definition="Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18069,7 +18069,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="initialFill" elementType="FHIR.MedicationRequest.DispenseRequest.InitialFill" description="First fill details" definition="Indicates the quantity or duration for the first dispense of the medication." comment="If populating this element, either the quantity or the duration must be included."/>
       <element name="dispenseInterval" elementType="FHIR.Duration" description="Minimum period of time between dispenses" definition="The minimum period of time that must occur between dispenses of the medication."/>
       <element name="validityPeriod" elementType="FHIR.Period" description="Time period supply is authorized for" definition="This indicates the validity period of a prescription (stale dating the Prescription)." comment="It reflects the prescribers' perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations."/>
@@ -18078,11 +18078,11 @@
       <element name="expectedSupplyDuration" elementType="FHIR.Duration" description="Number of days supply per dispense" definition="Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last." comment="In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage). When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors."/>
       <element name="performer" elementType="FHIR.Reference" description="Intended dispenser" definition="Indicates the intended dispensing Organization specified by the prescriber."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="First fill quantity" definition="The amount or quantity to provide as part of the first dispense."/>
       <element name="duration" elementType="FHIR.Duration" description="First fill duration" definition="The length of time that the first dispense is expected to last."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" description="Whether substitution is allowed or not" definition="True if the prescriber allows a different drug to be dispensed from what was prescribed." comment="This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="boolean" xsi:type="NamedTypeSpecifier"/>
@@ -18094,16 +18094,16 @@
          <binding name="MedicationIntendedSubstitutionReason" description="A coded concept describing the reason that a different medication should (or should not) be substituted from what was prescribed." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestPriority" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationStatement" identifier="http://hl7.org/fhir/StructureDefinition/MedicationStatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicationStatement" identifier="http://hl7.org/fhir/StructureDefinition/MedicationStatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Statement that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18200,13 +18200,13 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationStatementStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationStatementStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MedicationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProduct" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProduct" label="MedicinalProduct" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProduct" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProduct" label="MedicinalProduct" retrievable="true">
       <element name="identifier" description="Business identifier for this product. Could be an MPID" definition="Business identifier for this product. Could be an MPID.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18259,7 +18259,7 @@
       <search name="name" path="name.productName" type="System.String"/>
       <search name="name-language" path="name.countryLanguage.language" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.ManufacturingBusinessOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.ManufacturingBusinessOperation" retrievable="false">
       <element name="operationType" elementType="FHIR.CodeableConcept" description="The type of manufacturing operation" definition="The type of manufacturing operation."/>
       <element name="authorisationReferenceNumber" elementType="FHIR.Identifier" description="Regulatory authorization reference number" definition="Regulatory authorization reference number."/>
       <element name="effectiveDate" elementType="FHIR.dateTime" description="Regulatory authorization date" definition="Regulatory authorization date."/>
@@ -18269,7 +18269,7 @@
       </element>
       <element name="regulator" elementType="FHIR.Reference" description="A regulator which oversees the operation" definition="A regulator which oversees the operation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name" retrievable="false">
       <element name="productName" elementType="FHIR.string" description="The full product name" definition="The full product name."/>
       <element name="namePart" description="Coding words or phrases of the name" definition="Coding words or phrases of the name.">
          <elementTypeSpecifier elementType="FHIR.MedicinalProduct.Name.NamePart" xsi:type="ListTypeSpecifier"/>
@@ -18278,16 +18278,16 @@
          <elementTypeSpecifier elementType="FHIR.MedicinalProduct.Name.CountryLanguage" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name.CountryLanguage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name.CountryLanguage" retrievable="false">
       <element name="country" elementType="FHIR.CodeableConcept" description="Country code for where this name applies" definition="Country code for where this name applies."/>
       <element name="jurisdiction" elementType="FHIR.CodeableConcept" description="Jurisdiction code for where this name applies" definition="Jurisdiction code for where this name applies."/>
       <element name="language" elementType="FHIR.CodeableConcept" description="Language code for this name" definition="Language code for this name."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name.NamePart" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.Name.NamePart" retrievable="false">
       <element name="part" elementType="FHIR.string" description="A fragment of a product name" definition="A fragment of a product name."/>
       <element name="type" elementType="FHIR.Coding" description="Idenifying type for this part of the name (e.g. strength part)" definition="Idenifying type for this part of the name (e.g. strength part)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.SpecialDesignation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProduct.SpecialDesignation" retrievable="false">
       <element name="identifier" description="Identifier for the designation, or procedure number" definition="Identifier for the designation, or procedure number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18303,7 +18303,7 @@
       <element name="date" elementType="FHIR.dateTime" description="Date when the designation was granted" definition="Date when the designation was granted."/>
       <element name="species" elementType="FHIR.CodeableConcept" description="Animal species for which this applies" definition="Animal species for which this applies."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductAuthorization" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductAuthorization" label="MedicinalProductAuthorization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductAuthorization" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductAuthorization" label="MedicinalProductAuthorization" retrievable="true">
       <element name="identifier" description="Business identifier for the marketing authorization, as assigned by a regulator" definition="Business identifier for the marketing authorization, as assigned by a regulator.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18339,7 +18339,7 @@
       <search name="holder" path="holder" type="FHIR.Organization"/>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductAuthorization.JurisdictionalAuthorization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductAuthorization.JurisdictionalAuthorization" retrievable="false">
       <element name="identifier" description="The assigned number for the marketing authorization" definition="The assigned number for the marketing authorization.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18350,7 +18350,7 @@
       <element name="legalStatusOfSupply" elementType="FHIR.CodeableConcept" description="The legal status of supply in a jurisdiction or region" definition="The legal status of supply in a jurisdiction or region."/>
       <element name="validityPeriod" elementType="FHIR.Period" description="The start and expected end date of the authorization" definition="The start and expected end date of the authorization."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductAuthorization.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductAuthorization.Procedure" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Identifier for this procedure" definition="Identifier for this procedure."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of procedure" definition="Type of procedure."/>
       <element name="date" description="Date of procedure" definition="Date of procedure.">
@@ -18365,7 +18365,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductContraindication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductContraindication" label="MedicinalProductContraindication" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductContraindication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductContraindication" label="MedicinalProductContraindication" retrievable="true">
       <element name="subject" description="The medication for which this is an indication" definition="The medication for which this is an indication.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18390,7 +18390,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductContraindication.OtherTherapy" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductContraindication.OtherTherapy" retrievable="false">
       <element name="therapyRelationshipType" elementType="FHIR.CodeableConcept" description="The type of relationship between the medicinal product indication or contraindication and another therapy" definition="The type of relationship between the medicinal product indication or contraindication and another therapy."/>
       <element name="medication" description="Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication" definition="Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -18399,7 +18399,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductIndication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIndication" label="MedicinalProductIndication" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductIndication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIndication" label="MedicinalProductIndication" retrievable="true">
       <element name="subject" description="The medication for which this is an indication" definition="The medication for which this is an indication.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18426,7 +18426,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIndication.OtherTherapy" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIndication.OtherTherapy" retrievable="false">
       <element name="therapyRelationshipType" elementType="FHIR.CodeableConcept" description="The type of relationship between the medicinal product indication or contraindication and another therapy" definition="The type of relationship between the medicinal product indication or contraindication and another therapy."/>
       <element name="medication" description="Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication" definition="Reference to a specific medication (active substance, medicinal product or class of products) as part of an indication or contraindication.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -18435,7 +18435,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductIngredient" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIngredient" label="MedicinalProductIngredient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductIngredient" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIngredient" label="MedicinalProductIngredient" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="Identifier for the ingredient" definition="The identifier(s) of this Ingredient that are assigned by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate."/>
       <element name="role" elementType="FHIR.CodeableConcept" description="Ingredient role e.g. Active ingredient, excipient" definition="Ingredient role e.g. Active ingredient, excipient."/>
       <element name="allergenicIndicator" elementType="FHIR.boolean" description="If the ingredient is a known or suspected allergen" definition="If the ingredient is a known or suspected allergen."/>
@@ -18447,7 +18447,7 @@
       </element>
       <element name="substance" elementType="FHIR.MedicinalProductIngredient.Substance" description="The ingredient substance" definition="The ingredient substance."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="The specified substance" definition="The specified substance."/>
       <element name="group" elementType="FHIR.CodeableConcept" description="The group of specified substance, e.g. group 1 to 4" definition="The group of specified substance, e.g. group 1 to 4."/>
       <element name="confidentiality" elementType="FHIR.CodeableConcept" description="Confidentiality level of the specified substance as the ingredient" definition="Confidentiality level of the specified substance as the ingredient."/>
@@ -18455,7 +18455,7 @@
          <elementTypeSpecifier elementType="FHIR.MedicinalProductIngredient.SpecifiedSubstance.Strength" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance.Strength" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance.Strength" retrievable="false">
       <element name="presentation" elementType="FHIR.Ratio" description="The quantity of substance in the unit of presentation, or in the volume (or mass) of the single pharmaceutical product or manufactured item" definition="The quantity of substance in the unit of presentation, or in the volume (or mass) of the single pharmaceutical product or manufactured item."/>
       <element name="presentationLowLimit" elementType="FHIR.Ratio" description="A lower limit for the quantity of substance in the unit of presentation. For use when there is a range of strengths, this is the lower limit, with the presentation attribute becoming the upper limit" definition="A lower limit for the quantity of substance in the unit of presentation. For use when there is a range of strengths, this is the lower limit, with the presentation attribute becoming the upper limit."/>
       <element name="concentration" elementType="FHIR.Ratio" description="The strength per unitary volume (or mass)" definition="The strength per unitary volume (or mass)."/>
@@ -18468,7 +18468,7 @@
          <elementTypeSpecifier elementType="FHIR.MedicinalProductIngredient.SpecifiedSubstance.Strength.ReferenceStrength" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance.Strength.ReferenceStrength" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.SpecifiedSubstance.Strength.ReferenceStrength" retrievable="false">
       <element name="substance" elementType="FHIR.CodeableConcept" description="Relevant reference substance" definition="Relevant reference substance."/>
       <element name="strength" elementType="FHIR.Ratio" description="Strength expressed in terms of a reference substance" definition="Strength expressed in terms of a reference substance."/>
       <element name="strengthLowLimit" elementType="FHIR.Ratio" description="Strength expressed in terms of a reference substance" definition="Strength expressed in terms of a reference substance."/>
@@ -18477,7 +18477,7 @@
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.Substance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductIngredient.Substance" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="The ingredient substance" definition="The ingredient substance."/>
       <element name="strength" description="Quantity of the substance or specified substance present in the manufactured item or pharmaceutical product" definition="Quantity of the substance or specified substance present in the manufactured item or pharmaceutical product.">
          <elementTypeSpecifier xsi:type="ListTypeSpecifier">
@@ -18485,7 +18485,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductInteraction" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductInteraction" label="MedicinalProductInteraction" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductInteraction" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductInteraction" label="MedicinalProductInteraction" retrievable="true">
       <element name="subject" description="The medication for which this is a described interaction" definition="The medication for which this is a described interaction.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18505,7 +18505,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductInteraction.Interactant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductInteraction.Interactant" retrievable="false">
       <element name="item" description="The specific medication, food or laboratory test that interacts" definition="The specific medication, food or laboratory test that interacts.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -18513,7 +18513,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductManufactured" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductManufactured" label="MedicinalProductManufactured" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductManufactured" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductManufactured" label="MedicinalProductManufactured" retrievable="true">
       <element name="manufacturedDoseForm" elementType="FHIR.CodeableConcept" description="Dose form as manufactured and before any transformation into the pharmaceutical product" definition="Dose form as manufactured and before any transformation into the pharmaceutical product."/>
       <element name="unitOfPresentation" elementType="FHIR.CodeableConcept" description="The “real world” units in which the quantity of the manufactured item is described" definition="The “real world” units in which the quantity of the manufactured item is described."/>
       <element name="quantity" elementType="FHIR.Quantity" description="The quantity or &quot;count number&quot; of the manufactured item" definition="The quantity or &quot;count number&quot; of the manufactured item."/>
@@ -18528,7 +18528,7 @@
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductPackaged" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPackaged" label="MedicinalProductPackaged" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductPackaged" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPackaged" label="MedicinalProductPackaged" retrievable="true">
       <element name="identifier" description="Unique identifier" definition="Unique identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18553,11 +18553,11 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="subject" path="subject" type="FHIR.MedicinalProduct"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPackaged.BatchIdentifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPackaged.BatchIdentifier" retrievable="false">
       <element name="outerPackaging" elementType="FHIR.Identifier" description="A number appearing on the outer packaging of a specific batch" definition="A number appearing on the outer packaging of a specific batch."/>
       <element name="immediatePackaging" elementType="FHIR.Identifier" description="A number appearing on the immediate packaging (and not the outer packaging)" definition="A number appearing on the immediate packaging (and not the outer packaging)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPackaged.PackageItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPackaged.PackageItem" retrievable="false">
       <element name="identifier" description="Including possibly Data Carrier Identifier" definition="Including possibly Data Carrier Identifier.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18591,7 +18591,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductPharmaceutical" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPharmaceutical" label="MedicinalProductPharmaceutical" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductPharmaceutical" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPharmaceutical" label="MedicinalProductPharmaceutical" retrievable="true">
       <element name="identifier" description="An identifier for the pharmaceutical medicinal product" definition="An identifier for the pharmaceutical medicinal product.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18613,11 +18613,11 @@
       <search name="route" path="routeOfAdministration.code" type="System.Code"/>
       <search name="target-species" path="routeOfAdministration.targetSpecies.code" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.Characteristics" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.Characteristics" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="A coded characteristic" definition="A coded characteristic."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="The status of characteristic e.g. assigned or pending" definition="The status of characteristic e.g. assigned or pending."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Coded expression for the route" definition="Coded expression for the route."/>
       <element name="firstDose" elementType="FHIR.Quantity" description="The first dose (dose quantity) administered in humans can be specified, for a product under investigation, using a numerical value and its unit of measurement" definition="The first dose (dose quantity) administered in humans can be specified, for a product under investigation, using a numerical value and its unit of measurement."/>
       <element name="maxSingleDose" elementType="FHIR.Quantity" description="The maximum single dose that can be administered as per the protocol of a clinical trial can be specified using a numerical value and its unit of measurement" definition="The maximum single dose that can be administered as per the protocol of a clinical trial can be specified using a numerical value and its unit of measurement."/>
@@ -18628,18 +18628,18 @@
          <elementTypeSpecifier elementType="FHIR.MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Coded expression for the species" definition="Coded expression for the species."/>
       <element name="withdrawalPeriod" description="A species specific time during which consumption of animal product is not appropriate" definition="A species specific time during which consumption of animal product is not appropriate.">
          <elementTypeSpecifier elementType="FHIR.MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies.WithdrawalPeriod" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies.WithdrawalPeriod" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies.WithdrawalPeriod" retrievable="false">
       <element name="tissue" elementType="FHIR.CodeableConcept" description="Coded expression for the type of tissue for which the withdrawal period applues, e.g. meat, milk" definition="Coded expression for the type of tissue for which the withdrawal period applues, e.g. meat, milk."/>
       <element name="value" elementType="FHIR.Quantity" description="A value for the time" definition="A value for the time."/>
       <element name="supportingInformation" elementType="FHIR.string" description="Extra information about the withdrawal period" definition="Extra information about the withdrawal period."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductUndesirableEffect" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductUndesirableEffect" label="MedicinalProductUndesirableEffect" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MedicinalProductUndesirableEffect" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductUndesirableEffect" label="MedicinalProductUndesirableEffect" retrievable="true">
       <element name="subject" description="The medication for which this is an indication" definition="The medication for which this is an indication.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -18656,7 +18656,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MessageDefinition" identifier="http://hl7.org/fhir/StructureDefinition/MessageDefinition" label="MessageDefinition" retrievable="true" primaryCodePath="event" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MessageDefinition" identifier="http://hl7.org/fhir/StructureDefinition/MessageDefinition" label="MessageDefinition" retrievable="true" primaryCodePath="event">
       <element name="url" elementType="FHIR.uri" description="Business Identifier for a given MessageDefinition" definition="The business identifier that is used to reference the MessageDefinition and *is* expected to be consistent from server to server." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Primary key for the message definition on a given server" definition="A formal identifier that is used to identify this message definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this message definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -18736,11 +18736,11 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageDefinition.AllowedResponse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageDefinition.AllowedResponse" retrievable="false">
       <element name="message" elementType="FHIR.canonical" description="Reference to allowed message definition response" definition="A reference to the message definition that must be adhered to by this supported response."/>
       <element name="situation" elementType="FHIR.markdown" description="When should this response be used" definition="Provides a description of the circumstances in which this response should be used (as opposed to one of the alternative responses)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageDefinition.Focus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageDefinition.Focus" retrievable="false">
       <element name="code" elementType="FHIR.ResourceType" description="Type of resource" definition="The kind of resource that must be the focus for this message." comment="Multiple focuses addressing different resources may occasionally occur.  E.g. to link or unlink a resource from a particular account or encounter, etc.">
          <binding name="ResourceType" description="One of the resource types defined as part of this version of FHIR." strength="Required"/>
       </element>
@@ -18748,7 +18748,7 @@
       <element name="min" elementType="FHIR.unsignedInt" description="Minimum number of focuses of this type" definition="Identifies the minimum number of resources of this type that must be pointed to by a message in order for it to be valid against this MessageDefinition."/>
       <element name="max" elementType="FHIR.string" description="Maximum number of focuses of this type" definition="Identifies the maximum number of resources of this type that must be pointed to by a message in order for it to be valid against this MessageDefinition."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MessageHeader" identifier="http://hl7.org/fhir/StructureDefinition/MessageHeader" label="MessageHeader" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MessageHeader" identifier="http://hl7.org/fhir/StructureDefinition/MessageHeader" label="MessageHeader" retrievable="true">
       <element name="event" description="Code for the event this message represents or link to event definition" definition="Code that identifies the event this message represents and connects it with its definition. Events defined as part of the FHIR specification have the system value &quot;http://terminology.hl7.org/CodeSystem/message-events&quot;.  Alternatively uri to the EventDefinition." comment="The time of the event will be found in the focus resource. The time of the message will be found in [Bundle.timestamp](bundle-definitions.html#Bundle.timestamp).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Coding" xsi:type="NamedTypeSpecifier"/>
@@ -18968,33 +18968,33 @@
       </search>
       <search name="code" path="response.code" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Destination" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Destination" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name of system" definition="Human-readable name for the target system."/>
       <element name="target" elementType="FHIR.Reference" description="Particular delivery destination within the destination" definition="Identifies the target end system in situations where the initial message transmission is to an intermediary system."/>
       <element name="endpoint" elementType="FHIR.url" description="Actual destination address or id" definition="Indicates where the message should be routed to." comment="The id may be a non-resolvable URI for systems that do not use standard network-based addresses."/>
       <element name="receiver" elementType="FHIR.Reference" description="Intended &quot;real-world&quot; recipient for the data" definition="Allows data conveyed by a message to be addressed to a particular person or department when routing to a specific application isn't sufficient."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Response" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Response" retrievable="false">
       <element name="identifier" elementType="FHIR.id" description="Id of original message" definition="The MessageHeader.id of the message to which this message is a response."/>
       <element name="code" elementType="FHIR.ResponseType" description="ok | transient-error | fatal-error" definition="Code that identifies the type of response to the message - whether it was successful or not, and whether it should be resent or not." comment="This is a generic response to the request message. Specific data for the response will be found in MessageHeader.focus.">
          <binding name="ResponseType" description="The kind of response to a message." strength="Required"/>
       </element>
       <element name="details" elementType="FHIR.Reference" description="Specific list of hints/warnings/errors" definition="Full details of any issues found in the message." comment="This SHALL be contained in the bundle. If any of the issues are errors, the response code SHALL be an error."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Source" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MessageHeader.Source" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name of system" definition="Human-readable name for the source system."/>
       <element name="software" elementType="FHIR.string" description="Name of software running the system" definition="May include configuration or other information useful in debugging."/>
       <element name="version" elementType="FHIR.string" description="Version of software running" definition="Can convey versions of multiple systems in situations where a message passes through multiple hands."/>
       <element name="contact" elementType="FHIR.ContactPoint" description="Human contact for problems" definition="An e-mail, phone, website or other contact point to use to resolve issues with message communications."/>
       <element name="endpoint" elementType="FHIR.url" description="Actual message source address or id" definition="Identifies the routing target to send acknowledgements to." comment="The id may be a non-resolvable URI for systems that do not use standard network-based addresses."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MessageSignificanceCategory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MessageSignificanceCategory" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Messageheader_Response_Request" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Messageheader_Response_Request" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="FHIR.id" description="Version specific identifier" definition="The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted." comment="The server assigns this value, and ignores what the client specifies, except in the case that the server is imposing version integrity on updates/deletes."/>
       <element name="lastUpdated" elementType="FHIR.instant" description="When the resource version last changed" definition="When the resource last changed - e.g. when the version changed." comment="This value is always populated except when the resource is first being created. The server / resource manager sets this value; what a client provides is irrelevant. This is equivalent to the HTTP Last-Modified and SHOULD have the same value on a [read](http.html#read) interaction."/>
       <element name="source" elementType="FHIR.uri" description="Identifies where the resource comes from" definition="A uri that identifies the source system of the resource. This provides a minimal amount of [Provenance](provenance.html#) information that can be used to track or differentiate the source of information in the resource. The source may identify another FHIR server, document, message, database, etc." comment="In the provenance resource, this corresponds to Provenance.entity.what[x]. The exact use of the source (and the implied Provenance.entity.role) is left to implementer discretion. Only one nominated source is allowed; for additional provenance details, a full Provenance resource should be used. &#xa;&#xa;This element can be used to indicate where the current master source of a resource that has a canonical URL if the resource is no longer hosted at the canonical URL."/>
@@ -19010,10 +19010,10 @@
          <binding name="Tags" description="Codes that represent various types of tags, commonly workflow-related; e.g. &quot;Needs review by Dr. Jones&quot;." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="MimeType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="MimeType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="MolecularSequence" identifier="http://hl7.org/fhir/StructureDefinition/MolecularSequence" label="MolecularSequence" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="MolecularSequence" identifier="http://hl7.org/fhir/StructureDefinition/MolecularSequence" label="MolecularSequence" retrievable="true">
       <element name="identifier" description="Unique ID for this particular sequence. This is a FHIR-defined id" definition="A unique identifier for this particular sequence instance. This is a FHIR-defined id.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -19062,7 +19062,7 @@
       <search name="window-start" path="referenceSeq.windowStart" type="System.Decimal"/>
       <search name="chromosome" path="referenceSeq.chromosome" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Quality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Quality" retrievable="false">
       <element name="type" elementType="FHIR.QualityType" description="indel | snp | unknown" definition="INDEL / SNP / Undefined variant.">
          <binding name="qualityType" description="Type for quality report." strength="Required"/>
       </element>
@@ -19085,7 +19085,7 @@
       <element name="fScore" elementType="FHIR.decimal" description="F-score" definition="Harmonic mean of Recall and Precision, computed as: 2 * precision * recall / (precision + recall)."/>
       <element name="roc" elementType="FHIR.MolecularSequence.Quality.Roc" description="Receiver Operator Characteristic (ROC) Curve" definition="Receiver Operator Characteristic (ROC) Curve  to give sensitivity/specificity tradeoff."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Quality.Roc" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Quality.Roc" retrievable="false">
       <element name="score" description="Genotype quality score" definition="Invidual data point representing the GQ (genotype quality) score threshold.">
          <elementTypeSpecifier elementType="FHIR.integer" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -19108,7 +19108,7 @@
          <elementTypeSpecifier elementType="FHIR.decimal" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.ReferenceSeq" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.ReferenceSeq" retrievable="false">
       <element name="chromosome" elementType="FHIR.CodeableConcept" description="Chromosome containing genetic finding" definition="Structural unit composed of a nucleic acid molecule which controls its own replication through the interaction of specific proteins at one or more origins of replication ([SO:0000340](http://www.sequenceontology.org/browser/current_svn/term/SO:0000340)).">
          <binding name="chromosome-human" description="Chromosome number for human." strength="Example"/>
       </element>
@@ -19127,7 +19127,7 @@
       <element name="windowStart" elementType="FHIR.integer" description="Start position of the window on the  reference sequence" definition="Start position of the window on the reference sequence. If the coordinate system is either 0-based or 1-based, then start position is inclusive."/>
       <element name="windowEnd" elementType="FHIR.integer" description="End position of the window on the reference sequence" definition="End position of the window on the reference sequence. If the coordinate system is 0-based then end is exclusive and does not include the last position. If the coordinate system is 1-base, then end is inclusive and includes the last position."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Repository" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Repository" retrievable="false">
       <element name="type" elementType="FHIR.RepositoryType" description="directlink | openapi | login | oauth | other" definition="Click and see / RESTful API / Need login to see / RESTful API with authentication / Other ways to see resource.">
          <binding name="repositoryType" description="Type for access of external URI." strength="Required"/>
       </element>
@@ -19137,7 +19137,7 @@
       <element name="variantsetId" elementType="FHIR.string" description="Id of the variantset that used to call for variantset in repository" definition="Id of the variantset in this external repository. The server will understand how to use this id to call for more info about variantsets in external repository."/>
       <element name="readsetId" elementType="FHIR.string" description="Id of the read" definition="Id of the read in this external repository."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant" retrievable="false">
       <element name="variantType" elementType="FHIR.CodeableConcept" description="Structural variant change type" definition="Information about chromosome structure variation DNA change type.">
          <binding name="LOINC LL379-9 answerlist" description="DNA change type." strength="Required"/>
       </element>
@@ -19146,15 +19146,15 @@
       <element name="outer" elementType="FHIR.MolecularSequence.StructureVariant.Outer" description="Structural variant outer" definition="Structural variant outer."/>
       <element name="inner" elementType="FHIR.MolecularSequence.StructureVariant.Inner" description="Structural variant inner" definition="Structural variant inner."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant.Inner" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant.Inner" retrievable="false">
       <element name="start" elementType="FHIR.integer" description="Structural variant inner start" definition="Structural variant inner start. If the coordinate system is either 0-based or 1-based, then start position is inclusive."/>
       <element name="end" elementType="FHIR.integer" description="Structural variant inner end" definition="Structural variant inner end. If the coordinate system is 0-based then end is exclusive and does not include the last position. If the coordinate system is 1-base, then end is inclusive and includes the last position."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant.Outer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.StructureVariant.Outer" retrievable="false">
       <element name="start" elementType="FHIR.integer" description="Structural variant outer start" definition="Structural variant outer start. If the coordinate system is either 0-based or 1-based, then start position is inclusive."/>
       <element name="end" elementType="FHIR.integer" description="Structural variant outer end" definition="Structural variant outer end. If the coordinate system is 0-based then end is exclusive and does not include the last position. If the coordinate system is 1-base, then end is inclusive and includes the last position."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Variant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="MolecularSequence.Variant" retrievable="false">
       <element name="start" elementType="FHIR.integer" description="Start position of the variant on the  reference sequence" definition="Start position of the variant on the  reference sequence. If the coordinate system is either 0-based or 1-based, then start position is inclusive."/>
       <element name="end" elementType="FHIR.integer" description="End position of the variant on the reference sequence" definition="End position of the variant on the reference sequence. If the coordinate system is 0-based then end is exclusive and does not include the last position. If the coordinate system is 1-base, then end is inclusive and includes the last position."/>
       <element name="observedAllele" elementType="FHIR.string" description="Allele that was observed" definition="An allele is one of a set of coexisting sequence variants of a gene ([SO:0001023](http://www.sequenceontology.org/browser/current_svn/term/SO:0001023)).  Nucleotide(s)/amino acids from start position of sequence to stop position of sequence on the positive (+) strand of the observed  sequence. When the sequence  type is DNA, it should be the sequence on the positive (+) strand. This will lay in the range between variant.start and variant.end."/>
@@ -19162,17 +19162,17 @@
       <element name="cigar" elementType="FHIR.string" description="Extended CIGAR string for aligning the sequence with reference bases" definition="Extended CIGAR string for aligning the sequence with reference bases. See detailed documentation [here](http://support.illumina.com/help/SequencingAnalysisWorkflow/Content/Vault/Informatics/Sequencing_Analysis/CASAVA/swSEQ_mCA_ExtendedCIGARFormat.htm)."/>
       <element name="variantPointer" elementType="FHIR.Reference" description="Pointer to observed variant information" definition="A pointer to an Observation containing variant information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Money" identifier="http://hl7.org/fhir/StructureDefinition/Money" label="Money" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Money" identifier="http://hl7.org/fhir/StructureDefinition/Money" label="Money" retrievable="false">
       <element name="value" elementType="FHIR.decimal" description="Numerical value (with implicit precision)" definition="Numerical value (with implicit precision)." comment="Monetary values have their own rules for handling precision (refer to standard accounting text books)."/>
       <element name="currency" elementType="FHIR.CurrencyCode" description="ISO 4217 Currency Code" definition="ISO 4217 Currency Code.">
          <binding name="CurrencyCode" description="A code indicating the currency, taken from ISO 4217." strength="Required"/>
       </element>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="MoneyQuantity" identifier="http://hl7.org/fhir/StructureDefinition/MoneyQuantity" label="MoneyQuantity" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NameUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NameUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="NamingSystem" identifier="http://hl7.org/fhir/StructureDefinition/NamingSystem" label="NamingSystem" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="NamingSystem" identifier="http://hl7.org/fhir/StructureDefinition/NamingSystem" label="NamingSystem" retrievable="true">
       <element name="name" elementType="FHIR.string" description="Name for this naming system (computer friendly)" definition="A natural language name identifying the naming system. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly.The&quot;symbolic name&quot; for an OID would be captured as an extension."/>
       <element name="status" elementType="FHIR.PublicationStatus" description="draft | active | retired | unknown" definition="The status of this naming system. Enables tracking the life-cycle of the content." comment="Allows filtering of naming systems that are appropriate for use versus not.">
          <binding name="PublicationStatus" description="The lifecycle status of an artifact." strength="Required"/>
@@ -19217,7 +19217,7 @@
       <search name="name" path="name" type="System.String"/>
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NamingSystem.UniqueId" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NamingSystem.UniqueId" retrievable="false">
       <element name="type" elementType="FHIR.NamingSystemIdentifierType" description="oid | uuid | uri | other" definition="Identifies the unique identifier scheme used for this particular identifier." comment="Different identifier types may be used in different types of communications (OIDs for v3, URIs for FHIR, etc.).  Other includes RUIDs from v3, standard v2 code name strings, etc.">
          <binding name="NamingSystemIdentifierType" description="Identifies the style of unique identifier used to identify a namespace." strength="Required"/>
       </element>
@@ -19226,13 +19226,13 @@
       <element name="comment" elementType="FHIR.string" description="Notes about identifier usage" definition="Notes about the past or intended usage of this identifier." comment="e.g. &quot;must be used in Germany&quot; or &quot;was initially published in error with this value&quot;."/>
       <element name="period" elementType="FHIR.Period" description="When is identifier valid?" definition="Identifies the period of time over which this identifier is considered appropriate to refer to the naming system.  Outside of this window, the identifier might be non-deterministic." comment="Within a registry, a given identifier should only be &quot;active&quot; for a single namespace at a time.  (Ideally, an identifier should only ever be associated with a single namespace across all time)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NamingSystemIdentifierType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NamingSystemIdentifierType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NamingSystemType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NamingSystemType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="FHIR.NarrativeStatus" description="generated | extensions | additional | empty" definition="The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.">
          <binding name="NarrativeStatus" description="The status of a resource narrative." strength="Required"/>
       </element>
@@ -19245,16 +19245,16 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NarrativeStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NarrativeStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NoteType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NoteType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NutritiionOrderIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NutritiionOrderIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="NutritionOrder" identifier="http://hl7.org/fhir/StructureDefinition/NutritionOrder" label="NutritionOrder" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="NutritionOrder" identifier="http://hl7.org/fhir/StructureDefinition/NutritionOrder" label="NutritionOrder" retrievable="true">
       <element name="identifier" description="Identifiers assigned to this order" definition="Identifiers assigned to this order by the order sender or by the order receiver." comment="The Identifier.type element can be to indicate filler vs. placer if needed.  This is explained in further detail [here](servicerequest.html#notes).">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -19332,7 +19332,7 @@
       <search name="oraldiet" path="oralDiet.type" type="System.Code"/>
       <search name="datetime" path="dateTime" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.EnteralFormula" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.EnteralFormula" retrievable="false">
       <element name="baseFormulaType" elementType="FHIR.CodeableConcept" description="Type of enteral or infant formula" definition="The type of enteral or infant formula such as an adult standard formula with fiber or a soy-based infant formula.">
          <binding name="EnteralFormulaType" description="Codes for type of enteral formula to be administered to patient." strength="Example"/>
       </element>
@@ -19351,7 +19351,7 @@
       <element name="maxVolumeToDeliver" elementType="FHIR.SimpleQuantity" description="Upper limit on formula volume per unit of time" definition="The maximum total quantity of formula that may be administered to a subject over the period of time, e.g. 1440 mL over 24 hours."/>
       <element name="administrationInstruction" elementType="FHIR.string" description="Formula feeding instructions expressed as text" definition="Free text formula administration, feeding instructions or additional instructions or information." comment="Free text dosage instructions can be used for cases where the instructions are too complex to code."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.EnteralFormula.Administration" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.EnteralFormula.Administration" retrievable="false">
       <element name="schedule" elementType="FHIR.Timing" description="Scheduled frequency of enteral feeding" definition="The time period and frequency at which the enteral formula should be delivered to the patient."/>
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="The volume of formula to provide" definition="The volume of formula to provide to the patient per the specified administration schedule."/>
       <element name="rate" description="Speed with which the formula is provided per period of time" definition="The rate of administration of formula via a feeding pump, e.g. 60 mL per hour, according to the specified schedule." comment="Ratio is used when the quantity value in the denominator is not &quot;1&quot;, otherwise use Quantity. For example, the Ratio datatype is used for &quot;200 mL/4 hrs&quot; versus the Quantity datatype for &quot;50 mL/hr&quot;.">
@@ -19361,7 +19361,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet" retrievable="false">
       <element name="type" description="Type of oral diet or diet restrictions that describe what can be consumed orally" definition="The kind of diet or dietary restriction such as fiber restricted diet or diabetic diet.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="OralDiet" description="Codes used to indicate the type of diet being ordered for a patient." strength="Example"/>
@@ -19381,13 +19381,13 @@
       </element>
       <element name="instruction" elementType="FHIR.string" description="Instructions or additional information about the oral diet" definition="Free text or additional instructions or information pertaining to the oral diet." comment="Free text dosage instructions can be used for cases where the instructions are too complex to code."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet.Nutrient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet.Nutrient" retrievable="false">
       <element name="modifier" elementType="FHIR.CodeableConcept" description="Type of nutrient that is being modified" definition="The nutrient that is being modified such as carbohydrate or sodium.">
          <binding name="NutrientModifier" description="Codes for types of nutrients that are being modified such as carbohydrate or sodium." strength="Example"/>
       </element>
       <element name="amount" elementType="FHIR.SimpleQuantity" description="Quantity of the specified nutrient" definition="The quantity of the specified nutrient to include in diet."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet.Texture" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.OralDiet.Texture" retrievable="false">
       <element name="modifier" elementType="FHIR.CodeableConcept" description="Code to indicate how to alter the texture of the foods, e.g. pureed" definition="Any texture modifications (for solid foods) that should be made, e.g. easy to chew, chopped, ground, and pureed." comment="Coupled with the foodType (Meat).">
          <binding name="TextureModifier" description="Codes for food consistency types or texture modifications to apply to foods." strength="Example"/>
       </element>
@@ -19395,7 +19395,7 @@
          <binding name="TextureModifiedFoodType" description="Codes for types of foods that are texture-modified." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.Supplement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="NutritionOrder.Supplement" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of supplement product requested" definition="The kind of nutritional supplement product required such as a high protein or pediatric clear liquid supplement.">
          <binding name="SupplementType" description="Codes for nutritional supplements to be provided to the patient." strength="Example"/>
       </element>
@@ -19406,10 +19406,10 @@
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="Amount of the nutritional supplement" definition="The amount of the nutritional supplement to be given."/>
       <element name="instruction" elementType="FHIR.string" description="Instructions or additional information about the oral supplement" definition="Free text or additional instructions or information pertaining to the oral supplement." comment="Free text dosage instructions can be used for cases where the instructions are too complex to code."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="NutritionOrderStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="NutritionOrderStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Observation" identifier="http://hl7.org/fhir/StructureDefinition/Observation" label="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Observation" identifier="http://hl7.org/fhir/StructureDefinition/Observation" label="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -19736,7 +19736,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Observation.Component" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Type of component observation (code / type)" definition="Describes what was observed. Sometimes this is called the observation &quot;code&quot;." comment="*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.">
          <binding name="ObservationCode" description="Codes identifying names of simple observations." strength="Example"/>
       </element>
@@ -19768,7 +19768,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="FHIR.SimpleQuantity" description="Low Range, if relevant" definition="The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - &lt;=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is &lt;=2.3)."/>
       <element name="high" elementType="FHIR.SimpleQuantity" description="High Range, if relevant" definition="The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - &lt;=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3)."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Reference range qualifier" definition="Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range." comment="This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.">
@@ -19781,10 +19781,10 @@
       <element name="age" elementType="FHIR.Range" description="Applicable age range, if relevant" definition="The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so."/>
       <element name="text" elementType="FHIR.string" description="Text based reference range in an observation" definition="Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of &quot;Negative&quot; or a list or table of &quot;normals&quot;."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ObservationDataType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ObservationDataType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ObservationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ObservationDefinition" label="ObservationDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ObservationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ObservationDefinition" label="ObservationDefinition" retrievable="true" primaryCodePath="code">
       <element name="category" description="Category of observation" definition="A code that classifies the general type of observation." comment="This element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used for one instance of ObservationDefinition. The level of granularity is defined by the category concepts in the value set.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="ObservationCategory" description="Codes for high level observation categories." strength="Example"/>
@@ -19813,7 +19813,7 @@
       <element name="abnormalCodedValueSet" elementType="FHIR.Reference" description="Value set of abnormal coded values for the observations conforming to this ObservationDefinition" definition="The set of abnormal coded results for the observation conforming to this ObservationDefinition."/>
       <element name="criticalCodedValueSet" elementType="FHIR.Reference" description="Value set of critical coded values for the observations conforming to this ObservationDefinition" definition="The set of critical coded results for the observation conforming to this ObservationDefinition."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ObservationDefinition.QualifiedInterval" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ObservationDefinition.QualifiedInterval" retrievable="false">
       <element name="category" elementType="FHIR.ObservationRangeCategory" description="reference | critical | absolute" definition="The category of interval of values for continuous or ordinal observations conforming to this ObservationDefinition.">
          <binding name="ObservationRangeCategory" description="Codes identifying the category of observation range." strength="Required"/>
       </element>
@@ -19832,7 +19832,7 @@
       <element name="gestationalAge" elementType="FHIR.Range" description="Applicable gestational age range, if relevant" definition="The gestational age to which this reference range is applicable, in the context of pregnancy."/>
       <element name="condition" elementType="FHIR.string" description="Condition associated with the reference range" definition="Text based condition for which the reference range is valid."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ObservationDefinition.QuantitativeDetails" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ObservationDefinition.QuantitativeDetails" retrievable="false">
       <element name="customaryUnit" elementType="FHIR.CodeableConcept" description="Customary unit for quantitative results" definition="Customary unit used to report quantitative results of observations conforming to this ObservationDefinition.">
          <binding name="ObservationUnit" description="Codes identifying units of measure." strength="Extensible"/>
       </element>
@@ -19842,13 +19842,13 @@
       <element name="conversionFactor" elementType="FHIR.decimal" description="SI to Customary unit conversion factor" definition="Factor for converting value expressed with SI unit to value expressed with customary unit."/>
       <element name="decimalPrecision" elementType="FHIR.integer" description="Decimal precision of observation quantitative results" definition="Number of digits after decimal separator when the results of such observations are of type Quantity."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ObservationRangeCategory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ObservationRangeCategory" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ObservationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ObservationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="OperationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/OperationDefinition" label="OperationDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="OperationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/OperationDefinition" label="OperationDefinition" retrievable="true" primaryCodePath="code">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this operation definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this operation definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this operation definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the operation definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the operation definition" definition="The identifier that is used to identify this version of the operation definition when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the operation definition author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different operation definition instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the operation definition with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this operation definition (computer friendly)" definition="A natural language name identifying the operation definition. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -19921,13 +19921,13 @@
       <search name="type" path="type" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Overload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Overload" retrievable="false">
       <element name="parameterName" description="Name of parameter to include in overload" definition="Name of parameter to include in overload.">
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="comment" elementType="FHIR.string" description="Comments to go on overload" definition="Comments to go on overload."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter" retrievable="false">
       <element name="name" elementType="FHIR.code" description="Name in Parameters.parameter.name or in URL" definition="The name of used to identify the parameter." comment="This name must be a token (start with a letter in a..z, and only contain letters, numerals, and underscore. Note that for search parameters (type = string, with a search type), the name may be altered by the search modifiers."/>
       <element name="use" elementType="FHIR.OperationParameterUse" description="in | out" definition="Whether this is an input or an output parameter." comment="If a parameter name is used for both an input and an output parameter, the parameter should be defined twice.">
          <binding name="OperationParameterUse" description="Whether an operation parameter is an input or an output parameter." strength="Required"/>
@@ -19954,25 +19954,25 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter.Binding" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter.Binding" retrievable="false">
       <element name="strength" elementType="FHIR.BindingStrength" description="required | extensible | preferred | example" definition="Indicates the degree of conformance expectations associated with this binding - that is, the degree to which the provided value set must be adhered to in the instances." comment="For further discussion, see [Using Terminologies](terminologies.html).">
          <binding name="BindingStrength" description="Indication of the degree of conformance expectations associated with a binding." strength="Required"/>
       </element>
       <element name="valueSet" elementType="FHIR.canonical" description="Source of value set" definition="Points to the value set or external definition (e.g. implicit value set) that identifies the set of codes to be used." comment="For value sets with a referenceResource, the display can contain the value set description.  The reference may be version-specific or not."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter.ReferencedFrom" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationDefinition.Parameter.ReferencedFrom" retrievable="false">
       <element name="source" elementType="FHIR.string" description="Referencing parameter" definition="The name of the parameter or dot-separated path of parameter names pointing to the resource parameter that is expected to contain a reference to this resource."/>
       <element name="sourceId" elementType="FHIR.string" description="Element id of reference" definition="The id of the element in the referencing resource that is expected to resolve to this resource."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="OperationKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="OperationKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="OperationOutcome" identifier="http://hl7.org/fhir/StructureDefinition/OperationOutcome" label="OperationOutcome" retrievable="true" primaryCodePath="issue.code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="OperationOutcome" identifier="http://hl7.org/fhir/StructureDefinition/OperationOutcome" label="OperationOutcome" retrievable="true" primaryCodePath="issue.code">
       <element name="issue" description="A single issue associated with the action" definition="An error, warning, or information message that results from a system action.">
          <elementTypeSpecifier elementType="FHIR.OperationOutcome.Issue" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationOutcome.Issue" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="OperationOutcome.Issue" retrievable="false">
       <element name="severity" elementType="FHIR.IssueSeverity" description="fatal | error | warning | information" definition="Indicates whether the issue indicates a variation from successful processing." comment="This is labeled as &quot;Is Modifier&quot; because applications should not confuse hints and warnings with errors.">
          <binding name="IssueSeverity" description="How the issue affects the success of the action." strength="Required"/>
       </element>
@@ -19990,10 +19990,10 @@
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="OperationParameterUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="OperationParameterUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Organization" identifier="http://hl7.org/fhir/StructureDefinition/Organization" label="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Organization" identifier="http://hl7.org/fhir/StructureDefinition/Organization" label="Organization" retrievable="true">
       <element name="identifier" description="Identifies this organization  across multiple systems" definition="Identifier for the organization that is used to identify the organization across multiple disparate systems.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20039,7 +20039,7 @@
       <search name="endpoint" path="endpoint" type="FHIR.Endpoint"/>
       <search name="partof" path="partOf" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="FHIR.CodeableConcept" description="The type of contact" definition="Indicates a purpose for which the contact can be reached.">
          <binding name="ContactPartyType" description="The purpose for which you would contact a contact party." strength="Extensible"/>
       </element>
@@ -20049,7 +20049,7 @@
       </element>
       <element name="address" elementType="FHIR.Address" description="Visiting or postal addresses for the contact" definition="Visiting or postal addresses for the contact."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="OrganizationAffiliation" identifier="http://hl7.org/fhir/StructureDefinition/OrganizationAffiliation" label="OrganizationAffiliation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="OrganizationAffiliation" identifier="http://hl7.org/fhir/StructureDefinition/OrganizationAffiliation" label="OrganizationAffiliation" retrievable="true">
       <element name="identifier" description="Business identifiers that are specific to this role" definition="Business identifiers that are specific to this role.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20095,10 +20095,10 @@
       <search name="active" path="active" type="System.Code"/>
       <search name="phone" path="telecom.where(system='phone')" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="OrientationType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="OrientationType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="FHIR.code" description="Name used to access the parameter value" definition="The name of the parameter used to allow access to the value of the parameter in evaluation contexts."/>
       <element name="use" elementType="FHIR.ParameterUse" description="in | out" definition="Whether the parameter is input or output for the module.">
          <binding name="ParameterUse" description="Whether the parameter is input or output." strength="Required"/>
@@ -20111,10 +20111,10 @@
       </element>
       <element name="profile" elementType="FHIR.canonical" description="What profile the value is expected to be" definition="If specified, this indicates a profile that the input data must conform to, or that the output data will conform to."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ParameterUse" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ParameterUse" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Resource" namespace="FHIR" name="Parameters" identifier="http://hl7.org/fhir/StructureDefinition/Parameters" label="Parameters" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Resource" namespace="FHIR" name="Parameters" identifier="http://hl7.org/fhir/StructureDefinition/Parameters" label="Parameters" retrievable="true">
       <element name="parameter" description="Operation Parameter" definition="A parameter passed to or received from the operation.">
          <elementTypeSpecifier elementType="FHIR.Parameters.Parameter" xsi:type="ListTypeSpecifier"/>
          <constraint name="inv-1" severity="ERROR" message="A parameter must have one and only one of (value, resource, part)">
@@ -20122,7 +20122,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Parameters.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Parameters.Parameter" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name from the definition" definition="The name of the parameter (reference to the operation definition)."/>
       <element name="value" description="If parameter is a data type" definition="If the parameter is a data type.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -20185,16 +20185,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ParticipantRequired" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ParticipantRequired" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ParticipantStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ParticipantStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ParticipationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ParticipationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Patient" identifier="http://hl7.org/fhir/StructureDefinition/Patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Patient" identifier="http://hl7.org/fhir/StructureDefinition/Patient" label="Patient" retrievable="true">
       <element name="identifier" description="An identifier for this patient" definition="An identifier for this patient.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20283,13 +20283,13 @@
       </search>
       <search name="language" path="communication.language" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="FHIR.CodeableConcept" description="The language which can be used to communicate with the patient about his or her health" definition="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." comment="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.">
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
       <element name="preferred" elementType="FHIR.boolean" description="Language preference indicator" definition="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." comment="This language is specifically identified for communicating healthcare information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Contact" retrievable="false">
       <element name="relationship" description="The kind of relationship" definition="The nature of the relationship between the patient and the contact person.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="ContactRelationship" description="The nature of the relationship between a patient and a contact person for that patient." strength="Extensible"/>
@@ -20305,13 +20305,13 @@
       <element name="organization" elementType="FHIR.Reference" description="Organization that is associated with the contact" definition="Organization on behalf of which the contact is acting or for which the contact is working."/>
       <element name="period" elementType="FHIR.Period" description="The period during which this contact person or organization is valid to be contacted relating to this patient" definition="The period during which this contact person or organization is valid to be contacted relating to this patient."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Patient.Link" retrievable="false">
       <element name="other" elementType="FHIR.Reference" description="The other patient or related person resource that the link refers to" definition="The other patient resource that the link refers to." comment="Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual."/>
       <element name="type" elementType="FHIR.LinkType" description="replaced-by | replaces | refer | seealso" definition="The type of link between this patient resource and another patient resource.">
          <binding name="LinkType" description="The type of link between this patient resource and another patient resource." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="PaymentNotice" identifier="http://hl7.org/fhir/StructureDefinition/PaymentNotice" label="PaymentNotice" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="PaymentNotice" identifier="http://hl7.org/fhir/StructureDefinition/PaymentNotice" label="PaymentNotice" retrievable="true">
       <element name="identifier" description="Business Identifier for the payment noctice" definition="A unique identifier assigned to this payment notice.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20641,10 +20641,10 @@
       <search name="payment-status" path="paymentStatus" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="PaymentNoticeStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="PaymentNoticeStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="PaymentReconciliation" identifier="http://hl7.org/fhir/StructureDefinition/PaymentReconciliation" label="PaymentReconciliation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="PaymentReconciliation" identifier="http://hl7.org/fhir/StructureDefinition/PaymentReconciliation" label="PaymentReconciliation" retrievable="true">
       <element name="identifier" description="Business Identifier for a payment reconciliation" definition="A unique identifier assigned to this payment reconciliation.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20688,7 +20688,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="outcome" path="outcome" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PaymentReconciliation.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PaymentReconciliation.Detail" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Business identifier of the payment detail" definition="Unique identifier for the current payment item for the referenced payable."/>
       <element name="predecessor" elementType="FHIR.Identifier" description="Business identifier of the prior payment detail" definition="Unique identifier for the prior payment item for the referenced payable."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Category of payment" definition="Code to indicate the nature of the payment." comment="For example: payment, adjustment, funds advance, etc.">
@@ -20702,20 +20702,20 @@
       <element name="payee" elementType="FHIR.Reference" description="Recipient of the payment" definition="The party which is receiving the payment."/>
       <element name="amount" elementType="FHIR.Money" description="Amount allocated to this payable" definition="The monetary amount allocated from the total payment to the payable."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PaymentReconciliation.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PaymentReconciliation.ProcessNote" retrievable="false">
       <element name="type" elementType="FHIR.NoteType" description="display | print | printoper" definition="The business purpose of the note text.">
          <binding name="NoteType" description="The presentation types of notes." strength="Required"/>
       </element>
       <element name="text" elementType="FHIR.string" description="Note explanatory text" definition="The explanation or description associated with the processing."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="PaymentReconciliationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="PaymentReconciliationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Period" identifier="http://hl7.org/fhir/StructureDefinition/Period" label="Period" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Period" identifier="http://hl7.org/fhir/StructureDefinition/Period" label="Period" retrievable="false">
       <element name="start" elementType="FHIR.dateTime" description="Starting time with inclusive boundary" definition="The start of the period. The boundary is inclusive." comment="If the low element is missing, the meaning is that the low boundary is not known."/>
       <element name="end" elementType="FHIR.dateTime" description="End time with inclusive boundary, if not ongoing" definition="The end of the period. If the end of the period is missing, it means no end was known or planned at the time the instance was created. The start may be in the past, and the end date in the future, which means that period is expected/planned to end at that time." comment="The high value includes any matching date/time. i.e. 2012-02-03T10:00:00 is in a period that has an end value of 2012-02-03."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Person" identifier="http://hl7.org/fhir/StructureDefinition/Person" label="Person" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Person" identifier="http://hl7.org/fhir/StructureDefinition/Person" label="Person" retrievable="true">
       <element name="identifier" description="A human identifier for this person" definition="Identifier for a person within a particular scope.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -20768,13 +20768,13 @@
       <search name="email" path="telecom.where(system='email')" type="System.Code"/>
       <search name="gender" path="gender" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Person.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Person.Link" retrievable="false">
       <element name="target" elementType="FHIR.Reference" description="The resource to which this actual person is associated" definition="The resource to which this actual person is associated."/>
       <element name="assurance" elementType="FHIR.IdentityAssuranceLevel" description="level1 | level2 | level3 | level4" definition="Level of assurance that this link is associated with the target resource.">
          <binding name="IdentityAssuranceLevel" description="The level of confidence that this link represents the same actual person, based on NIST Authentication Levels." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="PlanDefinition" identifier="http://hl7.org/fhir/StructureDefinition/PlanDefinition" label="PlanDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="PlanDefinition" identifier="http://hl7.org/fhir/StructureDefinition/PlanDefinition" label="PlanDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this plan definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this plan definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this plan definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the plan definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the plan definition" definition="A formal identifier that is used to identify this plan definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this plan definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -21611,7 +21611,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action" retrievable="false">
       <element name="prefix" elementType="FHIR.string" description="User-visible prefix for the action (e.g. 1. or A.)" definition="A user-visible prefix for the action."/>
       <element name="title" elementType="FHIR.string" description="User-visible title" definition="The title of the action displayed to a user."/>
       <element name="description" elementType="FHIR.string" description="Brief description of the action" definition="A brief description of the action used to provide a summary to display to the user."/>
@@ -21700,17 +21700,17 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.Condition" retrievable="false">
       <element name="kind" elementType="FHIR.ActionConditionKind" description="applicability | start | stop" definition="The kind of condition." comment="Applicability criteria are used to determine immediate applicability when a plan definition is applied to a given context. Start and stop criteria are carried through application and used to describe enter/exit criteria for an action.">
          <binding name="ActionConditionKind" description="Defines the kinds of conditions that can appear on actions." strength="Required"/>
       </element>
       <element name="expression" elementType="FHIR.Expression" description="Boolean-valued expression" definition="An expression that returns true or false, indicating whether the condition is satisfied." comment="The expression may be inlined or may be a reference to a named expression within a logic library referenced by the library element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.DynamicValue" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.DynamicValue" retrievable="false">
       <element name="path" elementType="FHIR.string" description="The path to the element to be set dynamically" definition="The path to the element to be customized. This is the path on the resource that will hold the result of the calculation defined by the expression. The specified path SHALL be a FHIRPath resolveable on the specified target type of the ActivityDefinition, and SHALL consist only of identifiers, constant indexers, and a restricted subset of functions. The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details)." comment="To specify the path to the current action being realized, the %action environment variable is available in this path. For example, to specify the description element of the target action, the path would be %action.description. The path attribute contains a [Simple FHIRPath Subset](fhirpath.html#simple) that allows path traversal, but not calculation."/>
       <element name="expression" elementType="FHIR.Expression" description="An expression that provides the dynamic value for the customization" definition="An expression specifying the value of the customized element." comment="The expression may be inlined or may be a reference to a named expression within a logic library referenced by the library element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.Participant" retrievable="false">
       <element name="type" elementType="FHIR.ActionParticipantType" description="patient | practitioner | related-person | device" definition="The type of participant in the action.">
          <binding name="ActionParticipantType" description="The type of participant for the action." strength="Required"/>
       </element>
@@ -21718,7 +21718,7 @@
          <binding name="ActionParticipantRole" description="Defines roles played by participants for the action." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.RelatedAction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Action.RelatedAction" retrievable="false">
       <element name="actionId" elementType="FHIR.id" description="What action is this related to" definition="The element id of the related action."/>
       <element name="relationship" elementType="FHIR.ActionRelationshipType" description="before-start | before | before-end | concurrent-with-start | concurrent | concurrent-with-end | after-start | after | after-end" definition="The relationship of this action to the related action.">
          <binding name="ActionRelationshipType" description="Defines the types of relationships between actions." strength="Required"/>
@@ -21730,7 +21730,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Goal" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Goal" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="E.g. Treatment, dietary, behavioral" definition="Indicates a category the goal falls within.">
          <binding name="GoalCategory" description="Example codes for grouping goals for filtering or presentation." strength="Example"/>
       </element>
@@ -21754,7 +21754,7 @@
          <elementTypeSpecifier elementType="FHIR.PlanDefinition.Goal.Target" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PlanDefinition.Goal.Target" retrievable="false">
       <element name="measure" elementType="FHIR.CodeableConcept" description="The parameter whose value is to be tracked" definition="The parameter whose value is to be tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.">
          <binding name="GoalTargetMeasure" description="Identifies types of parameters that can be tracked to determine goal achievement." strength="Example"/>
       </element>
@@ -21767,7 +21767,7 @@
       </element>
       <element name="due" elementType="FHIR.Duration" description="Reach goal within" definition="Indicates the timeframe after the start of the goal in which the goal should be met."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Population" identifier="http://hl7.org/fhir/StructureDefinition/Population" label="Population" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Population" identifier="http://hl7.org/fhir/StructureDefinition/Population" label="Population" retrievable="false">
       <element name="age" description="The age of the specific population" definition="The age of the specific population.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Range" xsi:type="NamedTypeSpecifier"/>
@@ -21778,7 +21778,7 @@
       <element name="race" elementType="FHIR.CodeableConcept" description="Race of the specific population" definition="Race of the specific population."/>
       <element name="physiologicalCondition" elementType="FHIR.CodeableConcept" description="The existing physiological conditions of the specific population to which this applies" definition="The existing physiological conditions of the specific population to which this applies."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Practitioner" identifier="http://hl7.org/fhir/StructureDefinition/Practitioner" label="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Practitioner" identifier="http://hl7.org/fhir/StructureDefinition/Practitioner" label="Practitioner" retrievable="true">
       <element name="identifier" description="An identifier for the person as this agent" definition="An identifier that applies to this person in this role.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -21824,7 +21824,7 @@
       <search name="email" path="telecom.where(system='email')" type="System.Code"/>
       <search name="gender" path="gender" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier" description="An identifier for this qualification for the practitioner" definition="An identifier that applies to this person's qualification in this role.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -21834,7 +21834,7 @@
       <element name="period" elementType="FHIR.Period" description="Period during which the qualification is valid" definition="Period during which the qualification is valid."/>
       <element name="issuer" elementType="FHIR.Reference" description="Organization that regulates and issues the qualification" definition="Organization that regulates and issues the qualification."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="PractitionerRole" identifier="http://hl7.org/fhir/StructureDefinition/PractitionerRole" label="PractitionerRole" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="PractitionerRole" identifier="http://hl7.org/fhir/StructureDefinition/PractitionerRole" label="PractitionerRole" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifiers that are specific to a role/location" definition="Business Identifiers that are specific to a role/location.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -21884,7 +21884,7 @@
       <search name="email" path="telecom.where(system='email')" type="System.Code"/>
       <search name="organization" path="organization" type="FHIR.Organization"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="FHIR.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -21893,11 +21893,11 @@
       <element name="availableStartTime" elementType="FHIR.time" description="Opening time of day (ignored if allDay = true)" definition="The opening time of day. Note: If the AllDay flag is set, then this time is ignored." comment="The timezone is expected to be for where this HealthcareService is provided at."/>
       <element name="availableEndTime" elementType="FHIR.time" description="Closing time of day (ignored if allDay = true)" definition="The closing time of day. Note: If the AllDay flag is set, then this time is ignored." comment="The timezone is expected to be for where this HealthcareService is provided at."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Reason presented to the user explaining why time not available" definition="The reason that can be presented to the user as to why this time is not available."/>
       <element name="during" elementType="FHIR.Period" description="Service not available from this date" definition="Service is not available (seasonally or for a public holiday) from this date."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Procedure" identifier="http://hl7.org/fhir/StructureDefinition/Procedure" label="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Procedure" identifier="http://hl7.org/fhir/StructureDefinition/Procedure" label="Procedure" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External Identifiers for this procedure" definition="Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -22056,23 +22056,23 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="FHIR.CodeableConcept" description="Kind of change to device" definition="The kind of change that happened to the device during the procedure.">
          <binding name="DeviceActionKind" description="A kind of change that happened to the device during the procedure." strength="Preferred"/>
       </element>
       <element name="manipulated" elementType="FHIR.Reference" description="Device that was changed" definition="The device that was manipulated (changed) during the procedure."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="FHIR.CodeableConcept" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.">
          <binding name="ProcedurePerformerRole" description="A code that identifies the role of a performer of the procedure." strength="Example"/>
       </element>
       <element name="actor" elementType="FHIR.Reference" description="The reference to the practitioner" definition="The practitioner who was involved in the procedure."/>
       <element name="onBehalfOf" elementType="FHIR.Reference" description="Organization the device or practitioner was acting for" definition="The organization the device or practitioner was acting on behalf of."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ProcedureStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ProcedureStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ProdCharacteristic" identifier="http://hl7.org/fhir/StructureDefinition/ProdCharacteristic" label="ProdCharacteristic" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ProdCharacteristic" identifier="http://hl7.org/fhir/StructureDefinition/ProdCharacteristic" label="ProdCharacteristic" retrievable="false">
       <element name="height" elementType="FHIR.Quantity" description="Where applicable, the height can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used" definition="Where applicable, the height can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used."/>
       <element name="width" elementType="FHIR.Quantity" description="Where applicable, the width can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used" definition="Where applicable, the width can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used."/>
       <element name="depth" elementType="FHIR.Quantity" description="Where applicable, the depth can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used" definition="Where applicable, the depth can be specified using a numerical value and its unit of measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used."/>
@@ -22091,7 +22091,7 @@
       </element>
       <element name="scoring" elementType="FHIR.CodeableConcept" description="Where applicable, the scoring can be specified An appropriate controlled vocabulary shall be used The term and the term identifier shall be used" definition="Where applicable, the scoring can be specified An appropriate controlled vocabulary shall be used The term and the term identifier shall be used."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ProductShelfLife" identifier="http://hl7.org/fhir/StructureDefinition/ProductShelfLife" label="ProductShelfLife" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ProductShelfLife" identifier="http://hl7.org/fhir/StructureDefinition/ProductShelfLife" label="ProductShelfLife" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Unique identifier for the packaged Medicinal Product" definition="Unique identifier for the packaged Medicinal Product."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="This describes the shelf life, taking into account various scenarios such as shelf life of the packaged Medicinal Product itself, shelf life after transformation where necessary and shelf life after the first opening of a bottle, etc. The shelf life type shall be specified using an appropriate controlled vocabulary The controlled term and the controlled term identifier shall be specified" definition="This describes the shelf life, taking into account various scenarios such as shelf life of the packaged Medicinal Product itself, shelf life after transformation where necessary and shelf life after the first opening of a bottle, etc. The shelf life type shall be specified using an appropriate controlled vocabulary The controlled term and the controlled term identifier shall be specified."/>
       <element name="period" elementType="FHIR.Quantity" description="The shelf life time period can be specified using a numerical value for the period of time and its unit of time measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used" definition="The shelf life time period can be specified using a numerical value for the period of time and its unit of time measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used."/>
@@ -22099,13 +22099,13 @@
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="PropertyRepresentation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="PropertyRepresentation" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="PropertyType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="PropertyType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Provenance" identifier="http://hl7.org/fhir/StructureDefinition/Provenance" label="Provenance" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Provenance" identifier="http://hl7.org/fhir/StructureDefinition/Provenance" label="Provenance" retrievable="true">
       <element name="target" description="Target Reference(s) (usually version specific)" definition="The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity." comment="Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -22455,7 +22455,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Provenance.Agent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Provenance.Agent" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="How the agent participated" definition="The participation the agent had with respect to the activity." comment="For example: author, performer, enterer, attester, etc.">
          <binding name="ProvenanceAgentType" description="The type of participation that a provenance agent played with respect to the activity." strength="Extensible"/>
       </element>
@@ -22466,7 +22466,7 @@
       <element name="who" elementType="FHIR.Reference" description="Who participated" definition="The individual, device or organization that participated in the event." comment="whoIdentity should be used when the agent is not a Resource type."/>
       <element name="onBehalfOf" elementType="FHIR.Reference" description="Who the agent is representing" definition="The individual, device, or organization for whom the change was made." comment="onBehalfOfIdentity should be used when the agent is not a Resource type."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Provenance.Entity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Provenance.Entity" retrievable="false">
       <element name="role" elementType="FHIR.ProvenanceEntityRole" description="derivation | revision | quotation | source | removal" definition="How the entity was used during the activity.">
          <binding name="ProvenanceEntityRole" description="How an entity was used in an activity." strength="Required"/>
       </element>
@@ -22477,16 +22477,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ProvenanceEntityRole" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ProvenanceEntityRole" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="PublicationStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="PublicationStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="QualityType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="QualityType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Quantity" identifier="http://hl7.org/fhir/StructureDefinition/Quantity" label="Quantity" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Quantity" identifier="http://hl7.org/fhir/StructureDefinition/Quantity" label="Quantity" retrievable="false" primaryCodePath="code">
       <element name="value" elementType="FHIR.decimal" description="Numerical value (with implicit precision)" definition="The value of the measured amount. The value includes an implicit precision in the presentation of the value." comment="The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books)."/>
       <element name="comparator" elementType="FHIR.QuantityComparator" description="&lt; | &lt;= | >= | > - how to understand the value" definition="How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is &quot;&lt;&quot; , then the real value is &lt; stated value.">
          <binding name="QuantityComparator" description="How the Quantity should be understood and represented." strength="Required"/>
@@ -22495,10 +22495,10 @@
       <element name="system" elementType="FHIR.uri" description="System that defines coded unit form" definition="The identification of the system that provides the coded form of the unit."/>
       <element name="code" elementType="FHIR.code" description="Coded form of the unit" definition="A computer processable form of the unit in some unit representation system." comment="The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="QuantityComparator" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this questionnaire, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this questionnaire when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this questionnaire is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the questionnaire is stored on different servers." comment="The name of the referenced questionnaire can be conveyed using the http://hl7.org/fhir/StructureDefinition/display extension."/>
       <element name="identifier" description="Additional identifier for the questionnaire" definition="A formal identifier that is used to identify this questionnaire when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this questionnaire outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -22591,7 +22591,7 @@
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item" retrievable="false">
       <element name="linkId" elementType="FHIR.string" description="Unique id for item in questionnaire" definition="An identifier that is unique within the Questionnaire allowing linkage to the equivalent item in a QuestionnaireResponse resource." comment="This ''can'' be a meaningful identifier (e.g. a LOINC code) but is not intended to have any meaning.  GUIDs or sequential numbers are appropriate here."/>
       <element name="definition" elementType="FHIR.uri" description="ElementDefinition - details for the item" definition="This element is a URI that refers to an [ElementDefinition](elementdefinition.html) that provides information about this item, including information that might otherwise be included in the instance of the Questionnaire resource. A detailed description of the construction of the URI is shown in Comments, below. If this element is present then the following element values MAY be derived from the Element Definition if the corresponding elements of this Questionnaire resource instance have no value:&#xa;&#xa;* code (ElementDefinition.code) &#xa;* type (ElementDefinition.type) &#xa;* required (ElementDefinition.min) &#xa;* repeats (ElementDefinition.max) &#xa;* maxLength (ElementDefinition.maxLength) &#xa;* answerValueSet (ElementDefinition.binding)&#xa;* options (ElementDefinition.binding)." comment="The uri refers to an ElementDefinition in a [StructureDefinition](structuredefinition.html#) and always starts with the [canonical URL](references.html#canonical) for the target resource. When referring to a StructureDefinition, a fragment identifier is used to specify the element definition by its id [Element.id](element-definitions.html#Element.id). E.g. http://hl7.org/fhir/StructureDefinition/Observation#Observation.value[x]. In the absence of a fragment identifier, the first/root element definition in the target is the matching element definition."/>
       <element name="code" description="Corresponding concept for this item in a terminology" definition="A terminology code that corresponds to this group or question (e.g. a code from LOINC, which defines many questions and answers)." comment="The value may come from the ElementDefinition referred to by .definition.">
@@ -22629,7 +22629,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.AnswerOption" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.AnswerOption" retrievable="false">
       <element name="value" description="Answer value" definition="A potential answer that's allowed as the answer to this question." comment="The data type of the value must agree with the item.type.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="integer" xsi:type="NamedTypeSpecifier"/>
@@ -22643,7 +22643,7 @@
       </element>
       <element name="initialSelected" elementType="FHIR.boolean" description="Whether option is selected by default" definition="Indicates whether the answer value is selected when the list of possible answers is initially shown." comment="Use this instead of initial[v] if answerValueSet is present."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.EnableWhen" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.EnableWhen" retrievable="false">
       <element name="question" elementType="FHIR.string" description="Question that determines whether item is enabled" definition="The linkId for the question whose answer (or lack of answer) governs whether this item is enabled." comment="If multiple question occurrences are present for the same question (same linkId), then this refers to the nearest question occurrence reachable by tracing first the &quot;ancestor&quot; axis and then the &quot;preceding&quot; axis and then the &quot;following&quot; axis."/>
       <element name="operator" elementType="FHIR.QuestionnaireItemOperator" description="exists | = | != | > | &lt; | >= | &lt;=" definition="Specifies the criteria by which the question is enabled.">
          <binding name="QuestionnaireItemOperator" description="The criteria by which a question is enabled." strength="Required"/>
@@ -22664,7 +22664,7 @@
          <binding name="QuestionnaireQuestionOption3" description="Allowed values to answer questions." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.Initial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Questionnaire.Item.Initial" retrievable="false">
       <element name="value" description="Actual value for initializing the question" definition="The actual value to for an initial answer." comment="The type of the initial value must be consistent with the type of the item.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="boolean" xsi:type="NamedTypeSpecifier"/>
@@ -22683,13 +22683,13 @@
          <binding name="QuestionnaireQuestionOption2" description="Allowed values to answer questions." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireItemOperator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireItemOperator" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireItemType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireItemType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="Unique id for this set of answers" definition="A business identifier assigned to a particular completed (or partially completed) questionnaire."/>
       <element name="basedOn" description="Request fulfilled by this QuestionnaireResponse" definition="The order, proposal or plan that is fulfilled in whole or in part by this QuestionnaireResponse.  For example, a ServiceRequest seeking an intake assessment or a decision support recommendation to assess for post-partum depression.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
@@ -22906,7 +22906,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="QuestionnaireResponse.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="QuestionnaireResponse.Item" retrievable="false">
       <element name="linkId" elementType="FHIR.string" description="Pointer to specific item from Questionnaire" definition="The item from the Questionnaire that corresponds to this item in the QuestionnaireResponse resource."/>
       <element name="definition" elementType="FHIR.uri" description="ElementDefinition - details for the item" definition="A reference to an [ElementDefinition](elementdefinition.html) that provides the details for the item." comment="The ElementDefinition must be in a [StructureDefinition](structuredefinition.html#), and must have a fragment identifier that identifies the specific data element by its id (Element.id). E.g. http://hl7.org/fhir/StructureDefinition/Observation#Observation.value[x].&#xa;&#xa;There is no need for this element if the item pointed to by the linkId has a definition listed."/>
       <element name="text" elementType="FHIR.string" description="Name for group or question text" definition="Text that is displayed above the contents of the group or as the text of the question being answered."/>
@@ -22919,7 +22919,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="QuestionnaireResponse.Item.Answer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="QuestionnaireResponse.Item.Answer" retrievable="false">
       <element name="value" description="Single-valued answer to the question" definition="The answer (or one of the answers) provided by the respondent to the question." comment="More complex structures (Attachment, Resource and Quantity) will typically be limited to electronic forms that can expose an appropriate user interface to capture the components and enforce the constraints of a complex data type.  Additional complex types can be introduced through extensions. Must match the datatype specified by Questionnaire.item.type in the corresponding Questionnaire.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="boolean" xsi:type="NamedTypeSpecifier"/>
@@ -22943,18 +22943,18 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireResponseStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="QuestionnaireResponseStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Range" identifier="http://hl7.org/fhir/StructureDefinition/Range" label="Range" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Range" identifier="http://hl7.org/fhir/StructureDefinition/Range" label="Range" retrievable="false">
       <element name="low" elementType="FHIR.SimpleQuantity" description="Low limit" definition="The low limit. The boundary is inclusive." comment="If the low element is missing, the low boundary is not known."/>
       <element name="high" elementType="FHIR.SimpleQuantity" description="High limit" definition="The high limit. The boundary is inclusive." comment="If the high element is missing, the high boundary is not known."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Ratio" identifier="http://hl7.org/fhir/StructureDefinition/Ratio" label="Ratio" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Ratio" identifier="http://hl7.org/fhir/StructureDefinition/Ratio" label="Ratio" retrievable="false">
       <element name="numerator" elementType="FHIR.Quantity" description="Numerator value" definition="The value of the numerator."/>
       <element name="denominator" elementType="FHIR.Quantity" description="Denominator value" definition="The value of the denominator."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="FHIR.string" description="Literal reference, Relative, internal or absolute URL" definition="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources." comment="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server."/>
       <element name="type" elementType="FHIR.uri" description="Type the reference refers to (e.g. &quot;Patient&quot;)" definition="The expected type of the target of the reference. If both Reference.type and Reference.reference are populated and Reference.reference is a FHIR URL, both SHALL be consistent.&#xa;&#xa;The type is the Canonical URL of Resource Definition that is the type this reference refers to. References are URLs that are relative to http://hl7.org/fhir/StructureDefinition/ e.g. &quot;Patient&quot; is a reference to http://hl7.org/fhir/StructureDefinition/Patient. Absolute URLs are only allowed for logical models (and can only be used in references in logical models, not resources)." comment="This element is used to indicate the type of  the target of the reference. This may be used which ever of the other elements are populated (or not). In some cases, the type of the target may be determined by inspection of the reference (e.g. a RESTful URL) or by resolving the target of the reference; if both the type and a reference is provided, the reference SHALL resolve to a resource of the same type as that specified.">
          <binding name="FHIRResourceTypeExt" description="Aa resource (or, for logical models, the URI of the logical model)." strength="Extensible"/>
@@ -22962,16 +22962,16 @@
       <element name="identifier" elementType="FHIR.Identifier" description="Logical reference, when literal reference is not known" definition="An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference." comment="When an identifier is provided in place of a reference, any system processing the reference will only be able to resolve the identifier to a reference if it understands the business context in which the identifier is used. Sometimes this is global (e.g. a national identifier) but often it is not. For this reason, none of the useful mechanisms described for working with references (e.g. chaining, includes) are possible, nor should servers be expected to be able resolve the reference. Servers may accept an identifier based reference untouched, resolve it, and/or reject it - see CapabilityStatement.rest.resource.referencePolicy. &#xa;&#xa;When both an identifier and a literal reference are provided, the literal reference is preferred. Applications processing the resource are allowed - but not required - to check that the identifier matches the literal reference&#xa;&#xa;Applications converting a logical reference to a literal reference may choose to leave the logical reference present, or remove it.&#xa;&#xa;Reference is intended to point to a structure that can potentially be expressed as a FHIR resource, though there is no need for it to exist as an actual FHIR resource instance - except in as much as an application wishes to actual find the target of the reference. The content referred to be the identifier must meet the logical constraints implied by any limitations on what resource types are permitted for the reference.  For example, it would not be legitimate to send the identifier for a drug prescription if the type were Reference(Observation|DiagnosticReport).  One of the use-cases for Reference.identifier is the situation where no FHIR representation exists (where the type is Reference (Any)."/>
       <element name="display" elementType="FHIR.string" description="Text alternative for the resource" definition="Plain text narrative that identifies the resource in addition to the resource reference." comment="This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what's being referenced, not to fully describe it."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ReferenceHandlingPolicy" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ReferenceHandlingPolicy" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ReferenceVersionRules" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ReferenceVersionRules" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ReferredDocumentStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ReferredDocumentStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="FHIR.RelatedArtifactType" description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of" definition="The type of relationship to the related artifact.">
          <binding name="RelatedArtifactType" description="The type of relationship to the related artifact." strength="Required"/>
       </element>
@@ -22982,10 +22982,10 @@
       <element name="document" elementType="FHIR.Attachment" description="What document is being referenced" definition="The document being referenced, represented as an attachment. This is exclusive with the resource element."/>
       <element name="resource" elementType="FHIR.canonical" description="What resource is being referenced" definition="The related resource, such as a library, value set, profile, or other knowledge resource." comment="If the type is predecessor, this is a reference to the succeeding knowledge resource. If the type is successor, this is a reference to the prior knowledge resource."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RelatedArtifactType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="RelatedPerson" identifier="http://hl7.org/fhir/StructureDefinition/RelatedPerson" label="RelatedPerson" retrievable="true" primaryCodePath="relationship" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="RelatedPerson" identifier="http://hl7.org/fhir/StructureDefinition/RelatedPerson" label="RelatedPerson" retrievable="true" primaryCodePath="relationship">
       <element name="identifier" description="A human identifier for this person" definition="Identifier for a person within a particular scope.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -23034,19 +23034,19 @@
       <search name="name" path="name" type="System.String"/>
       <search name="patient" path="patient" type="FHIR.Patient"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RelatedPerson.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RelatedPerson.Communication" retrievable="false">
       <element name="language" elementType="FHIR.CodeableConcept" description="The language which can be used to communicate with the patient about his or her health" definition="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." comment="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.">
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
       <element name="preferred" elementType="FHIR.boolean" description="Language preference indicator" definition="Indicates whether or not the patient prefers this language (over other languages he masters up a certain level)." comment="This language is specifically identified for communicating healthcare information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RemittanceOutcome" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RemittanceOutcome" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RepositoryType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RepositoryType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="RequestGroup" identifier="http://hl7.org/fhir/StructureDefinition/RequestGroup" label="RequestGroup" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="RequestGroup" identifier="http://hl7.org/fhir/StructureDefinition/RequestGroup" label="RequestGroup" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Allows a service to provide a unique, business identifier for the request.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -23133,7 +23133,7 @@
       <search name="group-identifier" path="groupIdentifier" type="System.Code"/>
       <search name="authored" path="authoredOn" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action" retrievable="false">
       <element name="prefix" elementType="FHIR.string" description="User-visible prefix for the action (e.g. 1. or A.)" definition="A user-visible prefix for the action."/>
       <element name="title" elementType="FHIR.string" description="User-visible title" definition="The title of the action displayed to a user."/>
       <element name="description" elementType="FHIR.string" description="Short description of the action" definition="A short description of the action used to provide a summary to display to the user."/>
@@ -23191,13 +23191,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action.Condition" retrievable="false">
       <element name="kind" elementType="FHIR.ActionConditionKind" description="applicability | start | stop" definition="The kind of condition." comment="Applicability criteria are used to determine immediate applicability when a plan definition is applied to a given context. Start and stop criteria are carried through application and used to describe enter/exit criteria for an action.">
          <binding name="ActionConditionKind" description="The kind of condition for the action." strength="Required"/>
       </element>
       <element name="expression" elementType="FHIR.Expression" description="Boolean-valued expression" definition="An expression that returns true or false, indicating whether or not the condition is satisfied." comment="The expression may be inlined, or may be a reference to a named expression within a logic library referenced by the library element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action.RelatedAction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RequestGroup.Action.RelatedAction" retrievable="false">
       <element name="actionId" elementType="FHIR.id" description="What action this is related to" definition="The element id of the action this is related to."/>
       <element name="relationship" elementType="FHIR.ActionRelationshipType" description="before-start | before | before-end | concurrent-with-start | concurrent | concurrent-with-end | after-start | after | after-end" definition="The relationship of this action to the related action.">
          <binding name="ActionRelationshipType" description="Defines the types of relationships between actions." strength="Required"/>
@@ -23209,16 +23209,16 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RequestIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RequestIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RequestPriority" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RequestPriority" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchDefinition" label="ResearchDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchDefinition" label="ResearchDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this research definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this research definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this research definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the research definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the research definition" definition="A formal identifier that is used to identify this research definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this research definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -24046,7 +24046,7 @@
       <search name="title" path="title" type="System.String"/>
       <search name="description" path="description" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchElementDefinition" label="ResearchElementDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchElementDefinition" label="ResearchElementDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this research element definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this research element definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this research element definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the research element definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the research element definition" definition="A formal identifier that is used to identify this research element definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this research element definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -24879,7 +24879,7 @@
       <search name="context-type" path="useContext.code" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchElementDefinition.Characteristic" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchElementDefinition.Characteristic" retrievable="false">
       <element name="definition" description="What code or expression defines members?" definition="Define members of the research element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -24922,10 +24922,10 @@
          <binding name="GroupMeasure" description="Possible group measure aggregates (E.g. Mean, Median)." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResearchElementType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResearchElementType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchStudy" identifier="http://hl7.org/fhir/StructureDefinition/ResearchStudy" label="ResearchStudy" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchStudy" identifier="http://hl7.org/fhir/StructureDefinition/ResearchStudy" label="ResearchStudy" retrievable="true">
       <element name="identifier" description="Business Identifier for study" definition="Identifiers assigned to this research study by the sponsor or other systems.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25013,21 +25013,21 @@
       <search name="date" path="period" type="System.DateTime"/>
       <search name="site" path="site" type="FHIR.Location"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchStudy.Arm" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchStudy.Arm" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Label for study arm" definition="Unique, human-readable label for this arm of the study."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Categorization of study arm" definition="Categorization of study arm, e.g. experimental, active comparator, placebo comparater."/>
       <element name="description" elementType="FHIR.string" description="Short explanation of study path" definition="A succinct description of the path through the study that would be followed by a subject adhering to this arm."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchStudy.Objective" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ResearchStudy.Objective" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Label for the objective" definition="Unique, human-readable label for this objective of the study."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="primary | secondary | exploratory" definition="The kind of study objective.">
          <binding name="ResearchStudyObjectiveType" description="Codes for the kind of study objective." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResearchStudyStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResearchStudyStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchSubject" identifier="http://hl7.org/fhir/StructureDefinition/ResearchSubject" label="ResearchSubject" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ResearchSubject" identifier="http://hl7.org/fhir/StructureDefinition/ResearchSubject" label="ResearchSubject" retrievable="true">
       <element name="identifier" description="Business Identifier for research subject in a study" definition="Identifiers assigned to this research subject for a study.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25048,10 +25048,10 @@
       <search name="patient" path="individual" type="FHIR.Patient"/>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResearchSubjectStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResearchSubjectStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="FHIR" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="FHIR" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="FHIR.id" description="Logical id of this artifact" definition="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." comment="The only time that a resource does not have an id is when it is being submitted to the server using a create operation."/>
       <element name="meta" elementType="FHIR.Meta" description="Metadata about the resource" definition="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource."/>
       <element name="implicitRules" elementType="FHIR.uri" description="A set of rules under which this content was created" definition="A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc." comment="Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc."/>
@@ -25065,19 +25065,19 @@
       <search name="_source" path="meta.source" type="System.String"/>
       <search name="_tag" path="meta.tag" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResourceType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResourceType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResourceVersionPolicy" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResourceVersionPolicy" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ResponseType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ResponseType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RestfulCapabilityMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RestfulCapabilityMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="RiskAssessment" identifier="http://hl7.org/fhir/StructureDefinition/RiskAssessment" label="RiskAssessment" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="RiskAssessment" identifier="http://hl7.org/fhir/StructureDefinition/RiskAssessment" label="RiskAssessment" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Unique identifier for the assessment" definition="Business identifier assigned to the risk assessment.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25153,7 +25153,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskAssessment.Prediction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskAssessment.Prediction" retrievable="false">
       <element name="outcome" elementType="FHIR.CodeableConcept" description="Possible outcome for the subject" definition="One of the potential outcomes for the patient (e.g. remission, death,  a particular condition).">
          <binding name="RiskAssessmentOutcome" description="The condition or other outcome; e.g. death, remission, amputation, infection, etc." strength="Example"/>
       </element>
@@ -25178,10 +25178,10 @@
       </element>
       <element name="rationale" elementType="FHIR.string" description="Explanation of prediction" definition="Additional information explaining the basis for the prediction."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="RiskAssessmentStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="RiskAssessmentStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="RiskEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/RiskEvidenceSynthesis" label="RiskEvidenceSynthesis" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="RiskEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/RiskEvidenceSynthesis" label="RiskEvidenceSynthesis" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this risk evidence synthesis, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this risk evidence synthesis when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this risk evidence synthesis is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the risk evidence synthesis is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the risk evidence synthesis" definition="A formal identifier that is used to identify this risk evidence synthesis when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this risk evidence synthesis outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -25258,7 +25258,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="date" path="date" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.Certainty" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.Certainty" retrievable="false">
       <element name="rating" description="Certainty rating" definition="A rating of the certainty of the effect estimate.">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
          <binding name="QualityOfEvidenceRating" description="The quality of the evidence described. The code system used specifies the quality scale used to grade this evidence source while the code specifies the actual quality score (represented as a coded value) associated with the evidence." strength="Extensible"/>
@@ -25270,7 +25270,7 @@
          <elementTypeSpecifier elementType="FHIR.RiskEvidenceSynthesis.Certainty.CertaintySubcomponent" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of subcomponent of certainty rating" definition="Type of subcomponent of certainty rating.">
          <binding name="CertaintySubcomponentType" description="The subcomponent classification of quality of evidence rating systems." strength="Extensible"/>
       </element>
@@ -25282,7 +25282,7 @@
          <elementTypeSpecifier elementType="FHIR.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.RiskEstimate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.RiskEstimate" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of risk estimate" definition="Human-readable summary of risk estimate."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of risk estimate" definition="Examples include proportion and mean.">
          <binding name="RiskEstimateType" description="Whether the risk estimate is dichotomous, continuous or qualitative and the specific type of risk estimate (eg proportion or median)." strength="Extensible"/>
@@ -25297,7 +25297,7 @@
          <elementTypeSpecifier elementType="FHIR.RiskEvidenceSynthesis.RiskEstimate.PrecisionEstimate" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.RiskEstimate.PrecisionEstimate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.RiskEstimate.PrecisionEstimate" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of precision estimate" definition="Examples include confidence interval and interquartile range.">
          <binding name="PrecisionEstimateType" description="Method of reporting variability of estimates, such as confidence intervals, interquartile range or standard deviation." strength="Extensible"/>
       </element>
@@ -25305,15 +25305,15 @@
       <element name="from" elementType="FHIR.decimal" description="Lower bound" definition="Lower bound of confidence interval."/>
       <element name="to" elementType="FHIR.decimal" description="Upper bound" definition="Upper bound of confidence interval."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.SampleSize" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="RiskEvidenceSynthesis.SampleSize" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Description of sample size" definition="Human-readable summary of sample size."/>
       <element name="numberOfStudies" elementType="FHIR.integer" description="How many studies?" definition="Number of studies included in this evidence synthesis."/>
       <element name="numberOfParticipants" elementType="FHIR.integer" description="How many participants?" definition="Number of participants included in this evidence synthesis."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SPDXLicense" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SPDXLicense" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="FHIR.SimpleQuantity" description="Zero value and units" definition="The base quantity that a measured value of zero represents. In addition, this provides the units of the entire measurement series."/>
       <element name="period" elementType="FHIR.decimal" description="Number of milliseconds between samples" definition="The length of time between sampling times, measured in milliseconds." comment="This is usually a whole number."/>
       <element name="factor" elementType="FHIR.decimal" description="Multiply data by this before adding to origin" definition="A correction factor that is applied to the sampled data points before they are added to the origin."/>
@@ -25322,7 +25322,7 @@
       <element name="dimensions" elementType="FHIR.positiveInt" description="Number of sample points at each time point" definition="The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced - all the sample points for a point in time will be recorded at once." comment="If there is more than one dimension, the code for the type of data will define the meaning of the dimensions (typically ECG data)."/>
       <element name="data" elementType="FHIR.string" description="Decimal values with spaces, or &quot;E&quot; | &quot;U&quot; | &quot;L&quot;" definition="A series of data points which are decimal values separated by a single space (character u20). The special values &quot;E&quot; (error), &quot;L&quot; (below detection limit) and &quot;U&quot; (above detection limit) can also be used in place of a decimal value." comment="Data may be missing if it is omitted for summarization purposes. In general, data is required for any actual use of a SampledData."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Schedule" identifier="http://hl7.org/fhir/StructureDefinition/Schedule" label="Schedule" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Schedule" identifier="http://hl7.org/fhir/StructureDefinition/Schedule" label="Schedule" retrievable="true">
       <element name="identifier" description="External Ids for this item" definition="External Ids for this item.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25366,19 +25366,19 @@
       <search name="active" path="active" type="System.Code"/>
       <search name="identifier" path="identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SearchComparator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SearchComparator" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SearchEntryMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SearchEntryMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SearchModifierCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SearchModifierCode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SearchParamType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SearchParamType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SearchParameter" identifier="http://hl7.org/fhir/StructureDefinition/SearchParameter" label="SearchParameter" retrievable="true" primaryCodePath="target" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SearchParameter" identifier="http://hl7.org/fhir/StructureDefinition/SearchParameter" label="SearchParameter" retrievable="true" primaryCodePath="target">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this search parameter, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this search parameter when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this search parameter is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the search parameter is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the search parameter" definition="The identifier that is used to identify this version of the search parameter when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the search parameter author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different search parameter instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the search parameter with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this search parameter (computer friendly)" definition="A natural language name identifying the search parameter. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -25450,17 +25450,17 @@
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SearchParameter.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SearchParameter.Component" retrievable="false">
       <element name="definition" elementType="FHIR.canonical" description="Defines how the part works" definition="The definition of the search parameter that describes this part."/>
       <element name="expression" elementType="FHIR.string" description="Subexpression relative to main expression" definition="A sub-expression that defines how to extract values for this component from the output of the main SearchParameter.expression." comment="This expression overrides the expression in the definition and extracts the index values from the outcome of the composite expression."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SectionMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SectionMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SequenceType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SequenceType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ServiceRequest" identifier="http://hl7.org/fhir/StructureDefinition/ServiceRequest" label="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ServiceRequest" identifier="http://hl7.org/fhir/StructureDefinition/ServiceRequest" label="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Identifiers assigned to this order" definition="Identifiers assigned to this order instance by the orderer and/or the receiver and/or order fulfiller." comment="The identifier.type element is used to distinguish between the identifiers assigned by the orderer (known as the 'Placer' in HL7 v2) and the producer of the observations in response to the order (known as the 'Filler' in HL7 v2).  For further discussion and examples see the resource notes section below.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25641,16 +25641,16 @@
       <search name="priority" path="priority" type="System.Code"/>
       <search name="specimen" path="specimen" type="FHIR.Specimen"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestPriority" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestPriority" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="ServiceRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" description="Indication of the reason the entity signed the object(s)" definition="An indication of the reason that the entity signed this document. This may be explicitly included as part of the signature information and can be used when determining accountability for various actions concerning the document." comment="Examples include attesting to: authorship, correct transcription, and witness of specific event. Also known as a &amp;quot;Commitment Type Indication&amp;quot;.">
          <elementTypeSpecifier elementType="FHIR.Coding" xsi:type="ListTypeSpecifier"/>
          <binding name="SignatureType" description="An indication of the reason that an entity signed the object." strength="Preferred"/>
@@ -25667,10 +25667,10 @@
       <element name="data" elementType="FHIR.base64Binary" description="The actual signature content (XML DigSig. JWS, picture, etc.)" definition="The base64 encoding of the Signature content. When signature is not recorded electronically this element would be empty." comment="Where the signature type is an XML DigSig, the signed content is a FHIR Resource(s), the signature is of the XML form of the Resource(s) using  XML-Signature (XMLDIG) &quot;Detached Signature&quot; form."/>
    </typeInfo>
    <typeInfo baseType="FHIR.Quantity" namespace="FHIR" name="SimpleQuantity" identifier="http://hl7.org/fhir/StructureDefinition/SimpleQuantity" label="SimpleQuantity" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SlicingRules" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SlicingRules" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Slot" identifier="http://hl7.org/fhir/StructureDefinition/Slot" label="Slot" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Slot" identifier="http://hl7.org/fhir/StructureDefinition/Slot" label="Slot" retrievable="true">
       <element name="identifier" description="External Ids for this item" definition="External Ids for this item.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25706,13 +25706,13 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="status" path="status" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SlotStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SlotStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SortDirection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SortDirection" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Specimen" identifier="http://hl7.org/fhir/StructureDefinition/Specimen" label="Specimen" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Specimen" identifier="http://hl7.org/fhir/StructureDefinition/Specimen" label="Specimen" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="External Identifier" definition="Id for specimen.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25774,7 +25774,7 @@
       <search name="patient" path="subject.where(resolve() is Patient)" type="FHIR.Patient"/>
       <search name="container-id" path="container.identifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Collection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Collection" retrievable="false">
       <element name="collector" elementType="FHIR.Reference" description="Who collected the specimen" definition="Person who collected the specimen."/>
       <element name="collected" description="Collection time" definition="Time when specimen was collected from subject - the physiologically relevant time.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -25798,7 +25798,7 @@
          <binding name="FastingStatus" description="Codes describing the fasting status of the patient." strength="Extensible"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Container" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Container" retrievable="false">
       <element name="identifier" description="Id for the container" definition="Id for container. There may be multiple; a manufacturer's bar code, lab assigned identifier, etc. The container ID may differ from the specimen id in some circumstances.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -25816,7 +25816,7 @@
          <binding name="SpecimenContainerAdditive" description="Substance added to specimen container." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Processing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Specimen.Processing" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Textual description of procedure" definition="Textual description of procedure."/>
       <element name="procedure" elementType="FHIR.CodeableConcept" description="Indicates the treatment step  applied to the specimen" definition="A coded value specifying the procedure used to process the specimen.">
          <binding name="SpecimenProcessingProcedure" description="Type indicating the technique used to process the specimen." strength="Example"/>
@@ -25831,10 +25831,10 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SpecimenContainedPreference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SpecimenContainedPreference" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SpecimenDefinition" identifier="http://hl7.org/fhir/StructureDefinition/SpecimenDefinition" label="SpecimenDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SpecimenDefinition" identifier="http://hl7.org/fhir/StructureDefinition/SpecimenDefinition" label="SpecimenDefinition" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="Business identifier of a kind of specimen" definition="A business identifier associated with the kind of specimen."/>
       <element name="typeCollected" elementType="FHIR.CodeableConcept" description="Kind of material to collect" definition="The kind of material to be collected.">
          <binding name="CollectedSpecimenType" description="The type of the specimen to be collected." strength="Example"/>
@@ -25855,7 +25855,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="container" path="typeTested.container.type" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested" retrievable="false">
       <element name="isDerived" elementType="FHIR.boolean" description="Primary or secondary specimen" definition="Primary of secondary specimen."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of intended specimen" definition="The kind of specimen conditioned for testing expected by lab.">
          <binding name="IntendedSpecimenType" description="The type of specimen conditioned in a container for lab testing." strength="Example"/>
@@ -25874,7 +25874,7 @@
          <elementTypeSpecifier elementType="FHIR.SpecimenDefinition.TypeTested.Handling" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Container" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Container" retrievable="false">
       <element name="material" elementType="FHIR.CodeableConcept" description="Container material" definition="The type of material of the container.">
          <binding name="ContainerMaterial" description="Types of material for specimen containers." strength="Example"/>
       </element>
@@ -25897,7 +25897,7 @@
       </element>
       <element name="preparation" elementType="FHIR.string" description="Specimen container preparation" definition="Special processing that should be applied to the container for this kind of specimen."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Container.Additive" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Container.Additive" retrievable="false">
       <element name="additive" description="Additive associated with container" definition="Substance introduced in the kind of container to preserve, maintain or enhance the specimen. Examples: Formalin, Citrate, EDTA.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="CodeableConcept" xsi:type="NamedTypeSpecifier"/>
@@ -25906,7 +25906,7 @@
          <binding name="ContainerAdditive" description="Substance added to specimen container." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Handling" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SpecimenDefinition.TypeTested.Handling" retrievable="false">
       <element name="temperatureQualifier" elementType="FHIR.CodeableConcept" description="Temperature qualifier" definition="It qualifies the interval of temperature, which characterizes an occurrence of handling. Conditions that are not related to temperature may be handled in the instruction element.">
          <binding name="HandlingConditionSet" description="Set of handling instructions prior testing of the specimen." strength="Example"/>
       </element>
@@ -25914,16 +25914,16 @@
       <element name="maxDuration" elementType="FHIR.Duration" description="Maximum preservation time" definition="The maximum time interval of preservation of the specimen with these conditions."/>
       <element name="instruction" elementType="FHIR.string" description="Preservation instruction" definition="Additional textual instructions for the preservation or transport of the specimen. For instance, 'Protect from light exposure'."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SpecimenStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SpecimenStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Status" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Status" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StrandType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StrandType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="StructureDefinition" identifier="http://hl7.org/fhir/StructureDefinition/StructureDefinition" label="StructureDefinition" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="StructureDefinition" identifier="http://hl7.org/fhir/StructureDefinition/StructureDefinition" label="StructureDefinition" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this structure definition, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this structure definition when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this structure definition is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the structure definition is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the structure definition" definition="A formal identifier that is used to identify this structure definition when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this structure definition outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -26022,24 +26022,24 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Context" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Context" retrievable="false">
       <element name="type" elementType="FHIR.ExtensionContextType" description="fhirpath | element | extension" definition="Defines how to interpret the expression that defines what the context of the extension is.">
          <binding name="ExtensionContextType" description="How an extension context is interpreted." strength="Required"/>
       </element>
       <element name="expression" elementType="FHIR.string" description="Where the extension can be used in instances" definition="An expression that defines where an extension can be used in resources."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Differential" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Differential" retrievable="false">
       <element name="element" description="Definition of elements in the resource (if no StructureDefinition)" definition="Captures constraints on each element within the resource.">
          <elementTypeSpecifier elementType="FHIR.ElementDefinition" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Mapping" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Mapping" retrievable="false">
       <element name="identity" elementType="FHIR.id" description="Internal id when this mapping is used" definition="An Internal id that is used to identify this mapping set when specific mappings are made." comment="The specification is described once, with general comments, and then specific mappings are made that reference this declaration."/>
       <element name="uri" elementType="FHIR.uri" description="Identifies what this mapping refers to" definition="An absolute URI that identifies the specification that this mapping is expressed to." comment="A formal identity for the specification being mapped to helps with identifying maps consistently."/>
       <element name="name" elementType="FHIR.string" description="Names what this mapping refers to" definition="A name for the specification that is being mapped to."/>
       <element name="comment" elementType="FHIR.string" description="Versions, Issues, Scope limitations etc." definition="Comments about this mapping, including version notes, issues, scope limitations, and other important notes for usage."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Snapshot" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureDefinition.Snapshot" retrievable="false">
       <element name="element" description="Definition of elements in the resource (if no StructureDefinition)" definition="Captures constraints on each element within the resource.">
          <elementTypeSpecifier elementType="FHIR.ElementDefinition" xsi:type="ListTypeSpecifier"/>
          <constraint name="sdf-10" severity="ERROR" description="binding is required" message="provide either a binding reference or a description (or both)">
@@ -26047,10 +26047,10 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureDefinitionKind" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureDefinitionKind" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="StructureMap" identifier="http://hl7.org/fhir/StructureDefinition/StructureMap" label="StructureMap" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="StructureMap" identifier="http://hl7.org/fhir/StructureDefinition/StructureMap" label="StructureMap" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this structure map, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this structure map when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this structure map is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the structure map is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the structure map" definition="A formal identifier that is used to identify this structure map when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this structure map outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -26098,7 +26098,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group" retrievable="false">
       <element name="name" elementType="FHIR.id" description="Human-readable label" definition="A unique name for the group for the convenience of human readers."/>
       <element name="extends" elementType="FHIR.id" description="Another group that this group adds rules to" definition="Another group that this group adds rules to."/>
       <element name="typeMode" elementType="FHIR.StructureMapGroupTypeMode" description="none | types | type-and-types" definition="If this is the default rule set to apply for the source type or this combination of types." comment="Not applicable if the underlying model is untyped. There can only be one default mapping for any particular type combination.">
@@ -26112,7 +26112,7 @@
          <elementTypeSpecifier elementType="FHIR.StructureMap.Group.Rule" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Input" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Input" retrievable="false">
       <element name="name" elementType="FHIR.id" description="Name for this instance of data" definition="Name for this instance of data."/>
       <element name="type" elementType="FHIR.string" description="Type for this instance of data" definition="Type for this instance of data."/>
       <element name="mode" elementType="FHIR.StructureMapInputMode" description="source | target" definition="Mode for this instance of data.">
@@ -26120,7 +26120,7 @@
       </element>
       <element name="documentation" elementType="FHIR.string" description="Documentation for this instance of data" definition="Documentation for this instance of data."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule" retrievable="false">
       <element name="name" elementType="FHIR.id" description="Name of the rule for internal references" definition="Name of the rule for internal references."/>
       <element name="source" description="Source inputs to the mapping" definition="Source inputs to the mapping.">
          <elementTypeSpecifier elementType="FHIR.StructureMap.Group.Rule.Source" xsi:type="ListTypeSpecifier"/>
@@ -26144,13 +26144,13 @@
       </element>
       <element name="documentation" elementType="FHIR.string" description="Documentation for this instance of data" definition="Documentation for this instance of data."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Dependent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Dependent" retrievable="false">
       <element name="name" elementType="FHIR.id" description="Name of a rule or group to apply" definition="Name of a rule or group to apply."/>
       <element name="variable" description="Variable to pass to the rule or group" definition="Variable to pass to the rule or group.">
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Source" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Source" retrievable="false">
       <element name="context" elementType="FHIR.id" description="Type or variable this rule applies to" definition="Type or variable this rule applies to."/>
       <element name="min" elementType="FHIR.integer" description="Specified minimum cardinality" definition="Specified minimum cardinality for the element. This is optional; if present, it acts an implicit check on the input content."/>
       <element name="max" elementType="FHIR.string" description="Specified maximum cardinality (number or *)" definition="Specified maximum cardinality for the element - a number or a &quot;*&quot;. This is optional; if present, it acts an implicit check on the input content (* just serves as documentation; it's the default value)."/>
@@ -26218,7 +26218,7 @@
       <element name="check" elementType="FHIR.string" description="FHIRPath expression  - must be true or the mapping engine throws an error instead of completing" definition="FHIRPath expression  - must be true or the mapping engine throws an error instead of completing."/>
       <element name="logMessage" elementType="FHIR.string" description="Message to put in log if source exists (FHIRPath)" definition="A FHIRPath expression which specifies a message to put in the transform log when content matching the source rule is found." comment="This is typically used for recording that something Is not transformed to the target for some reason."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Target" retrievable="false">
       <element name="context" elementType="FHIR.id" description="Type or variable this rule applies to" definition="Type or variable this rule applies to."/>
       <element name="contextType" elementType="FHIR.StructureMapContextType" description="type | variable" definition="How to interpret the context.">
          <binding name="StructureMapContextType" description="How to interpret the context." strength="Required"/>
@@ -26237,7 +26237,7 @@
          <elementTypeSpecifier elementType="FHIR.StructureMap.Group.Rule.Target.Parameter" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Target.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Group.Rule.Target.Parameter" retrievable="false">
       <element name="value" description="Parameter value - variable or literal" definition="Parameter value - variable or literal.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="id" xsi:type="NamedTypeSpecifier"/>
@@ -26248,7 +26248,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Structure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="StructureMap.Structure" retrievable="false">
       <element name="url" elementType="FHIR.canonical" description="Canonical reference to structure definition" definition="The canonical reference to the structure."/>
       <element name="mode" elementType="FHIR.StructureMapModelMode" description="source | queried | target | produced" definition="How the referenced structure is used in this mapping.">
          <binding name="StructureMapModelMode" description="How the referenced structure is used in this mapping." strength="Required"/>
@@ -26256,28 +26256,28 @@
       <element name="alias" elementType="FHIR.string" description="Name for type in this map" definition="The name used for this type in the map." comment="This is needed if both types have the same name (e.g. version conversion)."/>
       <element name="documentation" elementType="FHIR.string" description="Documentation on use of structure" definition="Documentation that describes how the structure is used in the mapping."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapContextType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapContextType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapGroupTypeMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapGroupTypeMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapInputMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapInputMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapModelMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapModelMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapSourceListMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapSourceListMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapTargetListMode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapTargetListMode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="StructureMapTransform" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="StructureMapTransform" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Subscription" identifier="http://hl7.org/fhir/StructureDefinition/Subscription" label="Subscription" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Subscription" identifier="http://hl7.org/fhir/StructureDefinition/Subscription" label="Subscription" retrievable="true">
       <element name="status" elementType="FHIR.SubscriptionStatus" description="requested | active | error | off" definition="The status of the subscription, which marks the server state for managing the subscription." comment="A client can only submit subscription resources in the requested or off state. Only the server can  move a subscription from requested to active, and then to error. Either the server or the client can turn a subscription off.&#xa;&#xa;This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.">
          <binding name="SubscriptionStatus" description="The status of a subscription." strength="Required"/>
       </element>
@@ -26296,7 +26296,7 @@
       <search name="url" path="channel.endpoint" type="System.String"/>
       <search name="type" path="channel.type" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Subscription.Channel" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Subscription.Channel" retrievable="false">
       <element name="type" elementType="FHIR.SubscriptionChannelType" description="rest-hook | websocket | email | sms | message" definition="The type of channel to send notifications on.">
          <binding name="SubscriptionChannelType" description="The type of method used to execute a subscription." strength="Required"/>
       </element>
@@ -26308,13 +26308,13 @@
          <elementTypeSpecifier elementType="FHIR.string" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SubscriptionChannelType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SubscriptionChannelType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SubscriptionStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SubscriptionStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Substance" identifier="http://hl7.org/fhir/StructureDefinition/Substance" label="Substance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Substance" identifier="http://hl7.org/fhir/StructureDefinition/Substance" label="Substance" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Unique identifier" definition="Unique identifier for the substance." comment="This identifier is associated with the kind of substance in contrast to the  Substance.instance.identifier which is associated with the package/container.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -26343,7 +26343,7 @@
       <search name="container-identifier" path="instance.identifier" type="System.Code"/>
       <search name="expiry" path="instance.expiry" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Substance.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Substance.Ingredient" retrievable="false">
       <element name="quantity" elementType="FHIR.Ratio" description="Optional amount (concentration)" definition="The amount of the ingredient in the substance - a concentration ratio."/>
       <element name="substance" description="A component of the substance" definition="Another substance that is a component of this substance.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -26353,12 +26353,12 @@
          <binding name="SubstanceIngredient" description="Substance Ingredient codes." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Substance.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Substance.Instance" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Identifier of the package/container" definition="Identifier associated with the package/container (usually a label affixed directly)."/>
       <element name="expiry" elementType="FHIR.dateTime" description="When no longer valid to use" definition="When the substance is no longer valid to use. For some substances, a single arbitrary date is used for expiry."/>
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="Amount of substance in the package" definition="The amount of the substance."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceAmount" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceAmount" label="SubstanceAmount" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceAmount" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceAmount" label="SubstanceAmount" retrievable="false">
       <element name="amount" description="Used to capture quantitative values for a variety of elements. If only limits are given, the arithmetic mean would be the average. If only a single definite value for a given element is given, it would be captured in this field" definition="Used to capture quantitative values for a variety of elements. If only limits are given, the arithmetic mean would be the average. If only a single definite value for a given element is given, it would be captured in this field.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -26370,11 +26370,11 @@
       <element name="amountText" elementType="FHIR.string" description="A textual comment on a numeric value" definition="A textual comment on a numeric value."/>
       <element name="referenceRange" elementType="FHIR.SubstanceAmount.ReferenceRange" description="Reference range of possible or expected values" definition="Reference range of possible or expected values."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SubstanceAmount.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SubstanceAmount.ReferenceRange" retrievable="false">
       <element name="lowLimit" elementType="FHIR.Quantity" description="Lower limit possible or expected" definition="Lower limit possible or expected."/>
       <element name="highLimit" elementType="FHIR.Quantity" description="Upper limit possible or expected" definition="Upper limit possible or expected."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceNucleicAcid" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceNucleicAcid" label="SubstanceNucleicAcid" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceNucleicAcid" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceNucleicAcid" label="SubstanceNucleicAcid" retrievable="true">
       <element name="sequenceType" elementType="FHIR.CodeableConcept" description="The type of the sequence shall be specified based on a controlled vocabulary" definition="The type of the sequence shall be specified based on a controlled vocabulary."/>
       <element name="numberOfSubunits" elementType="FHIR.integer" description="The number of linear sequences of nucleotides linked through phosphodiester bonds shall be described. Subunits would be strands of nucleic acids that are tightly associated typically through Watson-Crick base pairing. NOTE: If not specified in the reference source, the assumption is that there is 1 subunit" definition="The number of linear sequences of nucleotides linked through phosphodiester bonds shall be described. Subunits would be strands of nucleic acids that are tightly associated typically through Watson-Crick base pairing. NOTE: If not specified in the reference source, the assumption is that there is 1 subunit."/>
       <element name="areaOfHybridisation" elementType="FHIR.string" description="The area of hybridisation shall be described if applicable for double stranded RNA or DNA. The number associated with the subunit followed by the number associated to the residue shall be specified in increasing order. The underscore “” shall be used as separator as follows: “Subunitnumber Residue”" definition="The area of hybridisation shall be described if applicable for double stranded RNA or DNA. The number associated with the subunit followed by the number associated to the residue shall be specified in increasing order. The underscore “” shall be used as separator as follows: “Subunitnumber Residue”."/>
@@ -26383,7 +26383,7 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceNucleicAcid.Subunit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit" retrievable="false">
       <element name="subunit" elementType="FHIR.integer" description="Index of linear sequences of nucleic acids in order of decreasing length. Sequences of the same length will be ordered by molecular weight. Subunits that have identical sequences will be repeated and have sequential subscripts" definition="Index of linear sequences of nucleic acids in order of decreasing length. Sequences of the same length will be ordered by molecular weight. Subunits that have identical sequences will be repeated and have sequential subscripts."/>
       <element name="sequence" elementType="FHIR.string" description="Actual nucleotide sequence notation from 5' to 3' end using standard single letter codes. In addition to the base sequence, sugar and type of phosphate or non-phosphate linkage should also be captured" definition="Actual nucleotide sequence notation from 5' to 3' end using standard single letter codes. In addition to the base sequence, sugar and type of phosphate or non-phosphate linkage should also be captured."/>
       <element name="length" elementType="FHIR.integer" description="The length of the sequence shall be captured" definition="The length of the sequence shall be captured."/>
@@ -26397,18 +26397,18 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceNucleicAcid.Subunit.Sugar" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit.Linkage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit.Linkage" retrievable="false">
       <element name="connectivity" elementType="FHIR.string" description="The entity that links the sugar residues together should also be captured for nearly all naturally occurring nucleic acid the linkage is a phosphate group. For many synthetic oligonucleotides phosphorothioate linkages are often seen. Linkage connectivity is assumed to be 3’-5’. If the linkage is either 3’-3’ or 5’-5’ this should be specified" definition="The entity that links the sugar residues together should also be captured for nearly all naturally occurring nucleic acid the linkage is a phosphate group. For many synthetic oligonucleotides phosphorothioate linkages are often seen. Linkage connectivity is assumed to be 3’-5’. If the linkage is either 3’-3’ or 5’-5’ this should be specified."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Each linkage will be registered as a fragment and have an ID" definition="Each linkage will be registered as a fragment and have an ID."/>
       <element name="name" elementType="FHIR.string" description="Each linkage will be registered as a fragment and have at least one name. A single name shall be assigned to each linkage" definition="Each linkage will be registered as a fragment and have at least one name. A single name shall be assigned to each linkage."/>
       <element name="residueSite" elementType="FHIR.string" description="Residues shall be captured as described in 5.3.6.8.3" definition="Residues shall be captured as described in 5.3.6.8.3."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit.Sugar" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceNucleicAcid.Subunit.Sugar" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="The Substance ID of the sugar or sugar-like component that make up the nucleotide" definition="The Substance ID of the sugar or sugar-like component that make up the nucleotide."/>
       <element name="name" elementType="FHIR.string" description="The name of the sugar or sugar-like component that make up the nucleotide" definition="The name of the sugar or sugar-like component that make up the nucleotide."/>
       <element name="residueSite" elementType="FHIR.string" description="The residues that contain a given sugar will be captured. The order of given residues will be captured in the 5‘-3‘direction consistent with the base sequences listed above" definition="The residues that contain a given sugar will be captured. The order of given residues will be captured in the 5‘-3‘direction consistent with the base sequences listed above."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstancePolymer" identifier="http://hl7.org/fhir/StructureDefinition/SubstancePolymer" label="SubstancePolymer" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstancePolymer" identifier="http://hl7.org/fhir/StructureDefinition/SubstancePolymer" label="SubstancePolymer" retrievable="true">
       <element name="class" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="geometry" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="copolymerConnectivity" description="Todo" definition="Todo.">
@@ -26424,19 +26424,19 @@
          <elementTypeSpecifier elementType="FHIR.SubstancePolymer.Repeat" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.MonomerSet" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.MonomerSet" retrievable="false">
       <element name="ratioType" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="startingMaterial" description="Todo" definition="Todo.">
          <elementTypeSpecifier elementType="FHIR.SubstancePolymer.MonomerSet.StartingMaterial" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.MonomerSet.StartingMaterial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.MonomerSet.StartingMaterial" retrievable="false">
       <element name="material" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="isDefining" elementType="FHIR.boolean" description="Todo" definition="Todo."/>
       <element name="amount" elementType="FHIR.SubstanceAmount" description="Todo" definition="Todo."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat" retrievable="false">
       <element name="numberOfUnits" elementType="FHIR.integer" description="Todo" definition="Todo."/>
       <element name="averageMolecularFormula" elementType="FHIR.string" description="Todo" definition="Todo."/>
       <element name="repeatUnitAmountType" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
@@ -26444,7 +26444,7 @@
          <elementTypeSpecifier elementType="FHIR.SubstancePolymer.Repeat.RepeatUnit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit" retrievable="false">
       <element name="orientationOfPolymerisation" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="repeatUnit" elementType="FHIR.string" description="Todo" definition="Todo."/>
       <element name="amount" elementType="FHIR.SubstanceAmount" description="Todo" definition="Todo."/>
@@ -26455,16 +26455,16 @@
          <elementTypeSpecifier elementType="FHIR.SubstancePolymer.Repeat.RepeatUnit.StructuralRepresentation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit.DegreeOfPolymerisation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit.DegreeOfPolymerisation" retrievable="false">
       <element name="degree" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="amount" elementType="FHIR.SubstanceAmount" description="Todo" definition="Todo."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit.StructuralRepresentation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstancePolymer.Repeat.RepeatUnit.StructuralRepresentation" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="representation" elementType="FHIR.string" description="Todo" definition="Todo."/>
       <element name="attachment" elementType="FHIR.Attachment" description="Todo" definition="Todo."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceProtein" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceProtein" label="SubstanceProtein" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceProtein" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceProtein" label="SubstanceProtein" retrievable="true">
       <element name="sequenceType" elementType="FHIR.CodeableConcept" description="The SubstanceProtein descriptive elements will only be used when a complete or partial amino acid sequence is available or derivable from a nucleic acid sequence" definition="The SubstanceProtein descriptive elements will only be used when a complete or partial amino acid sequence is available or derivable from a nucleic acid sequence."/>
       <element name="numberOfSubunits" elementType="FHIR.integer" description="Number of linear sequences of amino acids linked through peptide bonds. The number of subunits constituting the SubstanceProtein shall be described. It is possible that the number of subunits can be variable" definition="Number of linear sequences of amino acids linked through peptide bonds. The number of subunits constituting the SubstanceProtein shall be described. It is possible that the number of subunits can be variable."/>
       <element name="disulfideLinkage" description="The disulphide bond between two cysteine residues either on the same subunit or on two different subunits shall be described. The position of the disulfide bonds in the SubstanceProtein shall be listed in increasing order of subunit number and position within subunit followed by the abbreviation of the amino acids involved. The disulfide linkage positions shall actually contain the amino acid Cysteine at the respective positions" definition="The disulphide bond between two cysteine residues either on the same subunit or on two different subunits shall be described. The position of the disulfide bonds in the SubstanceProtein shall be listed in increasing order of subunit number and position within subunit followed by the abbreviation of the amino acids involved. The disulfide linkage positions shall actually contain the amino acid Cysteine at the respective positions.">
@@ -26474,7 +26474,7 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceProtein.Subunit" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceProtein.Subunit" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceProtein.Subunit" retrievable="false">
       <element name="subunit" elementType="FHIR.integer" description="Index of primary sequences of amino acids linked through peptide bonds in order of decreasing length. Sequences of the same length will be ordered by molecular weight. Subunits that have identical sequences will be repeated and have sequential subscripts" definition="Index of primary sequences of amino acids linked through peptide bonds in order of decreasing length. Sequences of the same length will be ordered by molecular weight. Subunits that have identical sequences will be repeated and have sequential subscripts."/>
       <element name="sequence" elementType="FHIR.string" description="The sequence information shall be provided enumerating the amino acids from N- to C-terminal end using standard single-letter amino acid codes. Uppercase shall be used for L-amino acids and lowercase for D-amino acids. Transcribed SubstanceProteins will always be described using the translated sequence; for synthetic peptide containing amino acids that are not represented with a single letter code an X should be used within the sequence. The modified amino acids will be distinguished by their position in the sequence" definition="The sequence information shall be provided enumerating the amino acids from N- to C-terminal end using standard single-letter amino acid codes. Uppercase shall be used for L-amino acids and lowercase for D-amino acids. Transcribed SubstanceProteins will always be described using the translated sequence; for synthetic peptide containing amino acids that are not represented with a single letter code an X should be used within the sequence. The modified amino acids will be distinguished by their position in the sequence."/>
       <element name="length" elementType="FHIR.integer" description="Length of linear sequences of amino acids contained in the subunit" definition="Length of linear sequences of amino acids contained in the subunit."/>
@@ -26484,7 +26484,7 @@
       <element name="cTerminalModificationId" elementType="FHIR.Identifier" description="Unique identifier for molecular fragment modification based on the ISO 11238 Substance ID" definition="Unique identifier for molecular fragment modification based on the ISO 11238 Substance ID."/>
       <element name="cTerminalModification" elementType="FHIR.string" description="The modification at the C-terminal shall be specified" definition="The modification at the C-terminal shall be specified."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceReferenceInformation" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceReferenceInformation" label="SubstanceReferenceInformation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceReferenceInformation" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceReferenceInformation" label="SubstanceReferenceInformation" retrievable="true">
       <element name="comment" elementType="FHIR.string" description="Todo" definition="Todo."/>
       <element name="gene" description="Todo" definition="Todo.">
          <elementTypeSpecifier elementType="FHIR.SubstanceReferenceInformation.Gene" xsi:type="ListTypeSpecifier"/>
@@ -26499,7 +26499,7 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceReferenceInformation.Target" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Classification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Classification" retrievable="false">
       <element name="domain" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="classification" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="subtype" description="Todo" definition="Todo.">
@@ -26509,21 +26509,21 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Gene" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Gene" retrievable="false">
       <element name="geneSequenceOrigin" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="gene" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="source" description="Todo" definition="Todo.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.GeneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.GeneElement" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="element" elementType="FHIR.Identifier" description="Todo" definition="Todo."/>
       <element name="source" description="Todo" definition="Todo.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceReferenceInformation.Target" retrievable="false">
       <element name="target" elementType="FHIR.Identifier" description="Todo" definition="Todo."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
       <element name="interaction" elementType="FHIR.CodeableConcept" description="Todo" definition="Todo."/>
@@ -26541,7 +26541,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceSourceMaterial" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSourceMaterial" label="SubstanceSourceMaterial" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceSourceMaterial" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSourceMaterial" label="SubstanceSourceMaterial" retrievable="true">
       <element name="sourceMaterialClass" elementType="FHIR.CodeableConcept" description="General high level classification of the source material specific to the origin of the material" definition="General high level classification of the source material specific to the origin of the material."/>
       <element name="sourceMaterialType" elementType="FHIR.CodeableConcept" description="The type of the source material shall be specified based on a controlled vocabulary. For vaccines, this subclause refers to the class of infectious agent" definition="The type of the source material shall be specified based on a controlled vocabulary. For vaccines, this subclause refers to the class of infectious agent."/>
       <element name="sourceMaterialState" elementType="FHIR.CodeableConcept" description="The state of the source material when extracted" definition="The state of the source material when extracted."/>
@@ -26568,11 +26568,11 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceSourceMaterial.PartDescription" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.FractionDescription" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.FractionDescription" retrievable="false">
       <element name="fraction" elementType="FHIR.string" description="This element is capturing information about the fraction of a plant part, or human plasma for fractionation" definition="This element is capturing information about the fraction of a plant part, or human plasma for fractionation."/>
       <element name="materialType" elementType="FHIR.CodeableConcept" description="The specific type of the material constituting the component. For Herbal preparations the particulars of the extracts (liquid/dry) is described in Specified Substance Group 1" definition="The specific type of the material constituting the component. For Herbal preparations the particulars of the extracts (liquid/dry) is described in Specified Substance Group 1."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism" retrievable="false">
       <element name="family" elementType="FHIR.CodeableConcept" description="The family of an organism shall be specified" definition="The family of an organism shall be specified."/>
       <element name="genus" elementType="FHIR.CodeableConcept" description="The genus of an organism shall be specified; refers to the Latin epithet of the genus element of the plant/animal scientific name; it is present in names for genera, species and infraspecies" definition="The genus of an organism shall be specified; refers to the Latin epithet of the genus element of the plant/animal scientific name; it is present in names for genera, species and infraspecies."/>
       <element name="species" elementType="FHIR.CodeableConcept" description="The species of an organism shall be specified; refers to the Latin epithet of the species of the plant/animal; it is present in names for species and infraspecies" definition="The species of an organism shall be specified; refers to the Latin epithet of the species of the plant/animal; it is present in names for species and infraspecies."/>
@@ -26584,28 +26584,28 @@
       <element name="hybrid" elementType="FHIR.SubstanceSourceMaterial.Organism.Hybrid" description="4.9.13.8.1 Hybrid species maternal organism ID (Optional)" definition="4.9.13.8.1 Hybrid species maternal organism ID (Optional)."/>
       <element name="organismGeneral" elementType="FHIR.SubstanceSourceMaterial.Organism.OrganismGeneral" description="4.9.13.7.1 Kingdom (Conditional)" definition="4.9.13.7.1 Kingdom (Conditional)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.Author" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.Author" retrievable="false">
       <element name="authorType" elementType="FHIR.CodeableConcept" description="The type of author of an organism species shall be specified. The parenthetical author of an organism species refers to the first author who published the plant/animal name (of any rank). The primary author of an organism species refers to the first author(s), who validly published the plant/animal name" definition="The type of author of an organism species shall be specified. The parenthetical author of an organism species refers to the first author who published the plant/animal name (of any rank). The primary author of an organism species refers to the first author(s), who validly published the plant/animal name."/>
       <element name="authorDescription" elementType="FHIR.string" description="The author of an organism species shall be specified. The author year of an organism shall also be specified when applicable; refers to the year in which the first author(s) published the infraspecific plant/animal name (of any rank)" definition="The author of an organism species shall be specified. The author year of an organism shall also be specified when applicable; refers to the year in which the first author(s) published the infraspecific plant/animal name (of any rank)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.Hybrid" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.Hybrid" retrievable="false">
       <element name="maternalOrganismId" elementType="FHIR.string" description="The identifier of the maternal species constituting the hybrid organism shall be specified based on a controlled vocabulary. For plants, the parents aren’t always known, and it is unlikely that it will be known which is maternal and which is paternal" definition="The identifier of the maternal species constituting the hybrid organism shall be specified based on a controlled vocabulary. For plants, the parents aren’t always known, and it is unlikely that it will be known which is maternal and which is paternal."/>
       <element name="maternalOrganismName" elementType="FHIR.string" description="The name of the maternal species constituting the hybrid organism shall be specified. For plants, the parents aren’t always known, and it is unlikely that it will be known which is maternal and which is paternal" definition="The name of the maternal species constituting the hybrid organism shall be specified. For plants, the parents aren’t always known, and it is unlikely that it will be known which is maternal and which is paternal."/>
       <element name="paternalOrganismId" elementType="FHIR.string" description="The identifier of the paternal species constituting the hybrid organism shall be specified based on a controlled vocabulary" definition="The identifier of the paternal species constituting the hybrid organism shall be specified based on a controlled vocabulary."/>
       <element name="paternalOrganismName" elementType="FHIR.string" description="The name of the paternal species constituting the hybrid organism shall be specified" definition="The name of the paternal species constituting the hybrid organism shall be specified."/>
       <element name="hybridType" elementType="FHIR.CodeableConcept" description="The hybrid type of an organism shall be specified" definition="The hybrid type of an organism shall be specified."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.OrganismGeneral" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.Organism.OrganismGeneral" retrievable="false">
       <element name="kingdom" elementType="FHIR.CodeableConcept" description="The kingdom of an organism shall be specified" definition="The kingdom of an organism shall be specified."/>
       <element name="phylum" elementType="FHIR.CodeableConcept" description="The phylum of an organism shall be specified" definition="The phylum of an organism shall be specified."/>
       <element name="class" elementType="FHIR.CodeableConcept" description="The class of an organism shall be specified" definition="The class of an organism shall be specified."/>
       <element name="order" elementType="FHIR.CodeableConcept" description="The order of an organism shall be specified," definition="The order of an organism shall be specified,."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.PartDescription" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSourceMaterial.PartDescription" retrievable="false">
       <element name="part" elementType="FHIR.CodeableConcept" description="Entity of anatomical origin of source material within an organism" definition="Entity of anatomical origin of source material within an organism."/>
       <element name="partLocation" elementType="FHIR.CodeableConcept" description="The detailed anatomic location when the part can be extracted from different anatomical locations of the organism. Multiple alternative locations may apply" definition="The detailed anatomic location when the part can be extracted from different anatomical locations of the organism. Multiple alternative locations may apply."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceSpecification" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSpecification" label="SubstanceSpecification" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SubstanceSpecification" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSpecification" label="SubstanceSpecification" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="Identifier by which this substance is known" definition="Identifier by which this substance is known."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="High level categorization, e.g. polymer or nucleic acid" definition="High level categorization, e.g. polymer or nucleic acid."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="Status of substance within the catalogue e.g. approved" definition="Status of substance within the catalogue e.g. approved."/>
@@ -26643,7 +26643,7 @@
       <element name="sourceMaterial" elementType="FHIR.Reference" description="Material or taxonomic/anatomical source for the substance" definition="Material or taxonomic/anatomical source for the substance."/>
       <search name="code" path="code.code" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Code" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Code" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="The specific code" definition="The specific code."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="Status of the code assignment" definition="Status of the code assignment."/>
       <element name="statusDate" elementType="FHIR.dateTime" description="The date at which the code status is changed as part of the terminology maintenance" definition="The date at which the code status is changed as part of the terminology maintenance."/>
@@ -26652,7 +26652,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Moiety" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Moiety" retrievable="false">
       <element name="role" elementType="FHIR.CodeableConcept" description="Role that the moiety is playing" definition="Role that the moiety is playing."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Identifier by which this moiety substance is known" definition="Identifier by which this moiety substance is known."/>
       <element name="name" elementType="FHIR.string" description="Textual name for this moiety substance" definition="Textual name for this moiety substance."/>
@@ -26666,7 +26666,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Name" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Name" retrievable="false">
       <element name="name" elementType="FHIR.string" description="The actual name" definition="The actual name."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Name type" definition="Name type."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="The status of the name" definition="The status of the name."/>
@@ -26697,12 +26697,12 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Name.Official" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Name.Official" retrievable="false">
       <element name="authority" elementType="FHIR.CodeableConcept" description="Which authority uses this official name" definition="Which authority uses this official name."/>
       <element name="status" elementType="FHIR.CodeableConcept" description="The status of the official name" definition="The status of the official name."/>
       <element name="date" elementType="FHIR.dateTime" description="Date of official name change" definition="Date of official name change."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Property" retrievable="false">
       <element name="category" elementType="FHIR.CodeableConcept" description="A category for this property, e.g. Physical, Chemical, Enzymatic" definition="A category for this property, e.g. Physical, Chemical, Enzymatic."/>
       <element name="code" elementType="FHIR.CodeableConcept" description="Property type e.g. viscosity, pH, isoelectric point" definition="Property type e.g. viscosity, pH, isoelectric point."/>
       <element name="parameters" elementType="FHIR.string" description="Parameters that were used in the measurement of a property (e.g. for viscosity: measured at 20C with a pH of 7.1)" definition="Parameters that were used in the measurement of a property (e.g. for viscosity: measured at 20C with a pH of 7.1)."/>
@@ -26719,7 +26719,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Relationship" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Relationship" retrievable="false">
       <element name="substance" description="A pointer to another substance, as a resource or just a representational code" definition="A pointer to another substance, as a resource or just a representational code.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -26742,7 +26742,7 @@
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure" retrievable="false">
       <element name="stereochemistry" elementType="FHIR.CodeableConcept" description="Stereochemistry type" definition="Stereochemistry type."/>
       <element name="opticalActivity" elementType="FHIR.CodeableConcept" description="Optical activity type" definition="Optical activity type."/>
       <element name="molecularFormula" elementType="FHIR.string" description="Molecular formula" definition="Molecular formula."/>
@@ -26758,24 +26758,24 @@
          <elementTypeSpecifier elementType="FHIR.SubstanceSpecification.Structure.Representation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Isotope" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Isotope" retrievable="false">
       <element name="identifier" elementType="FHIR.Identifier" description="Substance identifier for each non-natural or radioisotope" definition="Substance identifier for each non-natural or radioisotope."/>
       <element name="name" elementType="FHIR.CodeableConcept" description="Substance name for each non-natural or radioisotope" definition="Substance name for each non-natural or radioisotope."/>
       <element name="substitution" elementType="FHIR.CodeableConcept" description="The type of isotopic substitution present in a single substance" definition="The type of isotopic substitution present in a single substance."/>
       <element name="halfLife" elementType="FHIR.Quantity" description="Half life - for a non-natural nuclide" definition="Half life - for a non-natural nuclide."/>
       <element name="molecularWeight" elementType="FHIR.SubstanceSpecification.Structure.Isotope.MolecularWeight" description="The molecular weight or weight range (for proteins, polymers or nucleic acids)" definition="The molecular weight or weight range (for proteins, polymers or nucleic acids)."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Isotope.MolecularWeight" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Isotope.MolecularWeight" retrievable="false">
       <element name="method" elementType="FHIR.CodeableConcept" description="The method by which the molecular weight was determined" definition="The method by which the molecular weight was determined."/>
       <element name="type" elementType="FHIR.CodeableConcept" description="Type of molecular weight such as exact, average (also known as. number average), weight average" definition="Type of molecular weight such as exact, average (also known as. number average), weight average."/>
       <element name="amount" elementType="FHIR.Quantity" description="Used to capture quantitative values for a variety of elements. If only limits are given, the arithmetic mean would be the average. If only a single definite value for a given element is given, it would be captured in this field" definition="Used to capture quantitative values for a variety of elements. If only limits are given, the arithmetic mean would be the average. If only a single definite value for a given element is given, it would be captured in this field."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Representation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SubstanceSpecification.Structure.Representation" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="The type of structure (e.g. Full, Partial, Representative)" definition="The type of structure (e.g. Full, Partial, Representative)."/>
       <element name="representation" elementType="FHIR.string" description="The structural representation as text string in a format e.g. InChI, SMILES, MOLFILE, CDX" definition="The structural representation as text string in a format e.g. InChI, SMILES, MOLFILE, CDX."/>
       <element name="attachment" elementType="FHIR.Attachment" description="An attached file with the structural representation" definition="An attached file with the structural representation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SupplyDelivery" identifier="http://hl7.org/fhir/StructureDefinition/SupplyDelivery" label="SupplyDelivery" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SupplyDelivery" identifier="http://hl7.org/fhir/StructureDefinition/SupplyDelivery" label="SupplyDelivery" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="External identifier" definition="Identifier for the supply delivery event that is used to identify it across multiple disparate systems." comment="This identifier is typically assigned by the dispenser, and may be used to reference the delivery when exchanging information about it with other systems.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -26830,7 +26830,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SupplyDelivery.SuppliedItem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SupplyDelivery.SuppliedItem" retrievable="false">
       <element name="quantity" elementType="FHIR.SimpleQuantity" description="Amount dispensed" definition="The amount of supply that has been dispensed. Includes unit of measure."/>
       <element name="item" description="Medication, Substance, or Device supplied" definition="Identifies the medication, substance or device being dispensed. This is either a link to a resource representing the details of the item or a code that identifies the item from a known list.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -26840,10 +26840,10 @@
          <binding name="SupplyDeliveryItem" description="The item that was delivered." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SupplyDeliveryStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SupplyDeliveryStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="SupplyRequest" identifier="http://hl7.org/fhir/StructureDefinition/SupplyRequest" label="SupplyRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="SupplyRequest" identifier="http://hl7.org/fhir/StructureDefinition/SupplyRequest" label="SupplyRequest" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="Business Identifier for SupplyRequest" definition="Business identifiers assigned to this SupplyRequest by the author and/or other systems. These identifiers remain constant as the resource is updated and propagates from server to server." comment="The identifier.type element is used to distinguish between the identifiers assigned by the requester/placer and the performer/filler.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -26920,7 +26920,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="SupplyRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="SupplyRequest.Parameter" retrievable="false">
       <element name="code" elementType="FHIR.CodeableConcept" description="Item detail" definition="A code or string that identifies the device detail being asserted.">
          <binding name="ParameterCode" description="A code that identifies the device detail." strength="Example"/>
       </element>
@@ -26933,13 +26933,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SupplyRequestStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SupplyRequestStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="SystemRestfulInteraction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="SystemRestfulInteraction" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="Task" identifier="http://hl7.org/fhir/StructureDefinition/Task" label="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="Task" identifier="http://hl7.org/fhir/StructureDefinition/Task" label="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Task Instance Identifier" definition="The business identifier for this task.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -27488,7 +27488,7 @@
       </search>
       <search name="group-identifier" path="groupIdentifier" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Input" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Input" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Label for the input" definition="A code or description indicating how the input is intended to be used as part of the task execution." comment="If referencing a BPMN workflow or Protocol, the &quot;system&quot; is the URL for the workflow definition and the code is the &quot;name&quot; of the required input.">
          <binding name="TaskInputParameterType" description="Codes to identify types of input parameters.  These will typically be specific to a particular workflow.  E.g. &quot;Comparison source&quot;, &quot;Applicable consent&quot;, &quot;Concomitent Medications&quot;, etc." strength="Example"/>
       </element>
@@ -27547,7 +27547,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Output" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Output" retrievable="false">
       <element name="type" elementType="FHIR.CodeableConcept" description="Label for output" definition="The name of the Output parameter.">
          <binding name="TaskOutputParameterType" description="Codes to identify types of input parameters.  These will typically be specific to a particular workflow.  E.g. &quot;Identified issues&quot;, &quot;Preliminary results&quot;, &quot;Filler order&quot;, &quot;Final results&quot;, etc." strength="Example"/>
       </element>
@@ -27606,23 +27606,23 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Restriction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Task.Restriction" retrievable="false">
       <element name="repetitions" elementType="FHIR.positiveInt" description="How many times to repeat" definition="Indicates the number of times the requested action should occur."/>
       <element name="period" elementType="FHIR.Period" description="When fulfillment sought" definition="Over what time-period is fulfillment sought." comment="Note that period.high is the due date representing the time by which the task should be completed."/>
       <element name="recipient" description="For whom is fulfillment sought?" definition="For requests that are targeted to more than on potential recipient/target, for whom is fulfillment sought?">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TaskIntent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TaskIntent" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TaskPriority" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TaskPriority" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TaskStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TaskStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="TerminologyCapabilities" identifier="http://hl7.org/fhir/StructureDefinition/TerminologyCapabilities" label="TerminologyCapabilities" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="TerminologyCapabilities" identifier="http://hl7.org/fhir/StructureDefinition/TerminologyCapabilities" label="TerminologyCapabilities" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this terminology capabilities, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this terminology capabilities when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this terminology capabilities is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the terminology capabilities is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="version" elementType="FHIR.string" description="Business version of the terminology capabilities" definition="The identifier that is used to identify this version of the terminology capabilities when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the terminology capabilities author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different terminology capabilities instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the terminology capabilities with the format [url]|[version]."/>
       <element name="name" elementType="FHIR.string" description="Name for this terminology capabilities (computer friendly)" definition="A natural language name identifying the terminology capabilities. This name should be usable as an identifier for the module by machine processing applications such as code generation." comment="The name is not expected to be globally unique. The name should be a simple alphanumeric type name to ensure that it is machine-processing friendly."/>
@@ -27676,17 +27676,17 @@
       <search name="jurisdiction" path="jurisdiction" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Closure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Closure" retrievable="false">
       <element name="translation" elementType="FHIR.boolean" description="If cross-system closure is supported" definition="If cross-system closure is supported."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem" retrievable="false">
       <element name="uri" elementType="FHIR.canonical" description="URI for the Code System" definition="URI for the Code System."/>
       <element name="version" description="Version of Code System supported" definition="For the code system, a list of versions that are supported by the server." comment="Language translations might not be available for all codes.">
          <elementTypeSpecifier elementType="FHIR.TerminologyCapabilities.CodeSystem.Version" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="subsumption" elementType="FHIR.boolean" description="Whether subsumption is supported" definition="True if subsumption is supported for this version of the code system."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem.Version" retrievable="false">
       <element name="code" elementType="FHIR.string" description="Version identifier for this version" definition="For version-less code systems, there should be a single version with no identifier."/>
       <element name="isDefault" elementType="FHIR.boolean" description="If this is the default version for this code system" definition="If this is the default version for this code system."/>
       <element name="compositional" elementType="FHIR.boolean" description="If compositional grammar is supported" definition="If the compositional grammar defined by the code system is supported."/>
@@ -27700,13 +27700,13 @@
          <elementTypeSpecifier elementType="FHIR.code" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem.Version.Filter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.CodeSystem.Version.Filter" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Code of the property supported" definition="Code of the property supported."/>
       <element name="op" description="Operations supported for the property" definition="Operations supported for the property.">
          <elementTypeSpecifier elementType="FHIR.code" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Expansion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Expansion" retrievable="false">
       <element name="hierarchical" elementType="FHIR.boolean" description="Whether the server can return nested value sets" definition="Whether the server can return nested value sets."/>
       <element name="paging" elementType="FHIR.boolean" description="Whether the server supports paging on expansion" definition="Whether the server supports paging on expansion."/>
       <element name="incomplete" elementType="FHIR.boolean" description="Allow request for incomplete expansions?" definition="Allow request for incomplete expansions?"/>
@@ -27715,25 +27715,25 @@
       </element>
       <element name="textFilter" elementType="FHIR.markdown" description="Documentation about text searching works" definition="Documentation about text searching works." comment="This documentation should cover things like case sensitivity,  use of punctuation if not ignored, what wild cards are supported (if any), whether text is starts with or contains, and whether word order matters."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Expansion.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Expansion.Parameter" retrievable="false">
       <element name="name" elementType="FHIR.code" description="Expansion Parameter name" definition="Expansion Parameter name."/>
       <element name="documentation" elementType="FHIR.string" description="Description of support for parameter" definition="Description of support for parameter."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Implementation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Implementation" retrievable="false">
       <element name="description" elementType="FHIR.string" description="Describes this specific instance" definition="Information about the specific installation that this terminology capability statement relates to."/>
       <element name="url" elementType="FHIR.url" description="Base URL for the implementation" definition="An absolute base URL for the implementation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Software" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Software" retrievable="false">
       <element name="name" elementType="FHIR.string" description="A name the software is known by" definition="Name the software is known by."/>
       <element name="version" elementType="FHIR.string" description="Version covered by this statement" definition="The version identifier for the software covered by this statement." comment="If possible, a version should be specified, as statements are likely to be different for different versions of software."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Translation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.Translation" retrievable="false">
       <element name="needsMap" elementType="FHIR.boolean" description="Whether the client must identify the map" definition="Whether the client must identify the map."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.ValidateCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TerminologyCapabilities.ValidateCode" retrievable="false">
       <element name="translations" elementType="FHIR.boolean" description="Whether translations are validated" definition="Whether translations are validated."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="TestReport" identifier="http://hl7.org/fhir/StructureDefinition/TestReport" label="TestReport" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="TestReport" identifier="http://hl7.org/fhir/StructureDefinition/TestReport" label="TestReport" retrievable="true">
       <element name="identifier" elementType="FHIR.Identifier" description="External identifier" definition="Identifier for the TestScript assigned for external purposes outside the context of FHIR."/>
       <element name="name" elementType="FHIR.string" description="Informal name of the executed TestScript" definition="A free text natural language name identifying the executed TestScript." comment="Not expected to be globally unique."/>
       <element name="status" elementType="FHIR.TestReportStatus" description="completed | in-progress | waiting | stopped | entered-in-error" definition="The current state of this test report." comment="The status represents where the execution is currently within the test script execution life cycle.&#xa;&#xa;This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.">
@@ -27761,14 +27761,14 @@
       <search name="testscript" path="testScript" type="FHIR.TestScript"/>
       <search name="participant" path="participant.uri" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Participant" retrievable="false">
       <element name="type" elementType="FHIR.TestReportParticipantType" description="test-engine | client | server" definition="The type of participant.">
          <binding name="TestReportParticipantType" description="The type of participant." strength="Required"/>
       </element>
       <element name="uri" elementType="FHIR.uri" description="The uri of the participant. An absolute URL is preferred" definition="The uri of the participant. An absolute URL is preferred."/>
       <element name="display" elementType="FHIR.string" description="The display name of the participant" definition="The display name of the participant."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup" retrievable="false">
       <element name="action" description="A setup operation or assert that was executed" definition="Action would contain either an operation or an assertion." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
          <elementTypeSpecifier elementType="FHIR.TestReport.Setup.Action" xsi:type="ListTypeSpecifier"/>
          <constraint name="inv-1" severity="ERROR" message="Setup action SHALL contain either an operation or assert but not both.">
@@ -27776,33 +27776,33 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestReport.Setup.Action.Operation" description="The operation to perform" definition="The operation performed."/>
       <element name="assert" elementType="FHIR.TestReport.Setup.Action.Assert" description="The assertion to perform" definition="The results of the assertion performed on the previous operations."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action.Assert" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action.Assert" retrievable="false">
       <element name="result" elementType="FHIR.TestReportActionResult" description="pass | skip | fail | warning | error" definition="The result of this assertion.">
          <binding name="TestReportActionResult" description="The results of executing an action." strength="Required"/>
       </element>
       <element name="message" elementType="FHIR.markdown" description="A message associated with the result" definition="An explanatory message associated with the result."/>
       <element name="detail" elementType="FHIR.string" description="A link to further details on the result" definition="A link to further details on the result."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action.Operation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Setup.Action.Operation" retrievable="false">
       <element name="result" elementType="FHIR.TestReportActionResult" description="pass | skip | fail | warning | error" definition="The result of this operation.">
          <binding name="TestReportActionResult" description="The results of executing an action." strength="Required"/>
       </element>
       <element name="message" elementType="FHIR.markdown" description="A message associated with the result" definition="An explanatory message associated with the result."/>
       <element name="detail" elementType="FHIR.uri" description="A link to further details on the result" definition="A link to further details on the result."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Teardown" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Teardown" retrievable="false">
       <element name="action" description="One or more teardown operations performed" definition="The teardown action will only contain an operation." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
          <elementTypeSpecifier elementType="FHIR.TestReport.Teardown.Action" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Teardown.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Teardown.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestReport.Setup.Action.Operation" description="The teardown operation performed" definition="An operation would involve a REST request to a server."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Test" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Test" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Tracking/logging name of this test" definition="The name of this test used for tracking/logging purposes by test engines."/>
       <element name="description" elementType="FHIR.string" description="Tracking/reporting short description of the test" definition="A short description of the test used by test engines for tracking and reporting purposes."/>
       <element name="action" description="A test operation or assert that was performed" definition="Action would contain either an operation or an assertion." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
@@ -27812,23 +27812,23 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Test.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestReport.Test.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestReport.Setup.Action.Operation" description="The operation performed" definition="An operation would involve a REST request to a server."/>
       <element name="assert" elementType="FHIR.TestReport.Setup.Action.Assert" description="The assertion performed" definition="The results of the assertion performed on the previous operations."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TestReportActionResult" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TestReportActionResult" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TestReportParticipantType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TestReportParticipantType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TestReportResult" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TestReportResult" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TestReportStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TestReportStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="TestScript" identifier="http://hl7.org/fhir/StructureDefinition/TestScript" label="TestScript" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="TestScript" identifier="http://hl7.org/fhir/StructureDefinition/TestScript" label="TestScript" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this test script, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this test script when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this test script is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the test script is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" elementType="FHIR.Identifier" description="Additional identifier for the test script" definition="A formal identifier that is used to identify this test script when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this test script outside of FHIR, where it is not possible to use the logical URI."/>
       <element name="version" elementType="FHIR.string" description="Business version of the test script" definition="The identifier that is used to identify this version of the test script when it is referenced in a specification, model, design or instance. This is an arbitrary value managed by the test script author and is not expected to be globally unique. For example, it might be a timestamp (e.g. yyyymmdd) if a managed version is not available. There is also no expectation that versions can be placed in a lexicographical sequence." comment="There may be different test script instances that have the same identifier but different versions.  The version can be appended to the url in a reference to allow a reference to a particular business version of the test script with the format [url]|[version]."/>
@@ -27894,18 +27894,18 @@
       <search name="description" path="description" type="System.String"/>
       <search name="title" path="title" type="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Destination" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Destination" retrievable="false">
       <element name="index" elementType="FHIR.integer" description="The index of the abstract destination server starting at 1" definition="Abstract name given to a destination server in this test script.  The name is provided as a number starting at 1." comment="A given destination index (e.g. 1) can appear only once in the list (e.g. Destination 1 cannot be specified twice ... once as Form-Manager and again as Form-Processor within the same script as that could get confusing during test configuration). &#xa;&#xa;Different destination indices could play the same actor in the same test script (e.g. You could have two different test systems acting as Form-Manager).&#xa;&#xa;The destination indices provided elsewhere in the test script must be one of these destination indices."/>
       <element name="profile" elementType="FHIR.Coding" description="FHIR-Server | FHIR-SDC-FormManager | FHIR-SDC-FormReceiver | FHIR-SDC-FormProcessor" definition="The type of destination profile the test system supports." comment="Must be a &quot;receiver&quot;/&quot;server&quot; profile.">
          <binding name="TestScriptProfileDestinationType" description="The type of destination profile the test system supports." strength="Extensible"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Fixture" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Fixture" retrievable="false">
       <element name="autocreate" elementType="FHIR.boolean" description="Whether or not to implicitly create the fixture during setup" definition="Whether or not to implicitly create the fixture during setup. If true, the fixture is automatically created on each server being tested during setup, therefore no create operation is required for this fixture in the TestScript.setup section."/>
       <element name="autodelete" elementType="FHIR.boolean" description="Whether or not to implicitly delete the fixture during teardown" definition="Whether or not to implicitly delete the fixture during teardown. If true, the fixture is automatically deleted on each server being tested during teardown, therefore no delete operation is required for this fixture in the TestScript.teardown section."/>
       <element name="resource" elementType="FHIR.Reference" description="Reference of the resource" definition="Reference to the resource (containing the contents of the resource needed for operations)." comment="See http://build.fhir.org/resourcelist.html for complete list of resource types."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata" retrievable="false">
       <element name="link" description="Links to the FHIR specification" definition="A link to the FHIR specification that this test is covering.">
          <elementTypeSpecifier elementType="FHIR.TestScript.Metadata.Link" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -27913,7 +27913,7 @@
          <elementTypeSpecifier elementType="FHIR.TestScript.Metadata.Capability" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata.Capability" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata.Capability" retrievable="false">
       <element name="required" elementType="FHIR.boolean" description="Are the capabilities required?" definition="Whether or not the test execution will require the given capabilities of the server in order for this test script to execute."/>
       <element name="validated" elementType="FHIR.boolean" description="Are the capabilities validated?" definition="Whether or not the test execution will validate the given capabilities of the server in order for this test script to execute."/>
       <element name="description" elementType="FHIR.string" description="The expected capabilities of the server" definition="Description of the capabilities that this test script is requiring the server to support."/>
@@ -27926,17 +27926,17 @@
       </element>
       <element name="capabilities" elementType="FHIR.canonical" description="Required Capability Statement" definition="Minimum capabilities required of server for test script to execute successfully.   If server does not meet at a minimum the referenced capability statement, then all tests in this script are skipped." comment="The conformance statement of the server has to contain at a minimum the contents of the reference pointed to by this element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Metadata.Link" retrievable="false">
       <element name="url" elementType="FHIR.uri" description="URL to the specification" definition="URL to a particular requirement or feature within the FHIR specification."/>
       <element name="description" elementType="FHIR.string" description="Short description" definition="Short description of the link."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Origin" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Origin" retrievable="false">
       <element name="index" elementType="FHIR.integer" description="The index of the abstract origin server starting at 1" definition="Abstract name given to an origin server in this test script.  The name is provided as a number starting at 1." comment="A given origin index (e.g. 1) can appear only once in the list (e.g. Origin 1 cannot be specified twice ... once as FormFiller and again as FormProcessor within the same script as that could get confusing during test configuration). &#xa;&#xa;Different origin indices could play the same actor in the same test script (e.g. You could have two different test systems acting as Form-Filler).&#xa;&#xa;The origin indices provided elsewhere in the test script must be one of these origin indices."/>
       <element name="profile" elementType="FHIR.Coding" description="FHIR-Client | FHIR-SDC-FormFiller" definition="The type of origin profile the test system supports." comment="Must be a &quot;sender&quot;/&quot;client&quot; profile.">
          <binding name="TestScriptProfileOriginType" description="The type of origin profile the test system supports." strength="Extensible"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup" retrievable="false">
       <element name="action" description="A setup operation or assert to perform" definition="Action would contain either an operation or an assertion." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
          <elementTypeSpecifier elementType="FHIR.TestScript.Setup.Action" xsi:type="ListTypeSpecifier"/>
          <constraint name="tst-1" severity="ERROR" message="Setup action SHALL contain either an operation or assert but not both.">
@@ -27944,7 +27944,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestScript.Setup.Action.Operation" description="The setup operation to perform" definition="The operation to perform.">
          <constraint name="tst-7" severity="ERROR" message="Setup operation SHALL contain either sourceId or targetId or params or url.">
             <expression language="text/fhirpath" expression="sourceId.exists() or (targetId.count() + url.count() + params.count() = 1) or (type.code in ('capabilities' |'search' | 'transaction' | 'history'))"/>
@@ -27962,7 +27962,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Assert" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Assert" retrievable="false">
       <element name="label" elementType="FHIR.string" description="Tracking/logging assertion label" definition="The label would be used for tracking/logging purposes by test engines." comment="This has no impact on the verification itself."/>
       <element name="description" elementType="FHIR.string" description="Tracking/reporting assertion description" definition="The description would be used by test engines for tracking and reporting purposes." comment="This has no impact on the verification itself."/>
       <element name="direction" elementType="FHIR.AssertionDirectionType" description="response | request" definition="The direction to use for the assertion." comment="If the direction is specified as &quot;response&quot; (the default), then the processing of this assert is against the received response message. If the direction is specified as &quot;request&quot;, then the processing of this assert is against the sent request message.">
@@ -27998,7 +27998,7 @@
       <element name="value" elementType="FHIR.string" description="The value to compare to" definition="The value to compare to." comment="The string-representation of a number, string, or boolean that is expected.  Test engines do have to look for placeholders (${}) and replace the variable placeholders with the variable values at runtime before comparing this value to the actual value."/>
       <element name="warningOnly" elementType="FHIR.boolean" description="Will this assert produce a warning only on error?" definition="Whether or not the test execution will produce a warning only on error for this assert." comment="If this element is specified and it is true, then assertion failures can be logged by test engine but should not stop the test script execution from proceeding.  There are likely cases where the spec is not clear on what should happen. If the spec says something is optional (maybe a response header for example), but a server doesn’t do it, we could choose to issue a warning."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Operation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Operation" retrievable="false">
       <element name="type" elementType="FHIR.Coding" description="The operation code type that will be executed" definition="Server interaction or operation type." comment="See http://build.fhir.org/http.html for list of server interactions.">
          <binding name="TestScriptOperationCode" description="The allowable operation code types." strength="Extensible"/>
       </element>
@@ -28029,23 +28029,23 @@
       <element name="targetId" elementType="FHIR.id" description="Id of fixture used for extracting the [id],  [type], and [vid] for GET requests" definition="Id of fixture used for extracting the [id],  [type], and [vid] for GET requests." comment="If &quot;url&quot; element is specified, then &quot;targetId&quot;, &quot;params&quot;, and &quot;resource&quot; elements will be ignored as &quot;url&quot; element will have everything needed for constructing the request url.  If &quot;params&quot; element is specified, then &quot;targetId&quot; element is ignored.  For FHIR operations that require a resource (e.g. &quot;read&quot; and &quot;vread&quot; operations), the &quot;resource&quot; element must be specified when &quot;params&quot; element is specified.  If &quot;url&quot; and &quot;params&quot; elements are absent, then the request url will be constructed from &quot;targetId&quot; fixture if present.  For &quot;read&quot; operation, the resource and id values will be extracted from &quot;targetId&quot; fixture and used to construct the url.  For &quot;vread&quot; and &quot;history&quot; operations, the versionId value will also be used."/>
       <element name="url" elementType="FHIR.string" description="Request URL" definition="Complete request URL." comment="Used to set the request URL explicitly.  If &quot;url&quot; element is defined, then &quot;targetId&quot;, &quot;resource&quot;, and &quot;params&quot; elements will be ignored.  Test engines would use whatever is specified in &quot;url&quot; without tampering with the string (beyond encoding the URL for HTTP).  Test engines do have to look for placeholders (${}) and replace the variable placeholders with the variable values at runtime before sending the request."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Operation.RequestHeader" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Setup.Action.Operation.RequestHeader" retrievable="false">
       <element name="field" elementType="FHIR.string" description="HTTP header field name" definition="The HTTP header field e.g. &quot;Accept&quot;." comment="If header element is specified, then field is required."/>
       <element name="value" elementType="FHIR.string" description="HTTP headerfield value" definition="The value of the header e.g. &quot;application/fhir+xml&quot;." comment="If header element is specified, then value is required.  No conversions will be done by the test engine e.g. &quot;xml&quot; to &quot;application/fhir+xml&quot;.  The values will be set in HTTP headers &quot;as-is&quot;.  Test engines do have to look for placeholders (${}) and replace the variable placeholders with the variable values at runtime before sending the request."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Teardown" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Teardown" retrievable="false">
       <element name="action" description="One or more teardown operations to perform" definition="The teardown action will only contain an operation." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
          <elementTypeSpecifier elementType="FHIR.TestScript.Teardown.Action" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Teardown.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Teardown.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestScript.Setup.Action.Operation" description="The teardown operation to perform" definition="An operation would involve a REST request to a server.">
          <constraint name="tst-9" severity="ERROR" message="Teardown operation SHALL contain either sourceId or targetId or params or url.">
             <expression language="text/fhirpath" expression="sourceId.exists() or (targetId.count() + url.count() + params.count() = 1) or (type.code in ('capabilities' | 'search' | 'transaction' | 'history'))"/>
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Test" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Test" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Tracking/logging name of this test" definition="The name of this test used for tracking/logging purposes by test engines."/>
       <element name="description" elementType="FHIR.string" description="Tracking/reporting short description of the test" definition="A short description of the test used by test engines for tracking and reporting purposes."/>
       <element name="action" description="A test operation or assert to perform" definition="Action would contain either an operation or an assertion." comment="An action should contain either an operation or an assertion but not both.  It can contain any number of variables.">
@@ -28055,7 +28055,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Test.Action" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Test.Action" retrievable="false">
       <element name="operation" elementType="FHIR.TestScript.Setup.Action.Operation" description="The setup operation to perform" definition="An operation would involve a REST request to a server.">
          <constraint name="tst-8" severity="ERROR" message="Test operation SHALL contain either sourceId or targetId or params or url.">
             <expression language="text/fhirpath" expression="sourceId.exists() or (targetId.count() + url.count() + params.count() = 1) or (type.code in ('capabilities' | 'search' | 'transaction' | 'history'))"/>
@@ -28073,7 +28073,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Variable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="TestScript.Variable" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Descriptive name for this variable" definition="Descriptive name for this variable." comment="Placeholders would contain the variable name wrapped in ${} in &quot;operation.params&quot;, &quot;operation.requestHeader.value&quot;, and &quot;operation.url&quot; elements.  These placeholders would need to be replaced by the variable value before the operation is executed."/>
       <element name="defaultValue" elementType="FHIR.string" description="Default, hard-coded, or user-defined value for this variable" definition="A default, hard-coded, or user-defined value for this variable." comment="The purpose of this element is to allow for a pre-defined value that can be used as a default or as an override value. Test engines can optionally use this as a placeholder for user-defined execution time values."/>
       <element name="description" elementType="FHIR.string" description="Natural language description of the variable" definition="A free text natural language description of the variable and its purpose."/>
@@ -28083,10 +28083,10 @@
       <element name="path" elementType="FHIR.string" description="XPath or JSONPath against the fixture body" definition="XPath or JSONPath to evaluate against the fixture body.  When variables are defined, only one of either expression, headerField or path must be specified." comment="If headerField is defined, then the variable will be evaluated against the headers that sourceId is pointing to.  If expression or path is defined, then the variable will be evaluated against the fixture body that sourceId is pointing to.  It is an error to define any combination of expression, headerField and path."/>
       <element name="sourceId" elementType="FHIR.id" description="Fixture Id of source expression or headerField within this variable" definition="Fixture to evaluate the XPath/JSONPath expression or the headerField  against within this variable." comment="This can be a statically defined fixture (at the top of the TestScript) or a dynamically set fixture created by responseId of the `action.operation` element."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TestScriptRequestMethodCode" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TestScriptRequestMethodCode" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" description="When the event occurs" definition="Identifies specific times when the event occurs.">
          <elementTypeSpecifier elementType="FHIR.dateTime" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -28123,7 +28123,7 @@
          <binding name="TimingAbbreviation" description="Code for a known / defined timing pattern." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Timing.Repeat" retrievable="false">
       <element name="bounds" description="Length/Range of lengths, or (Start and/or end) limits" definition="Either a duration for the length of the timing schedule, a range of possible length, or outer bounds for start and/or end limits of the timing schedule.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="FHIR" name="Duration" xsi:type="NamedTypeSpecifier"/>
@@ -28158,7 +28158,7 @@
       </element>
       <element name="offset" elementType="FHIR.unsignedInt" description="Minutes from event (before or after)" definition="The number of minutes from the event. If the event code does not indicate whether the minutes is before or after the event, then the offset is assumed to be after the event."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="FHIR.TriggerType" description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended" definition="The type of triggering event.">
          <binding name="TriggerType" description="The type of trigger." strength="Required"/>
       </element>
@@ -28176,22 +28176,22 @@
       </element>
       <element name="condition" elementType="FHIR.Expression" description="Whether the event triggers (boolean expression)" definition="A boolean-valued expression that is evaluated in the context of the container of the trigger definition and returns whether or not the trigger fires." comment="This element can be only be specified for data type triggers and provides additional semantics for the trigger. The context available within the condition is based on the type of data event. For all events, the current resource will be available as context. In addition, for modification events, the previous resource will also be available. The expression may be inlined, or may be a simple absolute URI, which is a reference to a named expression within a logic library referenced by a library element or extension within the containing resource. If the expression is a FHIR Path expression, it evaluates in the context of a resource of one of the type identified in the data requirement, and may also refer to the variable %previous for delta comparisons on events of type data-changed, data-modified, and data-deleted which will always have the same type."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TriggerType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TriggerType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TypeDerivationRule" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TypeDerivationRule" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="TypeRestfulInteraction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="TypeRestfulInteraction" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="UDIEntryType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="UnitsOfTime" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="FHIR.Coding" description="Type of context being specified" definition="A code that identifies the type of context being specified by this usage context.">
          <binding name="UsageContextType" description="A code that specifies a type of context being specified by a usage context." strength="Extensible"/>
       </element>
@@ -28205,10 +28205,10 @@
          <binding name="UsageContextValue" description="A code that defines the specific value for the context being specified." strength="Example"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="Use" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="Use" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="ValueSet" identifier="http://hl7.org/fhir/StructureDefinition/ValueSet" label="ValueSet" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="ValueSet" identifier="http://hl7.org/fhir/StructureDefinition/ValueSet" label="ValueSet" retrievable="true">
       <element name="url" elementType="FHIR.uri" description="Canonical identifier for this value set, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this value set when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this value set is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the value set is stored on different servers." comment="Can be a urn:uuid: or a urn:oid: but real http: addresses are preferred.  Multiple instances may share the same URL if they have a distinct version.&#xa;&#xa;The determination of when to create a new version of a resource (same url, new version) vs. defining a new artifact is up to the author.  Considerations for making this decision are found in [Technical and Business Versions](resource.html#versions). &#xa;&#xa;In some cases, the resource can no longer be found at the stated url, but the url itself cannot change. Implementations can use the [meta.source](resource.html#meta) element to indicate where the current master source of the resource can be found."/>
       <element name="identifier" description="Additional identifier for the value set (business identifier)" definition="A formal identifier that is used to identify this value set when it is represented in other formats, or referenced in a specification, model, design or an instance." comment="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this value set outside of FHIR, where it is not possible to use the logical URI.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -28253,7 +28253,7 @@
       <search name="identifier" path="identifier" type="System.Code"/>
       <search name="version" path="version" type="System.Code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose" retrievable="false">
       <element name="lockedDate" elementType="FHIR.date" description="Fixed date for references with no specified version (transitive)" definition="The Locked Date is  the effective date that is used to determine the version of all referenced Code Systems and Value Set Definitions included in the compose that are not already tied to a specific version." comment="With a defined lockedDate the value set is considered &quot;Locked&quot;. Otherwise, the value set may have different expansions as underlying code systems and/or value sets evolve.  The interpretation of lockedDate is often dependent on the context - e.g. a SNOMED CT derived value set with a lockedDate will have a different expansion in USA than in UK.  If a value set specifies a version for include and exclude statements, and also specifies a locked date, the specified versions need to be available that date, or the value set will not be usable."/>
       <element name="inactive" elementType="FHIR.boolean" description="Whether inactive codes are in the value set" definition="Whether inactive codes - codes that are not approved for current use - are in the value set. If inactive = true, inactive codes are to be included in the expansion, if inactive = false, the inactive codes will not be included in the expansion. If absent, the behavior is determined by the implementation, or by the applicable $expand parameters (but generally, inactive codes would be expected to be included)." comment="Note that in the FHIR terminology framework, &quot;deprecated&quot; does not mean inactive, but in some code systems, e.g. LOINC, &quot;deprecated&quot; does mean inactive. Code systems should define what codes are considered to be inactive. If this is not clearly defined (including in the FHIR code system resource), then all codes are assumed to be active.&#xa;&#xa;The Value Set Definition specification defines an ActiveOnly element, which is the reverse of this element e.g. (ValueSet.compose.inactive=FALSE) is the same as (VSD.ActiveOnly=TRUE)."/>
       <element name="include" description="Include one or more codes from a code system or other value set(s)" definition="Include one or more codes from a code system or other value set(s)." comment="All the conditions in an include must be true. If a system is listed, all the codes from the system are listed. If one or more filters are listed, all of the filters must apply. If one or more value sets are listed, the codes must be in all the value sets. E.g. each include is 'include all the codes that meet all these conditions'.">
@@ -28274,7 +28274,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include" retrievable="false">
       <element name="system" elementType="FHIR.uri" description="The system the codes come from" definition="An absolute URI which is the code system from which the selected codes come from." comment="If there are no codes or filters, the entire code system is included. Note that the set of codes that are included may contain abstract codes. See ''Coding.system'' for further documentation about the correct value for the system element."/>
       <element name="version" elementType="FHIR.string" description="Specific version of the code system referred to" definition="The version of the code system that the codes are selected from, or the special version '*' for all versions." comment="This is used when selecting the descendants of a concept - they may change between versions. If no version is specified, then the exact contents of the value set might not be known until a context of use binds it to a particular version. The special value '*' means all versions; It is at server discretion regarding expansions and which versions must be supported."/>
       <element name="concept" description="A concept defined in the system" definition="Specifies a concept to be included or excluded." comment="The list of concepts is considered ordered, though the order might not have any particular significance. Typically, the order of an expansion follows that defined in the compose element.">
@@ -28287,14 +28287,14 @@
          <elementTypeSpecifier elementType="FHIR.canonical" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Concept" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Concept" retrievable="false">
       <element name="code" elementType="FHIR.code" description="Code or expression from system" definition="Specifies a code for the concept to be included or excluded." comment="Expressions are allowed if defined by the underlying code system."/>
       <element name="display" elementType="FHIR.string" description="Text to display for this code for this value set in this valueset" definition="The text to display to the user for this concept in the context of this valueset. If no display is provided, then applications using the value set use the display specified for the code by the system." comment="The value set resource allows for an alternative display to be specified for when this concept is used in this particular value set. See notes in the value set narrative about the correct use of this element."/>
       <element name="designation" description="Additional representations for this concept" definition="Additional representations for this concept when used in this value set - other languages, aliases, specialized purposes, used for particular purposes, etc." comment="Concepts have both a ```display``` and an array of ```designation```. The display is equivalent to a special designation with an implied ```designation.use``` of &quot;primary code&quot; and a language equal to the [Resource Language](resource.html#language).">
          <elementTypeSpecifier elementType="FHIR.ValueSet.Compose.Include.Concept.Designation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Concept.Designation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Concept.Designation" retrievable="false">
       <element name="language" elementType="FHIR.code" description="Human language of the designation" definition="The language this designation is defined for." comment="In the absence of a language, the resource language applies.">
          <binding name="Language" description="A human language." strength="Preferred"/>
       </element>
@@ -28303,14 +28303,14 @@
       </element>
       <element name="value" elementType="FHIR.string" description="The text value for this designation" definition="The text value for this designation."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Filter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Compose.Include.Filter" retrievable="false">
       <element name="property" elementType="FHIR.code" description="A property/filter defined by the code system" definition="A code that identifies a property or a filter defined in the code system."/>
       <element name="op" elementType="FHIR.FilterOperator" description="= | is-a | descendent-of | is-not-a | regex | in | not-in | generalizes | exists" definition="The kind of operation to perform as a part of the filter criteria." comment="In case filter.property represents a property of the system, the operation applies to the selected property. In case filter.property represents a filter of the system, the operation SHALL match one of the CodeSystem.filter.operator values.">
          <binding name="FilterOperator" description="The kind of operation to perform as a part of a property based filter." strength="Required"/>
       </element>
       <element name="value" elementType="FHIR.string" description="Code from the system, or regex criteria, or boolean value for exists" definition="The match value may be either a code defined by the system, or a string value, which is a regex match on the literal string of the property value  (if the filter represents a property defined in CodeSystem) or of the system filter value (if the filter represents a filter defined in CodeSystem) when the operation is 'regex', or one of the values (true and false), when the operation is 'exists'." comment="Use regex matching with care - full regex matching on every SNOMED CT term is prohibitive, for example."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion" retrievable="false">
       <element name="identifier" elementType="FHIR.uri" description="Identifies the value set expansion (business identifier)" definition="An identifier that uniquely identifies this expansion of the valueset, based on a unique combination of the provided parameters, the system default parameters, and the underlying system code system versions etc. Systems may re-use the same identifier as long as those factors remain the same, and the expansion is the same, but are not required to do so. This is a business identifier." comment="Typically, this uri is a UUID (e.g. urn:uuid:8230ff20-c97a-4167-a59d-dc2cb9df16dd)."/>
       <element name="timestamp" elementType="FHIR.dateTime" description="Time ValueSet expansion happened" definition="The time at which the expansion was produced by the expanding system." comment="This SHOULD be a fully populated instant, but in some circumstances, value sets are expanded by hand, and the expansion is published without that precision."/>
       <element name="total" elementType="FHIR.integer" description="Total number of codes in the expansion" definition="The total number of concepts in the expansion. If the number of concept nodes in this resource is less than the stated number, then the server can return more using the offset parameter." comment="Paging only applies to flat expansions."/>
@@ -28331,7 +28331,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion.Contains" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion.Contains" retrievable="false">
       <element name="system" elementType="FHIR.uri" description="System value for the code" definition="An absolute URI which is the code system in which the code for this item in the expansion is defined."/>
       <element name="abstract" elementType="FHIR.boolean" description="If user cannot select this entry" definition="If true, this entry is included in the expansion for navigational purposes, and the user cannot select the code directly as a proper value." comment="This should not be understood to exclude its use for searching (e.g. by subsumption testing). The client should know whether it is appropriate for the user to select an abstract code or not."/>
       <element name="inactive" elementType="FHIR.boolean" description="If concept is inactive in the code system" definition="If the concept is inactive in the code system that defines it. Inactive codes are those that are no longer to be used, but are maintained by the code system for understanding legacy data. It might not be known or specified whether an concept is inactive (and it may depend on the context of use)." comment="This should only have a value if the concept is inactive."/>
@@ -28349,7 +28349,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="ValueSet.Expansion.Parameter" retrievable="false">
       <element name="name" elementType="FHIR.string" description="Name as assigned by the client or server" definition="Name of the input parameter to the $expand operation; may be a server-assigned name for additional default or other server-supplied parameters used to control the expansion process." comment="The names are assigned at the discretion of the server."/>
       <element name="value" description="Value of the named parameter" definition="The value of the parameter.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -28363,10 +28363,10 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="VariableType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="VariableType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="VerificationResult" identifier="http://hl7.org/fhir/StructureDefinition/VerificationResult" label="VerificationResult" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="VerificationResult" identifier="http://hl7.org/fhir/StructureDefinition/VerificationResult" label="VerificationResult" retrievable="true">
       <element name="target" description="A resource that was validated" definition="A resource that was validated.">
          <elementTypeSpecifier elementType="FHIR.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -28550,7 +28550,7 @@
          </typeSpecifier>
       </search>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.Attestation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.Attestation" retrievable="false">
       <element name="who" elementType="FHIR.Reference" description="The individual or organization attesting to information" definition="The individual or organization attesting to information."/>
       <element name="onBehalfOf" elementType="FHIR.Reference" description="When the who is asserting on behalf of another (organization or individual)" definition="When the who is asserting on behalf of another (organization or individual)."/>
       <element name="communicationMethod" elementType="FHIR.CodeableConcept" description="The method by which attested information was submitted/retrieved" definition="The method by which attested information was submitted/retrieved (manual; API; Push).">
@@ -28562,7 +28562,7 @@
       <element name="proxySignature" elementType="FHIR.Signature" description="Proxy signature" definition="Signed assertion by the proxy entity indicating that they have the right to submit attested information on behalf of the attestation source."/>
       <element name="sourceSignature" elementType="FHIR.Signature" description="Attester signature" definition="Signed assertion by the attestation source that they have attested to the information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.PrimarySource" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.PrimarySource" retrievable="false">
       <element name="who" elementType="FHIR.Reference" description="Reference to the primary source" definition="Reference to the primary source."/>
       <element name="type" description="Type of primary source (License Board; Primary Education; Continuing Education; Postal Service; Relationship owner; Registration Authority; legal source; issuing source; authoritative source)" definition="Type of primary source (License Board; Primary Education; Continuing Education; Postal Service; Relationship owner; Registration Authority; legal source; issuing source; authoritative source).">
          <elementTypeSpecifier elementType="FHIR.CodeableConcept" xsi:type="ListTypeSpecifier"/>
@@ -28584,18 +28584,18 @@
          <binding name="push-type-available" description="Type of alerts/updates the primary source can send." strength="Preferred"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.Validator" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="VerificationResult.Validator" retrievable="false">
       <element name="organization" elementType="FHIR.Reference" description="Reference to the organization validating information" definition="Reference to the organization validating information."/>
       <element name="identityCertificate" elementType="FHIR.string" description="A digital identity certificate associated with the validator" definition="A digital identity certificate associated with the validator."/>
       <element name="attestationSignature" elementType="FHIR.Signature" description="Validator signature" definition="Signed assertion by the validator that they have validated the information."/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="VisionBase" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="VisionBase" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="VisionEyes" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="VisionEyes" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.DomainResource" namespace="FHIR" name="VisionPrescription" identifier="http://hl7.org/fhir/StructureDefinition/VisionPrescription" label="VisionPrescription" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.DomainResource" namespace="FHIR" name="VisionPrescription" identifier="http://hl7.org/fhir/StructureDefinition/VisionPrescription" label="VisionPrescription" retrievable="true">
       <element name="identifier" description="Business Identifier for vision prescription" definition="A unique identifier assigned to this vision prescription.">
          <elementTypeSpecifier elementType="FHIR.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -28635,7 +28635,7 @@
       <search name="status" path="status" type="System.Code"/>
       <search name="datewritten" path="dateWritten" type="System.DateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="VisionPrescription.LensSpecification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="VisionPrescription.LensSpecification" retrievable="false">
       <element name="product" elementType="FHIR.CodeableConcept" description="Product to be supplied" definition="Identifies the type of vision correction product which is required for the patient.">
          <binding name="VisionProduct" description="A coded concept describing the vision products." strength="Example"/>
       </element>
@@ -28659,76 +28659,76 @@
          <elementTypeSpecifier elementType="FHIR.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.BackboneElement" namespace="FHIR" name="VisionPrescription.LensSpecification.Prism" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.BackboneElement" namespace="FHIR" name="VisionPrescription.LensSpecification.Prism" retrievable="false">
       <element name="amount" elementType="FHIR.decimal" description="Amount of adjustment" definition="Amount of prism to compensate for eye alignment in fractional units."/>
       <element name="base" elementType="FHIR.VisionBase" description="up | down | in | out" definition="The relative base, or reference lens edge, for the prism.">
          <binding name="VisionBase" description="A coded concept listing the base codes." strength="Required"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="VisionStatus" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="VisionStatus" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="XPathUsageType" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="XPathUsageType" retrievable="false">
       <element name="value" elementType="System.String"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="base64Binary" identifier="http://hl7.org/fhir/StructureDefinition/base64Binary" label="base64Binary" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="base64Binary" identifier="http://hl7.org/fhir/StructureDefinition/base64Binary" label="base64Binary" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for base64Binary" definition="Primitive value for base64Binary"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="boolean" identifier="http://hl7.org/fhir/StructureDefinition/boolean" label="boolean" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="boolean" identifier="http://hl7.org/fhir/StructureDefinition/boolean" label="boolean" retrievable="false">
       <element name="value" elementType="System.Boolean" description="Primitive value for boolean" definition="Primitive value for boolean"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.uri" namespace="FHIR" name="canonical" identifier="http://hl7.org/fhir/StructureDefinition/canonical" label="canonical" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.uri" namespace="FHIR" name="canonical" identifier="http://hl7.org/fhir/StructureDefinition/canonical" label="canonical" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for canonical" definition="Primitive value for canonical"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.string" namespace="FHIR" name="code" identifier="http://hl7.org/fhir/StructureDefinition/code" label="code" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.string" namespace="FHIR" name="code" identifier="http://hl7.org/fhir/StructureDefinition/code" label="code" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for code" definition="Primitive value for code"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="date" identifier="http://hl7.org/fhir/StructureDefinition/date" label="date" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="date" identifier="http://hl7.org/fhir/StructureDefinition/date" label="date" retrievable="false">
       <element name="value" elementType="System.Date" description="Primitive value for date" definition="Primitive value for date"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="dateTime" identifier="http://hl7.org/fhir/StructureDefinition/dateTime" label="dateTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="dateTime" identifier="http://hl7.org/fhir/StructureDefinition/dateTime" label="dateTime" retrievable="false">
       <element name="value" elementType="System.DateTime" description="Primitive value for dateTime" definition="Primitive value for dateTime"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="decimal" identifier="http://hl7.org/fhir/StructureDefinition/decimal" label="decimal" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="decimal" identifier="http://hl7.org/fhir/StructureDefinition/decimal" label="decimal" retrievable="false">
       <element name="value" elementType="System.Decimal" description="Primitive value for decimal" definition="Primitive value for decimal"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.string" namespace="FHIR" name="id" identifier="http://hl7.org/fhir/StructureDefinition/id" label="id" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.string" namespace="FHIR" name="id" identifier="http://hl7.org/fhir/StructureDefinition/id" label="id" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for id" definition="Primitive value for id"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="instant" identifier="http://hl7.org/fhir/StructureDefinition/instant" label="instant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="instant" identifier="http://hl7.org/fhir/StructureDefinition/instant" label="instant" retrievable="false">
       <element name="value" elementType="System.DateTime" description="Primitive value for instant" definition="Primitive value for instant"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="integer" identifier="http://hl7.org/fhir/StructureDefinition/integer" label="integer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="integer" identifier="http://hl7.org/fhir/StructureDefinition/integer" label="integer" retrievable="false">
       <element name="value" elementType="System.Integer" description="Primitive value for integer" definition="Primitive value for integer"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.string" namespace="FHIR" name="markdown" identifier="http://hl7.org/fhir/StructureDefinition/markdown" label="markdown" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.string" namespace="FHIR" name="markdown" identifier="http://hl7.org/fhir/StructureDefinition/markdown" label="markdown" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for markdown" definition="Primitive value for markdown"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.uri" namespace="FHIR" name="oid" identifier="http://hl7.org/fhir/StructureDefinition/oid" label="oid" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.uri" namespace="FHIR" name="oid" identifier="http://hl7.org/fhir/StructureDefinition/oid" label="oid" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for oid" definition="Primitive value for oid"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.integer" namespace="FHIR" name="positiveInt" identifier="http://hl7.org/fhir/StructureDefinition/positiveInt" label="positiveInt" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.integer" namespace="FHIR" name="positiveInt" identifier="http://hl7.org/fhir/StructureDefinition/positiveInt" label="positiveInt" retrievable="false">
       <element name="value" elementType="System.Integer" description="Primitive value for positiveInt" definition="Primitive value for positiveInt"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="string" identifier="http://hl7.org/fhir/StructureDefinition/string" label="string" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="string" identifier="http://hl7.org/fhir/StructureDefinition/string" label="string" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for string" definition="Primitive value for string"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="time" identifier="http://hl7.org/fhir/StructureDefinition/time" label="time" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="time" identifier="http://hl7.org/fhir/StructureDefinition/time" label="time" retrievable="false">
       <element name="value" elementType="System.Time" description="Primitive value for time" definition="Primitive value for time"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.integer" namespace="FHIR" name="unsignedInt" identifier="http://hl7.org/fhir/StructureDefinition/unsignedInt" label="unsignedInt" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.integer" namespace="FHIR" name="unsignedInt" identifier="http://hl7.org/fhir/StructureDefinition/unsignedInt" label="unsignedInt" retrievable="false">
       <element name="value" elementType="System.Integer" description="Primitive value for unsignedInt" definition="Primitive value for unsignedInt"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="uri" identifier="http://hl7.org/fhir/StructureDefinition/uri" label="uri" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="uri" identifier="http://hl7.org/fhir/StructureDefinition/uri" label="uri" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for uri" definition="Primitive value for uri"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.uri" namespace="FHIR" name="url" identifier="http://hl7.org/fhir/StructureDefinition/url" label="url" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.uri" namespace="FHIR" name="url" identifier="http://hl7.org/fhir/StructureDefinition/url" label="url" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for url" definition="Primitive value for url"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.uri" namespace="FHIR" name="uuid" identifier="http://hl7.org/fhir/StructureDefinition/uuid" label="uuid" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.uri" namespace="FHIR" name="uuid" identifier="http://hl7.org/fhir/StructureDefinition/uuid" label="uuid" retrievable="false">
       <element name="value" elementType="System.String" description="Primitive value for uuid" definition="Primitive value for uuid"/>
    </typeInfo>
-   <typeInfo baseType="FHIR.Element" namespace="FHIR" name="xhtml" identifier="http://hl7.org/fhir/StructureDefinition/xhtml" label="xhtml" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="FHIR.Element" namespace="FHIR" name="xhtml" identifier="http://hl7.org/fhir/StructureDefinition/xhtml" label="xhtml" retrievable="false">
       <element name="value" elementType="System.String" description="Actual xhtml" definition="Actual xhtml"/>
    </typeInfo>
    <conversionInfo functionName="FHIRHelpers.ToCode" fromType="FHIR.Coding" toType="System.Code"/>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.0.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.0.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="QICore" version="4.0.0" url="http://hl7.org/fhir/us/qicore" targetUrl="http://hl7.org/fhir" targetQualifier="qicore" patientClassName="Patient" patientBirthDatePropertyName="birthDate">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="QICore.AddressUse"/>
       <element name="type" elementType="QICore.AddressType"/>
       <element name="text" elementType="System.String" target="%value.value"/>
@@ -22,7 +22,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="actuality" elementType="QICore.AdverseEventActuality"/>
       <element name="category" target="FHIRHelpers.ToConcept(%value)">
@@ -61,18 +61,18 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recorder"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false">
       <element name="instance" elementType="QICore.Reference"/>
       <element name="causality" elementType="QICore.AdverseEvent.SuspectEntity.Causality"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false">
       <element name="assessment" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="productRelatedness" elementType="System.String" target="%value.value"/>
       <element name="author" elementType="QICore.Reference"/>
       <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="AdverseEventActuality" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code">
       <element name="resolutionAge" elementType="QICore.resolutionAge" target="FHIRHelpers.ToQuantity(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/allergyintolerance-resolutionAge'].value)"/>
       <element name="reasonRefuted" elementType="QICore.reasonRefuted" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/allergyintolerance-reasonRefuted'].value)"/>
       <element name="identifier">
@@ -115,7 +115,7 @@
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manifestation" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -133,7 +133,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" target="QICore.Reference:null;System.String:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -143,7 +143,7 @@
       <element name="time" elementType="System.DateTime" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="QICore.MimeType"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
@@ -153,13 +153,13 @@
       <element name="title" elementType="System.String" target="%value.value"/>
       <element name="creation" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyLengthUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -178,7 +178,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyTempUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyWeightUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -241,7 +241,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -254,7 +254,7 @@
       <element name="reference" elementType="QICore.Reference"/>
       <element name="detail" elementType="QICore.CarePlan.Activity.Detail"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="QICore.CarePlanActivityKind"/>
       <element name="instantiatesCanonical" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -300,7 +300,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -340,7 +340,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="member"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false">
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="member" elementType="QICore.Reference"/>
       <element name="onBehalfOf" elementType="QICore.Reference"/>
@@ -350,7 +350,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -411,7 +411,7 @@
       <contextRelationship context="Device" relatedKeyElement="udi"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="party"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false">
       <element name="date" elementType="System.Date" target="%value.value"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="location" target="QICore.Address:null;QICore.Reference:null">
@@ -421,14 +421,14 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="provider" elementType="QICore.Reference"/>
       <element name="responsible" elementType="System.Boolean" target="%value.value"/>
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="qualification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="diagnosis" target="System.Concept:FHIRHelpers.ToConcept(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -442,7 +442,7 @@
       <element name="onAdmission" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="packageCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="focal" elementType="System.Boolean" target="%value.value"/>
       <element name="identifier" elementType="QICore.Identifier"/>
@@ -453,7 +453,7 @@
       </element>
       <element name="claimResponse" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="careTeamSequence" target="%value.value">
          <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
@@ -509,7 +509,7 @@
          <elementTypeSpecifier elementType="QICore.Claim.Item.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -531,7 +531,7 @@
          <elementTypeSpecifier elementType="QICore.Claim.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -550,11 +550,11 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="party" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="type" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -570,12 +570,12 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false">
       <element name="claim" elementType="QICore.Reference"/>
       <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="reference" elementType="QICore.Identifier"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -599,7 +599,7 @@
       <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ClaimStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="reasonCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="reasonCode">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -662,7 +662,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="sender"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false">
       <element name="content" target="System.String:%value.value;QICore.Attachment:null;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -671,7 +671,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="notDone" elementType="System.Boolean" target="%parent.modifierExtension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone'].value"/>
       <element name="identifier">
@@ -728,7 +728,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -794,7 +794,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="requester"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false">
       <element name="content" target="System.String:%value.value;QICore.Attachment:null;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -805,7 +805,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code">
       <element name="dueTo" target="System.Concept:FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/condition-dueTo'].value);QICore.Reference:null">
          <elementTypeSpecifier elementType="QICore.dueTo" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -869,7 +869,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false">
       <element name="code" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -877,20 +877,20 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="assessment">
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="telecom">
          <elementTypeSpecifier elementType="QICore.ContactPoint" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="QICore.ContactPointSystem"/>
       <element name="value" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="QICore.ContactPointUse"/>
@@ -903,7 +903,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="QICore.ContributorType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="contact">
@@ -911,7 +911,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -951,12 +951,12 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="subscriber"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="payor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" elementType="System.String" target="%value.value"/>
       <element name="name" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Decimal:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -968,7 +968,7 @@
          <elementTypeSpecifier elementType="QICore.Coverage.CostToBeneficiary.Exception" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -977,7 +977,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CoverageStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="QICore.FHIRAllTypes"/>
       <element name="profile" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -1002,7 +1002,7 @@
          <elementTypeSpecifier elementType="QICore.DataRequirement.Sort" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="valueSet" elementType="System.String" target="%value.value"/>
@@ -1010,7 +1010,7 @@
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value)">
@@ -1023,13 +1023,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="direction" elementType="QICore.SortDirection"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1077,11 +1077,11 @@
       </element>
       <element name="parent" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="QICore.DeviceNameType"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="valueQuantity" target="FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
@@ -1090,11 +1090,11 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="version" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="System.String" target="%value.value"/>
       <element name="issuer" elementType="System.String" target="%value.value"/>
       <element name="jurisdiction" elementType="System.String" target="%value.value"/>
@@ -1102,13 +1102,13 @@
       <element name="carrierHRF" elementType="System.String" target="%value.value"/>
       <element name="entryType" elementType="QICore.UDIEntryType"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="component" elementType="QICore.Identifier"/>
       <element name="value" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested" label="DeviceNotRequested" target="DeviceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested" label="DeviceNotRequested" target="DeviceRequest" retrievable="true" primaryCodePath="code">
       <element name="doNotPerformReason" elementType="QICore.DoNotPerformReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason'].value)"/>
       <element name="doNotPerform" elementType="System.Boolean" target="%parent.modifierExtension[url='http://hl7.org/fhir/StructureDefinition/request-doNotPerform'].value"/>
       <element name="identifier">
@@ -1169,7 +1169,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1241,7 +1241,7 @@
       <contextRelationship context="Device" relatedKeyElement="requester"/>
       <contextRelationship context="Device" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Boolean:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1255,7 +1255,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1294,11 +1294,11 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceUseStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="Diagnosis_Present_On_Admission_Extension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission" label="Diagnosis_Present_On_Admission_Extension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="System.String" target="%value.value"/>
       <element name="link" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="locationPerformed" elementType="QICore.Reference" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/diagnosticReport-locationPerformed']"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -1349,7 +1349,7 @@
          <elementTypeSpecifier elementType="QICore.Attachment" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="locationPerformed" elementType="QICore.Reference" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/diagnosticReport-locationPerformed']"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -1400,7 +1400,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.Concept" namespace="QICore" name="DoNotPerformReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason" label="DoNotPerformReason" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="QICore.Narrative"/>
       <element name="contained">
          <elementTypeSpecifier elementType="QICore.Resource" xsi:type="ListTypeSpecifier"/>
@@ -1412,7 +1412,7 @@
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="additionalInstruction" target="FHIRHelpers.ToConcept(%value)">
@@ -1436,7 +1436,7 @@
       <element name="maxDosePerAdministration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="maxDosePerLifetime" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="dose" target="System.Quantity:FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1456,14 +1456,14 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="extension">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EnableWhenBehavior" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)"/>
       <element name="procedure" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure']">
          <elementTypeSpecifier elementType="QICore.EncounterProcedureExtension" xsi:type="ListTypeSpecifier"/>
@@ -1524,7 +1524,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="individual"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -1532,13 +1532,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="QICore.Reference"/>
       <element name="use" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="rank" elementType="System.Integer" target="%value.value"/>
       <element name="diagnosisPresentOnAdmission" elementType="QICore.Diagnosis_Present_On_Admission_Extension" target="FHIRHelpers.ToConcept(%parent.diagnosis.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission'].value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="QICore.Identifier"/>
       <element name="origin" elementType="QICore.Reference"/>
       <element name="admitSource" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -1555,7 +1555,7 @@
       <element name="destination" elementType="QICore.Reference"/>
       <element name="dischargeDisposition" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="QICore.Reference"/>
       <element name="status" elementType="QICore.EncounterLocationStatus"/>
       <element name="physicalType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -1565,7 +1565,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false">
       <element name="type" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1576,7 +1576,7 @@
       </element>
       <element name="individual" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="QICore.EncounterStatus"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -1585,7 +1585,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='type'].value)"/>
       <element name="rank" elementType="System.Integer" target="%parent.extension[url='rank'].value.value"/>
       <element name="procedure" elementType="QICore.Reference" target="%parent.extension[url='procedure']"/>
@@ -1593,14 +1593,14 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="expression" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1665,7 +1665,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRSubstanceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FamilyHistoryStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1724,7 +1724,7 @@
       <element name="condition" elementType="QICore.FamilyMemberHistory.Condition"/>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="contributedToDeath" elementType="System.Boolean" target="%value.value"/>
@@ -1746,7 +1746,7 @@
       <element name="condition-abatement" elementType="QICore.abatement" target="System.Date:%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value.value;System.Quantity:FHIRHelpers.ToQuantity(%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value);System.Boolean:%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value.value"/>
       <element name="condition-severity" elementType="QICore.severity" target="FHIRHelpers.ToConcept(%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-severity'].value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1768,7 +1768,7 @@
       <contextRelationship context="Device" relatedKeyElement="author"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="FlagStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category">
       <element name="reasonRejected" elementType="QICore.reasonRejected" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/goal-reasonRejected'].value)"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -1802,7 +1802,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="detail" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Ratio:FHIRHelpers.ToRatio(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1819,7 +1819,7 @@
       </element>
       <element name="due" elementType="System.Date" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="QICore.NameUse"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="family" elementType="System.String" target="%value.value"/>
@@ -1838,7 +1838,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="QICore.IdentifierUse"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="system" elementType="System.String" target="%value.value"/>
@@ -1851,7 +1851,7 @@
       <element name="assigner" elementType="QICore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1894,7 +1894,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value"/>
       <element name="number" elementType="System.Integer" target="%value.value"/>
       <element name="modality" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
@@ -1916,18 +1916,18 @@
          <elementTypeSpecifier elementType="QICore.ImagingStudy.Series.Instance" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value"/>
       <element name="sopClass" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="number" elementType="System.Integer" target="%value.value"/>
       <element name="title" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImagingStudyStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1984,17 +1984,17 @@
       <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="publicationDate" elementType="System.DateTime" target="%value.value"/>
       <element name="presentationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="System.String" target="%value.value"/>
       <element name="authority" elementType="QICore.Reference"/>
       <element name="targetDisease" target="FHIRHelpers.ToConcept(%value)">
@@ -2013,12 +2013,12 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="System.DateTime" target="%value.value"/>
       <element name="detail" elementType="QICore.Reference"/>
       <element name="reported" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2049,7 +2049,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImmunizationEvaluationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2105,7 +2105,7 @@
          <elementTypeSpecifier elementType="QICore.Immunization.ProtocolApplied" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2117,7 +2117,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false">
       <element name="vaccineCode" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2153,14 +2153,14 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImmunizationStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Boolean" namespace="QICore" name="IsElective" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-isElective" label="IsElective" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2191,7 +2191,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2199,13 +2199,13 @@
       <element name="openingTime" elementType="System.Time" target="%value.value"/>
       <element name="closingTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="System.Decimal" target="%value.value"/>
       <element name="latitude" elementType="System.Decimal" target="%value.value"/>
       <element name="altitude" elementType="System.Decimal" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2219,11 +2219,11 @@
       </element>
       <element name="batch" elementType="QICore.Medication.Batch"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="System.String" target="%value.value"/>
       <element name="expirationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false">
       <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
@@ -2233,7 +2233,7 @@
       <element name="isActive" elementType="System.Boolean" target="%value.value"/>
       <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2295,7 +2295,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false">
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="site" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="route" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -2308,11 +2308,11 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2365,7 +2365,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationAdministrationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2426,11 +2426,11 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="receiver"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false">
       <element name="wasSubstituted" elementType="System.Boolean" target="%value.value"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="reason" target="FHIRHelpers.ToConcept(%value)">
@@ -2440,7 +2440,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2489,7 +2489,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationDispenseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2553,7 +2553,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2626,7 +2626,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="initialFill" elementType="QICore.MedicationRequest.DispenseRequest.InitialFill"/>
       <element name="dispenseInterval" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="validityPeriod">
@@ -2639,11 +2639,11 @@
       <element name="expectedSupplyDuration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="performer" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -2655,7 +2655,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2709,7 +2709,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="System.String" target="%value.value"/>
       <element name="lastUpdated" elementType="System.DateTime" target="%value.value"/>
       <element name="source" elementType="System.String" target="%value.value"/>
@@ -2725,7 +2725,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="QICore.NarrativeStatus"/>
       <element name="div" elementType="System.String" target="%value.value"/>
    </typeInfo>
@@ -2733,7 +2733,7 @@
    <typeInfo baseType="System.Boolean" namespace="QICore" name="NotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone" label="NotDone" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="NotDoneReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason" label="NotDoneReason" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="NotDoneRecorded" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded" label="NotDoneRecorded" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code">
       <element name="bodyPosition" elementType="QICore.bodyPosition" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/observation-bodyPosition'].value)"/>
       <element name="delta" elementType="QICore.delta" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/observation-delta'].value)"/>
       <element name="identifier">
@@ -2819,7 +2819,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.SampledData:null;System.Time:%value.value;System.DateTime:%value.value;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -2854,7 +2854,7 @@
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.DiastolicBP" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.FlowRate" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.SystolicBP" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="high" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -2868,7 +2868,7 @@
       </element>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="notDoneReason" elementType="QICore.NotDoneReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason'].value)"/>
       <element name="notDone" elementType="System.Boolean" target="%parent.modifierExtension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDone'].value"/>
       <element name="identifier">
@@ -2949,7 +2949,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ObservationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2977,7 +2977,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="name" elementType="QICore.HumanName"/>
       <element name="telecom">
@@ -2985,7 +2985,7 @@
       </element>
       <element name="address" elementType="QICore.Address"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="QICore.ParameterUse"/>
       <element name="min" elementType="System.Integer" target="%value.value"/>
@@ -2995,7 +2995,7 @@
       <element name="profile" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true">
       <element name="race" elementType="QICore.USCoreRaceExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']"/>
       <element name="ethnicity" elementType="QICore.USCoreEthnicityExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']"/>
       <element name="birthsex" elementType="QICore.USCoreBirthSexExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'].value.value"/>
@@ -3053,15 +3053,15 @@
       <contextRelationship context="Patient" relatedKeyElement="other"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="other"/>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Address" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="Address" xsi:type="NamedTypeSpecifier"/>
       <element name="address-preferred" elementType="QICore.preferred" target="%parent.address.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="preferred" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false">
       <element name="relationship" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3078,15 +3078,15 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false">
       <element name="other" elementType="QICore.Reference"/>
       <element name="type" elementType="QICore.LinkType"/>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Telecom" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Telecom" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
       <element name="telecom-preferred" elementType="QICore.preferred" target="%parent.telecom.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3111,7 +3111,7 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3123,7 +3123,7 @@
       </element>
       <element name="issuer" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3158,7 +3158,7 @@
       </element>
       <contextRelationship context="Practitioner" relatedKeyElement="practitioner"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3166,7 +3166,7 @@
       <element name="availableStartTime" elementType="System.Time" target="%value.value"/>
       <element name="availableEndTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="during">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -3174,7 +3174,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3254,16 +3254,16 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manipulated" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
       <element name="onBehalfOf" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ProcedureNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone" label="ProcedureNotDone" target="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ProcedureNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone" label="ProcedureNotDone" target="Procedure" retrievable="true" primaryCodePath="code">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -3344,7 +3344,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="ProcedureStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="PublicationStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name">
       <element name="url" elementType="System.String" target="%value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -3388,7 +3388,7 @@
          <elementTypeSpecifier elementType="QICore.Questionnaire.Item" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value"/>
       <element name="definition" elementType="System.String" target="%value.value"/>
       <element name="code" target="FHIRHelpers.ToCode(%value)">
@@ -3418,7 +3418,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false">
       <element name="value" target="System.Integer:%value.value;System.Date:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
@@ -3431,7 +3431,7 @@
       </element>
       <element name="initialSelected" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false">
       <element name="question" elementType="System.String" target="%value.value"/>
       <element name="operator" elementType="QICore.QuestionnaireItemOperator"/>
       <element name="answer" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
@@ -3449,7 +3449,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false">
       <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;QICore.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -3469,7 +3469,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemOperator" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="basedOn">
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
@@ -3496,7 +3496,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="source"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value"/>
       <element name="definition" elementType="System.String" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
@@ -3509,7 +3509,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false">
       <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;QICore.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -3533,13 +3533,13 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="System.String" target="%value.value"/>
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="display" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="QICore.RelatedArtifactType"/>
       <element name="label" elementType="System.String" target="%value.value"/>
       <element name="display" elementType="System.String" target="%value.value"/>
@@ -3549,7 +3549,7 @@
       <element name="resource" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3582,20 +3582,20 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="preferred" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="meta" elementType="QICore.Meta"/>
       <element name="implicitRules" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ResourceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="period" elementType="System.Decimal" target="%value.value"/>
       <element name="factor" elementType="System.Decimal" target="%value.value"/>
@@ -3604,7 +3604,7 @@
       <element name="dimensions" elementType="System.Integer" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3703,7 +3703,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)"/>
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
@@ -3813,7 +3813,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" target="FHIRHelpers.ToCode(%value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3825,7 +3825,7 @@
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3855,7 +3855,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Device" relatedKeyElement="subject"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false">
       <element name="collector" elementType="QICore.Reference"/>
       <element name="collected" target="System.DateTime:%value.value;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -3876,7 +3876,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3892,7 +3892,7 @@
       </element>
       <element name="container-sequenceNumber" elementType="QICore.sequenceNumber" target="%parent.container.extension[url='http://hl7.org/fhir/StructureDefinition/specimen-sequenceNumber'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="procedure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="additive">
@@ -3909,7 +3909,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SpecimenStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="Status" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3926,16 +3926,16 @@
          <elementTypeSpecifier elementType="QICore.Substance.Ingredient" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false">
       <element name="quantity" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
       <element name="substance" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="expiry" elementType="System.DateTime" target="%value.value"/>
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3990,7 +3990,7 @@
          <elementTypeSpecifier elementType="QICore.Task.Output" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4051,7 +4051,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4112,7 +4112,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false">
       <element name="repetitions" elementType="System.Integer" target="%value.value"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -4126,14 +4126,14 @@
    <typeInfo baseType="System.String" namespace="QICore" name="TaskIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" target="%value.value">
          <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="repeat" elementType="QICore.Timing.Repeat"/>
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false">
       <element name="bounds" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -4166,7 +4166,7 @@
       </element>
       <element name="offset" elementType="System.Integer" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="QICore.TriggerType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="timing" target="QICore.Timing:null;QICore.Reference:null;System.Date:%value.value;System.DateTime:%value.value">
@@ -4185,7 +4185,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="USCoreBirthSexExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex" label="US Core Birth Sex Extension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false">
       <element name="ombCategory" elementType="System.Code" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)"/>
       <element name="detailed" target="FHIRHelpers.ToCode(%parent.extension[url='detailed'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
@@ -4193,7 +4193,7 @@
       <element name="text" elementType="System.String" target="%parent.extension[url='text'].value.value"/>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4239,7 +4239,7 @@
       </element>
       <element name="parent" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4315,7 +4315,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4373,7 +4373,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4431,7 +4431,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4493,7 +4493,7 @@
       <element name="FlowRate" elementType="QICore.Observation.Component"/>
       <element name="Concentration" elementType="QICore.Observation.Component"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false">
       <element name="ombCategory" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4503,7 +4503,7 @@
       <element name="text" elementType="System.String" target="%parent.extension[url='text'].value.value"/>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4563,7 +4563,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4577,7 +4577,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="Use" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -4592,7 +4592,7 @@
    <typeInfo baseType="System.Concept" namespace="QICore" name="delta" identifier="http://hl7.org/fhir/StructureDefinition/observation-delta" label="delta" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="disability" identifier="http://hl7.org/fhir/StructureDefinition/patient-disability" label="disability" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Boolean" namespace="QICore" name="doNotPerform" identifier="http://hl7.org/fhir/StructureDefinition/request-doNotPerform" label="Do Not Perfom" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -4601,7 +4601,7 @@
    <typeInfo baseType="System.Quantity" namespace="QICore" name="duration" identifier="http://hl7.org/fhir/StructureDefinition/allergyintolerance-duration" label="duration" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="incisionDateTime" identifier="http://hl7.org/fhir/StructureDefinition/procedure-incisionDateTime" label="incisionDateTime" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Reference" namespace="QICore" name="locationPerformed" identifier="http://hl7.org/fhir/StructureDefinition/diagnosticReport-locationPerformed" label="locationPerformed" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='code'].value)"/>
       <element name="period" target="%parent.extension[url='period']">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -4610,7 +4610,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4669,7 +4669,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4728,7 +4728,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4787,7 +4787,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4846,7 +4846,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4907,7 +4907,7 @@
       <element name="SystolicBP" elementType="QICore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8480-6']"/>
       <element name="DiastolicBP" elementType="QICore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8462-4']"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4966,7 +4966,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5025,7 +5025,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5084,7 +5084,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5143,7 +5143,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5203,7 +5203,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.1.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.1.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="QICore" version="4.1.0" url="http://hl7.org/fhir/us/qicore" targetUrl="http://hl7.org/fhir" targetQualifier="qicore" patientClassName="Patient" patientBirthDatePropertyName="birthDate">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="QICore.AddressUse"/>
       <element name="type" elementType="QICore.AddressType"/>
       <element name="text" elementType="System.String" target="%value.value"/>
@@ -22,7 +22,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="actuality" elementType="QICore.AdverseEventActuality"/>
       <element name="category" target="FHIRHelpers.ToConcept(%value)">
@@ -61,18 +61,18 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recorder"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false">
       <element name="instance" elementType="QICore.Reference"/>
       <element name="causality" elementType="QICore.AdverseEvent.SuspectEntity.Causality"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false">
       <element name="assessment" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="productRelatedness" elementType="System.String" target="%value.value"/>
       <element name="author" elementType="QICore.Reference"/>
       <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="AdverseEventActuality" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code">
       <element name="resolutionAge" elementType="QICore.resolutionAge" target="FHIRHelpers.ToQuantity(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/allergyintolerance-resolutionAge'].value)"/>
       <element name="reasonRefuted" elementType="QICore.reasonRefuted" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/allergyintolerance-reasonRefuted'].value)"/>
       <element name="identifier">
@@ -115,7 +115,7 @@
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manifestation" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -133,7 +133,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" target="QICore.Reference:null;System.String:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -143,7 +143,7 @@
       <element name="time" elementType="System.DateTime" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="QICore.MimeType"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
@@ -153,13 +153,13 @@
       <element name="title" elementType="System.String" target="%value.value"/>
       <element name="creation" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyLengthUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -178,7 +178,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyTempUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyWeightUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -241,7 +241,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -254,7 +254,7 @@
       <element name="reference" elementType="QICore.Reference"/>
       <element name="detail" elementType="QICore.CarePlan.Activity.Detail"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="QICore.CarePlanActivityKind"/>
       <element name="instantiatesCanonical" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -300,7 +300,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -340,7 +340,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="member"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false">
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="member" elementType="QICore.Reference"/>
       <element name="onBehalfOf" elementType="QICore.Reference"/>
@@ -350,7 +350,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -411,7 +411,7 @@
       <contextRelationship context="Device" relatedKeyElement="udi"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="party"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false">
       <element name="date" elementType="System.Date" target="%value.value"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="location" target="QICore.Address:null;QICore.Reference:null">
@@ -421,14 +421,14 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="provider" elementType="QICore.Reference"/>
       <element name="responsible" elementType="System.Boolean" target="%value.value"/>
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="qualification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="diagnosis" target="System.Concept:FHIRHelpers.ToConcept(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -442,7 +442,7 @@
       <element name="onAdmission" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="packageCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="focal" elementType="System.Boolean" target="%value.value"/>
       <element name="identifier" elementType="QICore.Identifier"/>
@@ -453,7 +453,7 @@
       </element>
       <element name="claimResponse" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="careTeamSequence" target="%value.value">
          <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
@@ -509,7 +509,7 @@
          <elementTypeSpecifier elementType="QICore.Claim.Item.Detail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -531,7 +531,7 @@
          <elementTypeSpecifier elementType="QICore.Claim.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -550,11 +550,11 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="party" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="type" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -570,12 +570,12 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false">
       <element name="claim" elementType="QICore.Reference"/>
       <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="reference" elementType="QICore.Identifier"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -599,7 +599,7 @@
       <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ClaimStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="reasonCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="reasonCode">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -662,7 +662,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="sender"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false">
       <element name="content" target="System.String:%value.value;QICore.Attachment:null;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -671,7 +671,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -725,7 +725,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -791,7 +791,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="requester"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false">
       <element name="content" target="System.String:%value.value;QICore.Attachment:null;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -802,7 +802,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code">
       <element name="dueTo" target="System.Concept:FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/condition-dueTo'].value);QICore.Reference:null">
          <elementTypeSpecifier elementType="QICore.dueTo" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -866,7 +866,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false">
       <element name="code" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -874,20 +874,20 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="assessment">
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="telecom">
          <elementTypeSpecifier elementType="QICore.ContactPoint" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="QICore.ContactPointSystem"/>
       <element name="value" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="QICore.ContactPointUse"/>
@@ -900,7 +900,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="QICore.ContributorType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="contact">
@@ -908,7 +908,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -948,12 +948,12 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="subscriber"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="payor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" elementType="System.String" target="%value.value"/>
       <element name="name" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Decimal:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -965,7 +965,7 @@
          <elementTypeSpecifier elementType="QICore.Coverage.CostToBeneficiary.Exception" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -976,7 +976,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="CoverageStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.DataAbsentReason" namespace="QICore" name="Data Absent Reason" identifier="http://hl7.org/fhir/StructureDefinition/data-absent-reason" label="Why value is missing" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="DataAbsentReason" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="QICore.FHIRAllTypes"/>
       <element name="profile" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -1001,7 +1001,7 @@
          <elementTypeSpecifier elementType="QICore.DataRequirement.Sort" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="valueSet" elementType="System.String" target="%value.value"/>
@@ -1009,7 +1009,7 @@
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value)">
@@ -1022,13 +1022,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="direction" elementType="QICore.SortDirection"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1076,11 +1076,11 @@
       </element>
       <element name="parent" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="QICore.DeviceNameType"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="valueQuantity" target="FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
@@ -1089,11 +1089,11 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="version" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="System.String" target="%value.value"/>
       <element name="issuer" elementType="System.String" target="%value.value"/>
       <element name="jurisdiction" elementType="System.String" target="%value.value"/>
@@ -1101,14 +1101,14 @@
       <element name="carrierHRF" elementType="System.String" target="%value.value"/>
       <element name="entryType" elementType="QICore.UDIEntryType"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="component" elementType="QICore.Identifier"/>
       <element name="value" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo namespace="QICore" name="DeviceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested" label="DeviceNotRequested" target="DeviceRequest" retrievable="true" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1180,7 +1180,7 @@
       <contextRelationship context="Device" relatedKeyElement="requester"/>
       <contextRelationship context="Device" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Boolean:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1194,7 +1194,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1233,11 +1233,11 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceUseStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="DiagnosisPresentOnAdmissionExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission" label="DiagnosisPresentOnAdmissionExtension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="System.String" target="%value.value"/>
       <element name="link" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="valueReference" elementType="QICore.Reference" target="%parent.extension[url='null']"/>
       <element name="locationPerformed" elementType="QICore.locationPerformed" target="%parent.extension[url='null']"/>
       <element name="identifier">
@@ -1289,7 +1289,7 @@
          <elementTypeSpecifier elementType="QICore.Attachment" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="valueReference" elementType="QICore.Reference" target="%parent.extension[url='null']"/>
       <element name="locationPerformed" elementType="QICore.locationPerformed" target="%parent.extension[url='null']"/>
       <element name="identifier">
@@ -1341,7 +1341,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.Concept" namespace="QICore" name="DoNotPerformReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason" label="DoNotPerformReason" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="QICore.Narrative"/>
       <element name="contained">
          <elementTypeSpecifier elementType="QICore.Resource" xsi:type="ListTypeSpecifier"/>
@@ -1353,7 +1353,7 @@
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="additionalInstruction" target="FHIRHelpers.ToConcept(%value)">
@@ -1377,7 +1377,7 @@
       <element name="maxDosePerAdministration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="maxDosePerLifetime" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="dose" target="System.Quantity:FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1397,14 +1397,14 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="extension">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EnableWhenBehavior" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)"/>
       <element name="procedure" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure']">
          <elementTypeSpecifier elementType="QICore.EncounterProcedureExtension" xsi:type="ListTypeSpecifier"/>
@@ -1465,7 +1465,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="individual"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -1473,13 +1473,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="QICore.Reference"/>
       <element name="use" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="rank" elementType="System.Integer" target="%value.value"/>
       <element name="diagnosisPresentOnAdmission" elementType="QICore.DiagnosisPresentOnAdmissionExtension" target="FHIRHelpers.ToConcept(%parent.diagnosis.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission'].value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="QICore.Identifier"/>
       <element name="origin" elementType="QICore.Reference"/>
       <element name="admitSource" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -1496,7 +1496,7 @@
       <element name="destination" elementType="QICore.Reference"/>
       <element name="dischargeDisposition" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="QICore.Reference"/>
       <element name="status" elementType="QICore.EncounterLocationStatus"/>
       <element name="physicalType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -1506,7 +1506,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false">
       <element name="type" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1517,7 +1517,7 @@
       </element>
       <element name="individual" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="QICore.EncounterStatus"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -1526,7 +1526,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='type'].value)"/>
       <element name="rank" elementType="System.Integer" target="%parent.extension[url='rank'].value.value"/>
       <element name="procedure" elementType="QICore.Reference" target="%parent.extension[url='procedure']"/>
@@ -1534,14 +1534,14 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="expression" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1606,7 +1606,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRSubstanceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FamilyHistoryStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1665,7 +1665,7 @@
       <element name="condition" elementType="QICore.FamilyMemberHistory.Condition"/>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="contributedToDeath" elementType="System.Boolean" target="%value.value"/>
@@ -1687,7 +1687,7 @@
       <element name="condition-abatement" elementType="QICore.abatement" target="System.Date:%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value.value;System.Quantity:FHIRHelpers.ToQuantity(%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value);System.Boolean:%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement'].value.value"/>
       <element name="condition-severity" elementType="QICore.severity" target="FHIRHelpers.ToConcept(%parent.condition.extension[url='http://hl7.org/fhir/StructureDefinition/familymemberhistory-severity'].value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1709,7 +1709,7 @@
       <contextRelationship context="Device" relatedKeyElement="author"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="FlagStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category">
       <element name="reasonRejected" elementType="QICore.reasonRejected" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/goal-reasonRejected'].value)"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -1743,7 +1743,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="detail" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Ratio:FHIRHelpers.ToRatio(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1760,7 +1760,7 @@
       </element>
       <element name="due" elementType="System.Date" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="QICore.NameUse"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="family" elementType="System.String" target="%value.value"/>
@@ -1779,7 +1779,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="QICore.IdentifierUse"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="system" elementType="System.String" target="%value.value"/>
@@ -1792,7 +1792,7 @@
       <element name="assigner" elementType="QICore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1835,7 +1835,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value"/>
       <element name="number" elementType="System.Integer" target="%value.value"/>
       <element name="modality" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
@@ -1857,18 +1857,18 @@
          <elementTypeSpecifier elementType="QICore.ImagingStudy.Series.Instance" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value"/>
       <element name="sopClass" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="number" elementType="System.Integer" target="%value.value"/>
       <element name="title" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImagingStudyStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1920,17 +1920,17 @@
       <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="publicationDate" elementType="System.DateTime" target="%value.value"/>
       <element name="presentationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="System.String" target="%value.value"/>
       <element name="authority" elementType="QICore.Reference"/>
       <element name="targetDisease" target="FHIRHelpers.ToConcept(%value)">
@@ -1949,12 +1949,12 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="System.DateTime" target="%value.value"/>
       <element name="detail" elementType="QICore.Reference"/>
       <element name="reported" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1985,7 +1985,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImmunizationEvaluationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2041,7 +2041,7 @@
          <elementTypeSpecifier elementType="QICore.Immunization.ProtocolApplied" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2053,7 +2053,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false">
       <element name="vaccineCode" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2089,13 +2089,13 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.Boolean" namespace="QICore" name="IsElective" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-isElective" label="IsElective" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2126,7 +2126,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2134,14 +2134,14 @@
       <element name="openingTime" elementType="System.Time" target="%value.value"/>
       <element name="closingTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="System.Decimal" target="%value.value"/>
       <element name="latitude" elementType="System.Decimal" target="%value.value"/>
       <element name="altitude" elementType="System.Decimal" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="LocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2155,11 +2155,11 @@
       </element>
       <element name="batch" elementType="QICore.Medication.Batch"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="System.String" target="%value.value"/>
       <element name="expirationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false">
       <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
@@ -2169,7 +2169,7 @@
       <element name="isActive" elementType="System.Boolean" target="%value.value"/>
       <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2231,7 +2231,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false">
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="site" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="route" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -2244,11 +2244,11 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2301,7 +2301,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationAdministrationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2362,11 +2362,11 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="receiver"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false">
       <element name="wasSubstituted" elementType="System.Boolean" target="%value.value"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="reason" target="FHIRHelpers.ToConcept(%value)">
@@ -2376,7 +2376,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2425,7 +2425,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationDispenseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2489,7 +2489,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2562,7 +2562,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="dispenseInterval" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="validityPeriod">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -2574,11 +2574,11 @@
       <element name="expectedSupplyDuration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="performer" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -2588,7 +2588,7 @@
       <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2642,7 +2642,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="System.String" target="%value.value"/>
       <element name="lastUpdated" elementType="System.DateTime" target="%value.value"/>
       <element name="source" elementType="System.String" target="%value.value"/>
@@ -2658,7 +2658,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="QICore.NarrativeStatus"/>
       <element name="div" elementType="System.String" target="%value.value"/>
    </typeInfo>
@@ -2666,7 +2666,7 @@
    <typeInfo baseType="System.Concept" namespace="QICore" name="NotDoneReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason" label="NotDoneReason" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="NotDoneRecorded" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded" label="NotDoneRecorded" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="NotDoneValueSet" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneValueSet" label="Not Done Value Set" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code">
       <element name="bodyPosition" elementType="QICore.bodyPosition" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/observation-bodyPosition'].value)"/>
       <element name="delta" elementType="QICore.delta" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/observation-delta'].value)"/>
       <element name="identifier">
@@ -2752,7 +2752,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.SampledData:null;System.Time:%value.value;System.DateTime:%value.value;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -2787,7 +2787,7 @@
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.DiastolicBP" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.FlowRate" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.SystolicBP" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="high" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -2801,7 +2801,7 @@
       </element>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="notDoneReason" elementType="QICore.NotDoneReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason'].value)"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -2881,7 +2881,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ObservationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2911,7 +2911,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="name" elementType="QICore.HumanName"/>
       <element name="telecom">
@@ -2919,7 +2919,7 @@
       </element>
       <element name="address" elementType="QICore.Address"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="QICore.ParameterUse"/>
       <element name="min" elementType="System.Integer" target="%value.value"/>
@@ -2929,7 +2929,7 @@
       <element name="profile" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true">
       <element name="race" elementType="QICore.USCoreRaceExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']"/>
       <element name="ethnicity" elementType="QICore.USCoreEthnicityExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']"/>
       <element name="birthsex" elementType="QICore.USCoreBirthSexExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'].value.value"/>
@@ -2987,15 +2987,15 @@
       <contextRelationship context="Patient" relatedKeyElement="other"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="other"/>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Address" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="Address" xsi:type="NamedTypeSpecifier"/>
       <element name="address-preferred" elementType="QICore.preferred" target="%parent.address.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="preferred" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false">
       <element name="relationship" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3012,15 +3012,15 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false">
       <element name="other" elementType="QICore.Reference"/>
       <element name="type" elementType="QICore.LinkType"/>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Telecom" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Telecom" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
       <element name="telecom-preferred" elementType="QICore.preferred" target="%parent.telecom.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3049,7 +3049,7 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3061,7 +3061,7 @@
       </element>
       <element name="issuer" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3100,7 +3100,7 @@
       </element>
       <contextRelationship context="Practitioner" relatedKeyElement="practitioner"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3108,7 +3108,7 @@
       <element name="availableStartTime" elementType="System.Time" target="%value.value"/>
       <element name="availableEndTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="during">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -3116,7 +3116,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3197,11 +3197,11 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manipulated" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="QICore.Reference"/>
       <element name="onBehalfOf" elementType="QICore.Reference"/>
@@ -3209,7 +3209,7 @@
    <typeInfo namespace="QICore" name="ProcedureNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone" label="ProcedureNotDone" target="Procedure" retrievable="true" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="PublicationStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name">
       <element name="url" elementType="System.String" target="%value.value"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -3253,7 +3253,7 @@
          <elementTypeSpecifier elementType="QICore.Questionnaire.Item" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value"/>
       <element name="definition" elementType="System.String" target="%value.value"/>
       <element name="code" target="FHIRHelpers.ToCode(%value)">
@@ -3283,7 +3283,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false">
       <element name="value" target="System.Integer:%value.value;System.Date:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
@@ -3296,7 +3296,7 @@
       </element>
       <element name="initialSelected" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false">
       <element name="question" elementType="System.String" target="%value.value"/>
       <element name="operator" elementType="QICore.QuestionnaireItemOperator"/>
       <element name="answer" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
@@ -3314,7 +3314,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false">
       <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;QICore.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -3334,7 +3334,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemOperator" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="basedOn">
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
@@ -3361,7 +3361,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="source"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value"/>
       <element name="definition" elementType="System.String" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
@@ -3374,7 +3374,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false">
       <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;QICore.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -3398,13 +3398,13 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="System.String" target="%value.value"/>
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="display" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="QICore.RelatedArtifactType"/>
       <element name="label" elementType="System.String" target="%value.value"/>
       <element name="display" elementType="System.String" target="%value.value"/>
@@ -3414,7 +3414,7 @@
       <element name="resource" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3447,20 +3447,20 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="preferred" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="meta" elementType="QICore.Meta"/>
       <element name="implicitRules" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ResourceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="period" elementType="System.Decimal" target="%value.value"/>
       <element name="factor" elementType="System.Decimal" target="%value.value"/>
@@ -3469,7 +3469,7 @@
       <element name="dimensions" elementType="System.Integer" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3568,7 +3568,7 @@
          <elementTypeSpecifier elementType="QICore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)"/>
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
@@ -3678,7 +3678,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" target="FHIRHelpers.ToCode(%value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3690,7 +3690,7 @@
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3720,7 +3720,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Device" relatedKeyElement="subject"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false">
       <element name="collector" elementType="QICore.Reference"/>
       <element name="collected" target="System.DateTime:%value.value;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -3741,7 +3741,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3757,7 +3757,7 @@
       </element>
       <element name="container-sequenceNumber" elementType="QICore.sequenceNumber" target="%parent.container.extension[url='http://hl7.org/fhir/StructureDefinition/specimen-sequenceNumber'].value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="procedure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="additive">
@@ -3774,7 +3774,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SpecimenStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="Status" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3791,16 +3791,16 @@
          <elementTypeSpecifier elementType="QICore.Substance.Ingredient" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false">
       <element name="quantity" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
       <element name="substance" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false">
       <element name="identifier" elementType="QICore.Identifier"/>
       <element name="expiry" elementType="System.DateTime" target="%value.value"/>
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -3855,7 +3855,7 @@
          <elementTypeSpecifier elementType="QICore.Task.Output" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -3916,7 +3916,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;QICore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.Annotation:null;QICore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);QICore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);QICore.HumanName:null;QICore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);QICore.Reference:null;QICore.SampledData:null;QICore.Signature:null;QICore.Timing:null;QICore.ContactDetail:null;QICore.Contributor:null;QICore.DataRequirement:null;QICore.Expression:null;QICore.ParameterDefinition:null;QICore.RelatedArtifact:null;QICore.TriggerDefinition:null;QICore.UsageContext:null;QICore.Dosage:null;QICore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -3977,7 +3977,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false">
       <element name="repetitions" elementType="System.Integer" target="%value.value"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -3989,7 +3989,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskIntent" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="TaskNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-tasknotdone" label="TaskNotDone" target="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="TaskNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-tasknotdone" label="TaskNotDone" target="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4047,14 +4047,14 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" target="%value.value">
          <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="repeat" elementType="QICore.Timing.Repeat"/>
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false">
       <element name="bounds" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -4087,7 +4087,7 @@
       </element>
       <element name="offset" elementType="System.Integer" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="QICore.TriggerType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="timing" target="QICore.Timing:null;QICore.Reference:null;System.Date:%value.value;System.DateTime:%value.value">
@@ -4106,7 +4106,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="USCoreBirthSexExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex" label="US Core Birth Sex Extension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false">
       <element name="ombCategory" elementType="System.Code" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)"/>
       <element name="detailed" target="FHIRHelpers.ToCode(%parent.extension[url='detailed'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
@@ -4114,7 +4114,7 @@
       <element name="text" elementType="System.String" target="%parent.extension[url='text'].value.value"/>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4160,7 +4160,7 @@
       </element>
       <element name="parent" elementType="QICore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4236,7 +4236,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4294,7 +4294,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4352,7 +4352,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4414,7 +4414,7 @@
       <element name="FlowRate" elementType="QICore.Observation.Component"/>
       <element name="Concentration" elementType="QICore.Observation.Component"/>
    </typeInfo>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false">
       <element name="ombCategory" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4424,7 +4424,7 @@
       <element name="text" elementType="System.String" target="%parent.extension[url='text'].value.value"/>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4484,7 +4484,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;QICore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4498,7 +4498,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="Use" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -4512,7 +4512,7 @@
    <typeInfo baseType="System.Boolean" namespace="QICore" name="cadavericDonor" identifier="http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor" label="cadavericDonor" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="delta" identifier="http://hl7.org/fhir/StructureDefinition/observation-delta" label="delta" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="disability" identifier="http://hl7.org/fhir/StructureDefinition/patient-disability" label="disability" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -4521,7 +4521,7 @@
    <typeInfo baseType="System.Quantity" namespace="QICore" name="duration" identifier="http://hl7.org/fhir/StructureDefinition/allergyintolerance-duration" label="duration" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="incisionDateTime" identifier="http://hl7.org/fhir/StructureDefinition/procedure-incisionDateTime" label="incisionDateTime" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Reference" namespace="QICore" name="locationPerformed" identifier="http://hl7.org/fhir/StructureDefinition/diagnosticReport-locationPerformed" label="locationPerformed" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='code'].value)"/>
       <element name="period" target="%parent.extension[url='period']">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -4530,7 +4530,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4589,7 +4589,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4648,7 +4648,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4707,7 +4707,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4766,7 +4766,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4827,7 +4827,7 @@
       <element name="SystolicBP" elementType="QICore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8480-6']"/>
       <element name="DiastolicBP" elementType="QICore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8462-4']"/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4886,7 +4886,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -4945,7 +4945,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5004,7 +5004,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5063,7 +5063,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -5123,7 +5123,7 @@
          <elementTypeSpecifier elementType="QICore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.1.1.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/qicore-modelinfo-4.1.1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="QICore" version="4.1.1" url="http://hl7.org/fhir/us/qicore" targetUrl="http://hl7.org/fhir" targetQualifier="qicore" patientClassName="Patient" patientBirthDatePropertyName="birthDate">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="QICore.AddressUse" target="%value.value" description="home | work | temp | old | billing - purpose of this address" definition="The purpose of this address." comment="Applications can assume that an address is current unless it explicitly says that it is temporary or old.">
          <binding name="AddressUse" description="The use of an address." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -62,7 +62,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AdverseEvent" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-adverseevent" label="AdverseEvent" retrievable="true" primaryCodePath="type">
       <element name="identifier" elementType="QICore.Identifier" description="Business identifier for the event" definition="Business identifiers assigned to this adverse event by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -180,7 +180,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recorder"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity" retrievable="false">
       <element name="instance" elementType="QICore.Reference" description="Refers to the specific entity that caused the adverse event" definition="Identifies the actual instance of what caused the adverse event.  May be a substance, medication, medication administration, medication statement or a device." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -192,7 +192,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AdverseEvent.SuspectEntity.Causality" retrievable="false">
       <element name="assessment" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Assessment of if the entity caused the event" definition="Assessment of if the entity caused the event.">
          <binding name="AdverseEventCausalityAssessment" description="Codes for the assessment of whether the entity caused the event." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -217,7 +217,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="AdverseEventActuality" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code">
       <element name="resolutionAge" elementType="QICore.resolutionAge" target="FHIRHelpers.ToQuantity(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/allergyintolerance-resolutionAge'].value)" description="Age that the allergy or intolerance resolved" definition="The estimated patient age at which the allergy or intolerance resolved. Should be specified only if the status is resolved." comment="Removed Date since it is hard to imagine knowing the date an allergy abated. The assertion date is already captured." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -340,7 +340,7 @@
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Specific substance or pharmaceutical product considered to be responsible for event" definition="Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance." comment="Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, &quot;penicillins&quot;), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, &quot;amoxycillin&quot;). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.">
          <binding name="SubstanceCode" description="Codes defining the type of the substance (including pharmaceutical products)." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -395,7 +395,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" target="FHIRHelpers.ToValue(%value)" description="Individual responsible for the annotation" definition="The individual responsible for making the annotation." comment="Organization is used when there's no need for specific attribution as to who made the comment.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -416,7 +416,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="QICore.MimeType" target="%value.value" description="Mime type of the content, with charset etc." definition="Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.">
          <binding name="MimeType" description="The mime type of an attachment. Any valid mime type is allowed." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -460,7 +460,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension" description="Extensions that cannot be ignored even if unrecognized" definition="May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.&#xa;&#xa;Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself)." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -472,7 +472,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyLengthUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="BodyStructure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-bodystructure" label="BodyStructure" retrievable="true">
       <element name="identifier" description="Bodystructure identifier" definition="Identifier for this instance of the anatomical structure.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -523,7 +523,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyTempUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="BodyWeightUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CarePlan" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careplan" label="CarePlan" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this plan" definition="Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -674,7 +674,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)" description="Results of the activity" definition="Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not)." comment="Note that this should not duplicate the activity status (e.g. completed or in progress).">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="CarePlanActivityOutcome" description="Identifies the results of the activity." strength="Example"/>
@@ -705,7 +705,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="QICore.CarePlanActivityKind" target="%value.value" description="Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription" definition="A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.">
          <binding name="CarePlanActivityKind" description="Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -816,7 +816,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CareTeam" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-careteam" label="CareTeam" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this team" definition="Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -905,7 +905,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="member"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CareTeam.Participant" retrievable="false">
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of involvement" definition="Indicates specific responsibility of an individual within the care team, such as &quot;Primary care physician&quot;, &quot;Trained social worker counselor&quot;, &quot;Caregiver&quot;, etc." comment="Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly." mustSupport="true">
          <binding description="Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -931,7 +931,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Claim" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim" label="Claim" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier for claim" definition="A unique identifier assigned to this claim.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1097,7 +1097,7 @@
       <contextRelationship context="Device" relatedKeyElement="udi"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="party"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Accident" retrievable="false">
       <element name="date" elementType="System.Date" target="%value.value" description="When the incident occurred" definition="Date of an accident event  related to the products and services contained in the claim." comment="The date of the accident has to precede the dates of the products and services but within a reasonable timeframe.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1119,7 +1119,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.CareTeam" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Order of care team" definition="A number to uniquely identify care team entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1148,7 +1148,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Diagnosis" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Diagnosis instance identifier" definition="A number to uniquely identify diagnosis entries." comment="Diagnosis are presented in list order to their expected importance: primary, secondary, etc.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1184,7 +1184,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Insurance" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Insurance instance identifier" definition="A number to uniquely identify insurance entries and provide a sequence of coverages to convey coordination of benefit order.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1222,7 +1222,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Item instance identifier" definition="A number to uniquely identify item entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1358,7 +1358,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Item instance identifier" definition="A number to uniquely identify item entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1429,7 +1429,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Item.Detail.SubDetail" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Item instance identifier" definition="A number to uniquely identify item entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1494,7 +1494,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Payee" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Category of recipient" definition="Type of Party to be reimbursed: subscriber, provider, other.">
          <binding name="PayeeType" description="A code for the party to be reimbursed." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1507,7 +1507,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Procedure" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Procedure instance identifier" definition="A number to uniquely identify procedure entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1542,7 +1542,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.Related" retrievable="false">
       <element name="claim" elementType="QICore.Reference" description="Reference to the related claim" definition="Reference to a related claim.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1560,7 +1560,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Claim.SupportingInfo" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="Information instance identifier" definition="A number to uniquely identify supporting information entries.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1609,7 +1609,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ClaimStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Communication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communication" label="Communication" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="Unique identifier" definition="Business identifiers assigned to this communication by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1757,7 +1757,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="sender"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Communication.Payload" retrievable="false">
       <element name="content" target="FHIRHelpers.ToValue(%value)" description="Message part content" definition="A communicated content (or for multi-part communications, one portion of the communication).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -1769,7 +1769,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationnotdone" label="CommunicationNotDone" target="Communication" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value" description="Extension" definition="Captures the recorded date of the event." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1923,7 +1923,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="CommunicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-communicationrequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="Unique identifier" definition="Business identifiers assigned to this communication request by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2071,7 +2071,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="requester"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="CommunicationRequest.Payload" retrievable="false">
       <element name="content" target="FHIRHelpers.ToValue(%value)" description="Message part content" definition="The communicated content (or for multi-part communications, one portion of the communication).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
@@ -2085,7 +2085,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="CommunicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Condition" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition" label="Condition" retrievable="true" primaryCodePath="code">
       <element name="dueTo" target="FHIRHelpers.ToValue(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/condition-dueTo'].value)" description="What caused the Condition?" definition="Further conditions, problems, diagnoses, procedures or events or the substance that caused/triggered this Condition." comment="Although a condition may be caused by a substance, this is not intended to be used to record allergies/adverse reactions to substances." mustSupport="false">
          <elementTypeSpecifier elementType="QICore.dueTo" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2233,7 +2233,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Evidence" retrievable="false">
       <element name="code" target="FHIRHelpers.ToConcept(%value)" description="Manifestation/symptom" definition="A manifestation or symptom that led to the recording of this condition.">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ManifestationOrSymptom" description="Codes that describe the manifestation or symptoms of a condition." strength="Example"/>
@@ -2248,7 +2248,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Simple summary (disease specific)" definition="A simple summary of the stage such as &quot;Stage 3&quot;. The determination of the stage is disease-specific." mustSupport="true">
          <binding name="ConditionStage" description="Codes describing condition stages (e.g. Cancer stages)." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2268,7 +2268,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="Name of an individual to contact" definition="The name of an individual to contact." comment="If there is no named individual, the telecom information is for the organization as a whole.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2281,7 +2281,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="QICore.ContactPointSystem" target="%value.value" description="phone | fax | email | pager | url | sms | other" definition="Telecommunications form for contact point - what communications system is required to make use of the contact.">
          <binding name="ContactPointSystem" description="Telecommunications form for contact point." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2315,7 +2315,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="QICore.ContributorType" target="%value.value" description="author | editor | reviewer | endorser" definition="The type of contributor.">
          <binding name="ContributorType" description="The type of contributor." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2335,7 +2335,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Coverage" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-coverage" label="Coverage" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Business Identifier for the coverage" definition="A unique identifier assigned to this coverage." comment="The main (and possibly only) identifier for the coverage - often referred to as a Member Id, Certificate number, Personal Health Number or Case ID. May be constructed as the concatenation of the Coverage.SubscriberID and the Coverage.dependant.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2440,7 +2440,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="subscriber"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="payor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.Class" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of class such as 'group' or 'plan'" definition="The type of classification for which an insurer-specific class label or number and optional name is provided, for example may be used to identify a class of coverage or employer group, Policy, Plan.">
          <binding name="CoverageClass" description="The policy classifications, eg. Group, Plan, Class, etc." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2458,7 +2458,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Cost category" definition="The category of patient centric costs associated with treatment." comment="For example visit, specialist visits, emergency, inpatient care, etc.">
          <binding name="CopayTypes" description="The types of services to which patient copayments are specified." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2481,7 +2481,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Coverage.CostToBeneficiary.Exception" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Exception category" definition="The code for the specific exception.">
          <binding name="CoverageFinancialException" description="The types of exceptions from the part or full value of financial obligations such as copays." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2500,7 +2500,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="CoverageStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.DataAbsentReason" namespace="QICore" name="Data Absent Reason" identifier="http://hl7.org/fhir/StructureDefinition/data-absent-reason" label="Why value is missing" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="DataAbsentReason" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="QICore.FHIRAllTypes" target="%value.value" description="The type of the required data" definition="The type of the required data, specified as the type name of a resource. For profiles, this value is set to the type of the base resource of the profile.">
          <binding name="FHIRAllTypes" description="A list of all the concrete types defined in this version of the FHIR specification - Abstract Types, Data Types and Resource Types." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2559,7 +2559,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="A code-valued attribute to filter on" definition="The code-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type code, Coding, or CodeableConcept." comment="The path attribute contains a [Simple FHIRPath Subset](fhirpath.html#simple) that allows path traversal, but not calculation.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2582,7 +2582,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="A date-valued attribute to filter on" definition="The date-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type date, dateTime, Period, Schedule, or Timing." comment="The path attribute contains a [Simple FHIR Subset](fhirpath.html#simple) that allows path traversal, but not calculation.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2606,7 +2606,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="The name of the attribute to perform the sort" definition="The attribute of the sort. The specified path must be resolvable from the type of the required data. The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements. Note that the index must be an integer constant.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2621,7 +2621,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Device" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-device" label="Device" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by manufacturers other organizations or owners." comment="The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2766,7 +2766,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="The name of the device" definition="The name of the device.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2779,7 +2779,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Property" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)" definition="Code that specifies the property DeviceDefinitionPropetyCode (Extensible).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2798,7 +2798,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The standard that is used to operate and communicate" definition="The standard that is used to operate and communicate.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2810,7 +2810,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="System.String" target="%value.value" description="Mandatory fixed portion of UDI" definition="The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2843,7 +2843,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Device.Version" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The type of the device version" definition="The type of the device version.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2861,7 +2861,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested" label="DeviceNotRequested" target="DeviceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicenotrequested" label="DeviceNotRequested" target="DeviceRequest" retrievable="true" primaryCodePath="code">
       <element name="doNotPerformReason" elementType="QICore.DoNotPerformReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason'].value)" description="Extension" definition="Indicates the reason the event was not performed." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3032,7 +3032,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept">
       <element name="identifier" description="External Request identifier" definition="Identifiers assigned to this order by the orderer or by the receiver." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3192,7 +3192,7 @@
       <contextRelationship context="Device" relatedKeyElement="requester"/>
       <contextRelationship context="Device" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DeviceRequest.Parameter" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Device detail" definition="A code or string that identifies the device detail being asserted.">
          <binding name="ParameterCode" description="A code that identifies the device detail." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3214,7 +3214,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DeviceUseStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-deviceusestatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code">
       <element name="identifier" description="External identifier for this record" definition="An external identifier for this statement such as an IRI.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3300,7 +3300,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="DeviceUseStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="DiagnosisPresentOnAdmissionExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission" label="DiagnosisPresentOnAdmissionExtension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="System.String" target="%value.value" description="Comment about the image (e.g. explanation)" definition="A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features." comment="The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3312,7 +3312,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportLab" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-lab" label="DiagnosticReportLab" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="valueReference" elementType="QICore.Reference" target="%parent.extension[url='null']" description="Value of extension" definition="Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/extensibility.html) for a list)." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3444,7 +3444,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="DiagnosticReportNote" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note" label="DiagnosticReportNote" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="valueReference" elementType="QICore.Reference" target="%parent.extension[url='null']" description="Value of extension" definition="Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/extensibility.html) for a list)." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3571,7 +3571,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.Concept" namespace="QICore" name="DoNotPerformReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason" label="DoNotPerformReason" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Resource" namespace="QICore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="QICore.Narrative" description="Text summary of the resource, for human interpretation" definition="A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." comment="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a &quot;text blob&quot; or where text is additionally entered raw or narrated and encoded information is added later.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3599,7 +3599,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="The order of the dosage instructions" definition="Indicates the order in which the dosage instructions should be applied or interpreted.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3677,7 +3677,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The kind of dose or rate specified" definition="The kind of dose or rate specified, for example, ordered or calculated.">
          <binding name="DoseAndRateType" description="The kind of dose or rate specified." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3708,7 +3708,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" target="%value.value" description="Unique id for inter-element referencing" definition="Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces."/>
       <element name="extension" description="Additional content defined by implementations" definition="May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="QICore.Extension" xsi:type="ListTypeSpecifier"/>
@@ -3721,7 +3721,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EnableWhenBehavior" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Encounter" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter" label="Encounter" retrievable="true" primaryCodePath="type">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)" description="Reason for current status" definition="Captures the reason for the current state of the resource." comment="This is generally only used for &quot;exception&quot; statuses such as &quot;suspended&quot; or &quot;cancelled&quot;.  The reason for performing the request at all is captured in reasonCode, not here.  (Distinct reason codes for different statuses can be enforced using invariants if they are universal bindings)." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3880,7 +3880,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="individual"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)" description="inpatient | outpatient | ambulatory | emergency +" definition="inpatient | outpatient | ambulatory | emergency +.">
          <binding name="EncounterClass" description="Classification of the encounter." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3896,7 +3896,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="QICore.Reference" description="The diagnosis or procedure relevant to the encounter" definition="Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure." comment="For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis)." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3922,7 +3922,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="QICore.Identifier" description="Pre-admission identifier" definition="Pre-admission identifier.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3978,7 +3978,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="QICore.Reference" description="Location the encounter takes place" definition="The location where the encounter takes place." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4005,7 +4005,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.Participant" retrievable="false">
       <element name="type" target="FHIRHelpers.ToConcept(%value)" description="Role of participant in encounter" definition="Role of participant in encounter." comment="The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc." mustSupport="true">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ParticipantType" description="Role of participant in encounter." strength="Extensible"/>
@@ -4027,7 +4027,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="QICore.EncounterStatus" target="%value.value" description="planned | arrived | triaged | in-progress | onleave | finished | cancelled +" definition="planned | arrived | triaged | in-progress | onleave | finished | cancelled +.">
          <binding name="EncounterStatus" description="Current state of the encounter." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4044,7 +4044,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="EncounterProcedureExtension" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-procedure" label="EncounterProcedureExtension" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='type'].value)" description="type" definition="Whether the procedure was primary or secondary.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4073,7 +4073,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value" description="Natural language description of the condition" definition="A brief, natural language description of the condition that effectively communicates the intended semantics.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4101,7 +4101,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
       <element name="value" target="FHIRHelpers.ToValue(%value)" description="Value of extension" definition="Value of extension - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -4169,7 +4169,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FHIRSubstanceStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="FamilyHistoryStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-familymemberhistory" label="FamilyMemberHistory" retrievable="true">
       <element name="identifier" description="External Id(s) for this record" definition="Business identifiers assigned to this family member history by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4296,7 +4296,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="FamilyMemberHistory.Condition" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Condition suffered by relation" definition="The actual condition specified. Could be a coded condition (like MI or Diabetes) or a less specific string like 'cancer' depending on how much is known about the condition and the capabilities of the creating system." mustSupport="true">
          <binding name="ConditionCode" description="Identification of the Condition or diagnosis." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4352,7 +4352,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Flag" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-flag" label="Flag" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier" definition="Business identifiers assigned to this flag by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4406,7 +4406,7 @@
       <contextRelationship context="Device" relatedKeyElement="author"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="FlagStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Goal" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-goal" label="Goal" retrievable="true" primaryCodePath="category">
       <element name="reasonRejected" elementType="QICore.reasonRejected" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/goal-reasonRejected'].value)" description="The reason the goal was not accepted" definition="The reason the goal was not accepted. Applies only if the status of the goal is rejected." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4513,7 +4513,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The parameter whose value is being tracked" definition="The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level." mustSupport="false">
          <binding description="LOINC codes" strength="Preferred"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4543,7 +4543,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="QICore.NameUse" target="%value.value" description="usual | official | temp | nickname | anonymous | old | maiden" definition="Identifies the purpose for this name." comment="Applications can assume that a name is current unless it explicitly says that it is temporary or old.">
          <binding name="NameUse" description="The use of a human name." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4587,7 +4587,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="QICore.IdentifierUse" target="%value.value" description="usual | official | temp | secondary | old (If known)" definition="The purpose of this identifier." comment="Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.">
          <binding name="IdentifierUse" description="Identifies the purpose for this identifier, if known ." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4625,7 +4625,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImagingStudy" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-imagingstudy" label="ImagingStudy" retrievable="true">
       <element name="identifier" description="Identifiers for the whole study" definition="Identifiers for the ImagingStudy such as DICOM Study Instance UID, and Accession Number." comment="See discussion under [Imaging Study Implementation Notes](http://hl7.org/fhir/R4/imagingstudy.html#notes) for encoding of DICOM Study Instance UID. Accession Number should use ACSN Identifier type.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4742,7 +4742,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value" description="DICOM Series Instance UID for the series" definition="The DICOM Series Instance UID for the series." comment="See [DICOM PS3.3 C.7.3](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.3.html).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4811,7 +4811,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Instance" retrievable="false">
       <element name="uid" elementType="System.String" target="%value.value" description="DICOM SOP Instance UID" definition="The DICOM SOP Instance UID for this image or other DICOM content." comment="See  [DICOM PS3.3 C.12.1](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4834,7 +4834,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImagingStudy.Series.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the series.">
          <binding name="EventPerformerFunction" description="The type of involvement of the performer." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4848,7 +4848,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImagingStudyStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Immunization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization record.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5018,7 +5018,7 @@
       <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="System.String" target="%value.value" description="Educational material document identifier" definition="Identifier of the material presented to the patient.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5040,7 +5040,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="What type of performance was done" definition="Describes the type of performance (e.g. ordering provider, administering provider, etc.).">
          <binding name="ImmunizationFunction" description="The role a practitioner or organization plays in the immunization event." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5053,7 +5053,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="System.String" target="%value.value" description="Name of vaccine series" definition="One possible path to achieve presumed immunity against a disease - within the context of an authority.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5090,7 +5090,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="System.DateTime" target="%value.value" description="When reaction started" definition="Date of reaction to the immunization.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5107,7 +5107,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationevaluation" label="ImmunizationEvaluation" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization evaluation record." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5190,7 +5190,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ImmunizationEvaluationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationnotdone" label="ImmunizationNotDone" target="Immunization" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization record.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5370,7 +5370,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-immunizationrec" label="ImmunizationRecommendation" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this particular recommendation record.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5403,7 +5403,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation" retrievable="false">
       <element name="vaccineCode" target="FHIRHelpers.ToConcept(%value)" description="Vaccine  or vaccine group recommendation applies to" definition="Vaccine(s) or vaccine group that pertain to the recommendation." mustSupport="true">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding description="This identifies the CVX code system" strength="Extensible"/>
@@ -5484,7 +5484,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of date" definition="Date classification of recommendation.  For example, earliest date to give, latest date to give, etc.">
          <binding name="ImmunizationRecommendationDateCriterion" description="Classifies date criterion with respect to conveying information about a patient's vaccination status (e.g. due date, latest to give date, etc.)." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5499,7 +5499,7 @@
    </typeInfo>
    <typeInfo baseType="System.Boolean" namespace="QICore" name="IsElective" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-isElective" label="IsElective" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Location" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location" label="Location" retrievable="true">
       <element name="identifier" description="Unique code or number identifying the location to its users" definition="Unique code or number identifying the location to its users." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5597,7 +5597,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek" target="%value.value" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -5621,7 +5621,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="System.Decimal" target="%value.value" description="Longitude with WGS84 datum" definition="Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5640,7 +5640,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="LocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Medication" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" label="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for this medication" definition="Business identifier for this medication." comment="The serial number could be included as an identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5687,7 +5687,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="System.String" target="%value.value" description="Identifier assigned to batch" definition="The assigned lot number of a batch of the specified product.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5699,7 +5699,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Medication.Ingredient" retrievable="false">
       <element name="item" target="FHIRHelpers.ToValue(%value)" description="The actual ingredient or content" definition="The actual ingredient - either a substance (simple ingredient) or another medication of a medication." mustSupport="false">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
@@ -5720,7 +5720,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministration" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationadministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Administration that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5853,7 +5853,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Dosage" retrievable="false">
       <element name="text" elementType="System.String" target="%value.value" description="Free text dosage instructions e.g. SIG" definition="Free text dosage can be used for cases where the dosage administered is too complex to code. When coded dosage is present, the free text dosage may still be present for display to humans.&#xd;&#xd;The dosage instructions should reflect the dosage of the medication that was administered.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5892,7 +5892,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationAdministration.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the medication administration.">
          <binding name="MedicationAdministrationPerformerFunction" description="A code describing the role an individual played in administering the medication." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5905,7 +5905,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationAdministrationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotadministered" label="MedicationAdministrationNotDone" target="MedicationAdministration" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value" description="Extension" definition="Captures the recorded date of the event." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6044,7 +6044,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationAdministrationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispense" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationdispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Dispense that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6194,7 +6194,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="receiver"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Who performed the dispense and what they did" definition="Distinguishes the type of performer in the dispense.  For example, date enterer, packager, final checker.">
          <binding name="MedicationDispensePerformerFunction" description="A code describing the role an individual played in dispensing a medication." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6207,7 +6207,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationDispense.Substitution" retrievable="false">
       <element name="wasSubstituted" elementType="System.Boolean" target="%value.value" description="Whether a substitution was or was not performed on the dispense" definition="True if the dispenser dispensed a different drug or product from what was prescribed.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6233,7 +6233,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationDispenseNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotdispensed" label="MedicationDispenseNotDone" target="MedicationDispense" retrievable="true">
       <element name="recorded" elementType="QICore.NotDoneRecorded" target="%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'].value.value" description="Extension" definition="Captures the recorded date of the event." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6387,7 +6387,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationDispenseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested" label="MedicationNotRequested" target="MedicationRequest" retrievable="true">
       <element name="identifier" description="External ids for this request" definition="Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6582,7 +6582,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External ids for this request" definition="Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6777,7 +6777,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="dispenseInterval" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="Minimum period of time between dispenses" definition="The minimum period of time that must occur between dispenses of the medication." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6812,7 +6812,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="First fill quantity" definition="The amount or quantity to provide as part of the first dispense.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6824,7 +6824,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" target="FHIRHelpers.ToValue(%value)" description="Whether substitution is allowed or not" definition="True if the prescriber allows a different drug to be dispensed from what was prescribed." comment="This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -6843,7 +6843,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="MedicationStatement" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationstatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication">
       <element name="identifier" description="External identifier" definition="Identifiers associated with this Medication Statement that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6959,7 +6959,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="System.String" target="%value.value" description="Version specific identifier" definition="The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted." comment="The server assigns this value, and ignores what the client specifies, except in the case that the server is imposing version integrity on updates/deletes.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -6998,7 +6998,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="QICore.NarrativeStatus" target="%value.value" description="generated | extensions | additional | empty" definition="The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.">
          <binding name="NarrativeStatus" description="The status of a resource narrative." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7021,7 +7021,7 @@
    <typeInfo baseType="System.Concept" namespace="QICore" name="NotDoneReason" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason" label="NotDoneReason" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="NotDoneRecorded" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded" label="NotDoneRecorded" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="NotDoneValueSet" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneValueSet" label="Not Done Value Set" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Observation" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation" label="Observation" retrievable="true" primaryCodePath="code">
       <element name="bodyPosition" elementType="QICore.bodyPosition" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/observation-bodyPosition'].value)" description="The body position during the observation" definition="The position of the body when the observation was done, e.g. standing, sitting. To be used only when the body position in not precoordinated in the observation code." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7214,7 +7214,7 @@
       <contextRelationship context="Device" relatedKeyElement="device"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.Component" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of component observation (code / type)" definition="Describes what was observed. Sometimes this is called the observation &quot;code&quot;." comment="*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation." mustSupport="true">
          <binding name="VitalSigns" description="This identifies the vital sign result type." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7270,7 +7270,7 @@
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.DiastolicBP" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.FlowRate" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Observation.Component" namespace="QICore" name="Observation.Component.SystolicBP" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="Low Range, if relevant" definition="The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - &lt;=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is &lt;=2.3).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7308,7 +7308,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ObservationNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone" label="ObservationNotDone" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="notDoneReason" elementType="QICore.NotDoneReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason'].value)" description="Extension" definition="Indicates the reason the event was not done." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7494,7 +7494,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ObservationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Organization" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-organization" label="Organization" retrievable="true">
       <element name="identifier" description="Identifies this organization  across multiple systems" definition="Identifier for the organization that is used to identify the organization across multiple disparate systems." comment="NPI preferred." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7580,7 +7580,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The type of contact" definition="Indicates a purpose for which the contact can be reached.">
          <binding name="ContactPartyType" description="The purpose for which you would contact a contact party." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7604,7 +7604,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="Name used to access the parameter value" definition="The name of the parameter used to allow access to the value of the parameter in evaluation contexts.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7644,7 +7644,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Patient" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" label="Patient" retrievable="true">
       <element name="race" elementType="QICore.USCoreRaceExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']" description="US Core Race Extension" definition="Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:&#xa;&#xa;   - American Indian or Alaska Native&#xa;   - Asian&#xa;   - Black or African American&#xa;   - Native Hawaiian or Other Pacific Islander&#xa;   - White." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7826,7 +7826,7 @@
       <contextRelationship context="Patient" relatedKeyElement="other"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="other"/>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Address" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="Address" xsi:type="NamedTypeSpecifier"/>
       <element name="address-preferred" elementType="QICore.preferred" target="%parent.address.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value" description="Preferred" definition="Flag denoting whether parent item is preferred - e.g., a preferred address or telephone number." comment="Make general extension." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7837,7 +7837,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The language which can be used to communicate with the patient about his or her health" definition="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." comment="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." mustSupport="true">
          <binding strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7850,7 +7850,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Contact" retrievable="false">
       <element name="relationship" target="FHIRHelpers.ToConcept(%value)" description="The kind of relationship" definition="The nature of the relationship between the patient and the contact person.">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ContactRelationship" description="The nature of the relationship between a patient and a contact person for that patient." strength="Extensible"/>
@@ -7894,7 +7894,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Patient.Link" retrievable="false">
       <element name="other" elementType="QICore.Reference" description="The other patient or related person resource that the link refers to" definition="The other patient resource that the link refers to." comment="Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -7907,7 +7907,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo namespace="QICore" name="Patient.Telecom" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="Patient.Telecom" retrievable="false">
       <baseTypeSpecifier namespace="QICore" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
       <element name="telecom-preferred" elementType="QICore.preferred" target="%parent.telecom.extension[url='http://hl7.org/fhir/StructureDefinition/iso21090-preferred'].value.value" description="Preferred" definition="Flag denoting whether parent item is preferred - e.g., a preferred address or telephone number." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7918,7 +7918,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Practitioner" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner" label="Practitioner" retrievable="true">
       <element name="identifier" description="An identifier for the person as this agent" definition="An identifier that applies to this person in this role." comment="NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7994,7 +7994,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier" description="An identifier for this qualification for the practitioner" definition="An identifier that applies to this person's qualification in this role.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8021,7 +8021,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="PractitionerRole" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitionerrole" label="PractitionerRole" retrievable="true">
       <element name="identifier" description="Business Identifiers that are specific to a role/location" definition="Business Identifiers that are specific to a role/location." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8108,7 +8108,7 @@
       </element>
       <contextRelationship context="Practitioner" relatedKeyElement="practitioner"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek" target="%value.value" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="QICore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -8132,7 +8132,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value" description="Reason presented to the user explaining why time not available" definition="The reason that can be presented to the user as to why this time is not available.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8147,7 +8147,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Procedure" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure" label="Procedure" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']" description="The access point or points used for this procedure" definition="The approach body site used for this procedure.  Multiple locations are allowed." mustSupport="false">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8352,7 +8352,7 @@
       <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Kind of change to device" definition="The kind of change that happened to the device during the procedure.">
          <binding name="DeviceActionKind" description="A kind of change that happened to the device during the procedure." strength="Preferred"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8365,7 +8365,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.">
          <binding name="ProcedurePerformerRole" description="A code that identifies the role of a performer of the procedure." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8386,7 +8386,7 @@
    <typeInfo namespace="QICore" name="ProcedureNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedurenotdone" label="ProcedureNotDone" target="Procedure" retrievable="true" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="PublicationStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name">
       <element name="url" elementType="System.String" target="%value.value" description="Canonical identifier for this questionnaire, represented as a URI (globally unique)" definition="An absolute URI that is used to identify this questionnaire when it is referenced in a specification, model, design or an instance; also called its canonical identifier. This SHOULD be globally unique and SHOULD be a literal address at which at which an authoritative instance of this questionnaire is (or will be) published. This URL can be the target of a canonical reference. It SHALL remain the same when the questionnaire is stored on different servers." comment="The name of the referenced questionnaire can be conveyed using the http://hl7.org/fhir/StructureDefinition/display extension.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8546,7 +8546,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value" description="Unique id for item in questionnaire" definition="An identifier that is unique within the Questionnaire allowing linkage to the equivalent item in a QuestionnaireResponse resource." comment="This ''can'' be a meaningful identifier (e.g. a LOINC code) but is not intended to have any meaning.  GUIDs or sequential numbers are appropriate here.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8641,7 +8641,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.AnswerOption" retrievable="false">
       <element name="value" target="FHIRHelpers.ToValue(%value)" description="Answer value" definition="A potential answer that's allowed as the answer to this question." comment="The data type of the value must agree with the item.type.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
@@ -8662,7 +8662,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.EnableWhen" retrievable="false">
       <element name="question" elementType="System.String" target="%value.value" description="Question that determines whether item is enabled" definition="The linkId for the question whose answer (or lack of answer) governs whether this item is enabled." comment="If multiple question occurrences are present for the same question (same linkId), then this refers to the nearest question occurrence reachable by tracing first the &quot;ancestor&quot; axis and then the &quot;preceding&quot; axis and then the &quot;following&quot; axis.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8693,7 +8693,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Questionnaire.Item.Initial" retrievable="false">
       <element name="value" target="FHIRHelpers.ToValue(%value)" description="Actual value for initializing the question" definition="The actual value to for an initial answer." comment="The type of the initial value must be consistent with the type of the item.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -8717,7 +8717,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemOperator" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireItemType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true">
       <element name="identifier" elementType="QICore.Identifier" description="Unique id for this set of answers" definition="A business identifier assigned to a particular completed (or partially completed) questionnaire.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8789,7 +8789,7 @@
       <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
       <contextRelationship context="RelatedPerson" relatedKeyElement="source"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item" retrievable="false">
       <element name="linkId" elementType="System.String" target="%value.value" description="Pointer to specific item from Questionnaire" definition="The item from the Questionnaire that corresponds to this item in the QuestionnaireResponse resource.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8820,7 +8820,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="QuestionnaireResponse.Item.Answer" retrievable="false">
       <element name="value" target="FHIRHelpers.ToValue(%value)" description="Single-valued answer to the question" definition="The answer (or one of the answers) provided by the respondent to the question." comment="More complex structures (Attachment, Resource and Quantity) will typically be limited to electronic forms that can expose an appropriate user interface to capture the components and enforce the constraints of a complex data type.  Additional complex types can be introduced through extensions. Must match the datatype specified by Questionnaire.item.type in the corresponding Questionnaire.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -8851,7 +8851,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="QuestionnaireResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="System.String" target="%value.value" description="Literal reference, Relative, internal or absolute URL" definition="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources." comment="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -8874,7 +8874,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="QICore.RelatedArtifactType" target="%value.value" description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of" definition="The type of relationship to the related artifact.">
          <binding name="RelatedArtifactType" description="The type of relationship to the related artifact." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8913,7 +8913,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="RelatedPerson" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-relatedperson" label="RelatedPerson" retrievable="true">
       <element name="identifier" description="A human identifier for this person" definition="Identifier for a person within a particular scope.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -8988,7 +8988,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="RelatedPerson.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The language which can be used to communicate with the patient about his or her health" definition="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." comment="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.">
          <binding name="Language" description="A human language." strength="Preferred"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9003,7 +9003,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="RequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="QICore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="System.String" target="%value.value" description="Logical id of this artifact" definition="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." comment="The only time that a resource does not have an id is when it is being submitted to the server using a create operation."/>
       <element name="meta" elementType="QICore.Meta" description="Metadata about the resource" definition="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9023,7 +9023,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="ResourceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="Zero value and units" definition="The base quantity that a measured value of zero represents. In addition, this provides the units of the entire measurement series.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9060,7 +9060,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceNotRequested" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicenotrequested" label="ServiceNotRequested" target="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="approachBodyStructure" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/procedure-approachBodyStructure']" description="The access point or points used for this procedure" definition="The approach body site used for this procedure.  Multiple locations are allowed." mustSupport="false">
          <elementTypeSpecifier elementType="QICore.approachBodyStructure" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9315,7 +9315,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="ServiceRequest" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest" label="ServiceRequest" retrievable="true" primaryCodePath="code">
       <element name="statusReason" elementType="QICore.statusReason" target="FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/request-statusReason'].value)" description="Reason for current status" definition="Captures the reason for the current state of the resource." comment="This is generally only used for &quot;exception&quot; statuses such as &quot;suspended&quot; or &quot;cancelled&quot;.  The reason for performing the request at all is captured in reasonCode, not here.  (Distinct reason codes for different statuses can be enforced using invariants if they are universal bindings)." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9574,7 +9574,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="ServiceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" target="FHIRHelpers.ToCode(%value)" description="Indication of the reason the entity signed the object(s)" definition="An indication of the reason that the entity signed this document. This may be explicitly included as part of the signature information and can be used when determining accountability for various actions concerning the document." comment="Examples include attesting to: authorship, correct transcription, and witness of specific event. Also known as a &amp;quot;Commitment Type Indication&amp;quot;.">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
          <binding name="SignatureType" description="An indication of the reason that an entity signed the object." strength="Preferred"/>
@@ -9616,7 +9616,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Specimen" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-specimen" label="Specimen" retrievable="true" primaryCodePath="type">
       <element name="identifier" description="External Identifier" definition="Id for specimen.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9695,7 +9695,7 @@
       <contextRelationship context="Patient" relatedKeyElement="subject"/>
       <contextRelationship context="Device" relatedKeyElement="subject"/>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Collection" retrievable="false">
       <element name="collector" elementType="QICore.Reference" description="Who collected the specimen" definition="Person who collected the specimen." mustSupport="false">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9745,7 +9745,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Container" retrievable="false">
       <element name="identifier" description="Id for the container" definition="Id for container. There may be multiple; a manufacturer's bar code, lab assigned identifier, etc. The container ID may differ from the specimen id in some circumstances.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9792,7 +9792,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Specimen.Processing" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value" description="Textual description of procedure" definition="Textual description of procedure.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9824,7 +9824,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="SpecimenStatus" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="Status" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Substance" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-substance" label="Substance" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Unique identifier" definition="Unique identifier for the substance." comment="This identifier is associated with the kind of substance in contrast to the  Substance.instance.identifier which is associated with the package/container.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -9868,7 +9868,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Ingredient" retrievable="false">
       <element name="quantity" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)" description="Optional amount (concentration)" definition="The amount of the ingredient in the substance - a concentration ratio." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9880,7 +9880,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Substance.Instance" retrievable="false">
       <element name="identifier" elementType="QICore.Identifier" description="Identifier of the package/container" definition="Identifier associated with the package/container (usually a label affixed directly).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -9897,7 +9897,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="Task" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-task" label="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Task Instance Identifier" definition="The business identifier for this task." mustSupport="true">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10074,7 +10074,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Input" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Label for the input" definition="A code or description indicating how the input is intended to be used as part of the task execution." comment="If referencing a BPMN workflow or Protocol, the &quot;system&quot; is the URL for the workflow definition and the code is the &quot;name&quot; of the required input.">
          <binding name="TaskInputParameterType" description="Codes to identify types of input parameters.  These will typically be specific to a particular workflow.  E.g. &quot;Comparison source&quot;, &quot;Applicable consent&quot;, &quot;Concomitent Medications&quot;, etc." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10143,7 +10143,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Output" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Label for output" definition="The name of the Output parameter.">
          <binding name="TaskOutputParameterType" description="Codes to identify types of input parameters.  These will typically be specific to a particular workflow.  E.g. &quot;Identified issues&quot;, &quot;Preliminary results&quot;, &quot;Filler order&quot;, &quot;Final results&quot;, etc." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10212,7 +10212,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Task.Restriction" retrievable="false">
       <element name="repetitions" elementType="System.Integer" target="%value.value" description="How many times to repeat" definition="Indicates the number of times the requested action should occur.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -10234,7 +10234,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskIntent" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="TaskNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-tasknotdone" label="TaskNotDone" target="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="TaskNotDone" identifier="http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-tasknotdone" label="TaskNotDone" target="Task" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Task Instance Identifier" definition="The business identifier for this task.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10421,7 +10421,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskPriority" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="TaskStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.BackboneElement" namespace="QICore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" target="%value.value" description="When the event occurs" definition="Identifies specific times when the event occurs.">
          <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10467,7 +10467,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="Timing.Repeat" retrievable="false">
       <element name="bounds" target="FHIRHelpers.ToValue(%value)" description="Length/Range of lengths, or (Start and/or end) limits" definition="Either a duration for the length of the timing schedule, a range of possible length, or outer bounds for start and/or end limits of the timing schedule.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -10560,7 +10560,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="QICore.TriggerType" target="%value.value" description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended" definition="The type of triggering event.">
          <binding name="TriggerType" description="The type of trigger." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10598,7 +10598,7 @@
    <typeInfo baseType="System.String" namespace="QICore" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="QICore" name="USCoreBirthSexExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex" label="US Core Birth Sex Extension" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreEthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false">
       <element name="ombCategory" elementType="System.Code" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)" description="Hispanic or Latino|Not Hispanic or Latino" definition="The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf)." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -10626,7 +10626,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by manufacturers other organizations or owners." comment="The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10770,7 +10770,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreLaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -10952,7 +10952,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11114,7 +11114,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11276,7 +11276,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCorePulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11464,7 +11464,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="USCoreRaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false">
       <element name="ombCategory" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)" description="American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White" definition="The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf)." mustSupport="true">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11493,7 +11493,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="USCoreSmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11646,7 +11646,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Element" namespace="QICore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)" description="Type of context being specified" definition="A code that identifies the type of context being specified by this usage context.">
          <binding name="UsageContextType" description="A code that specifies a type of context being specified by a usage context." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11669,7 +11669,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="QICore" name="Use" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="abatement" identifier="http://hl7.org/fhir/StructureDefinition/familymemberhistory-abatement" label="abatement" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -11683,7 +11683,7 @@
    <typeInfo baseType="System.Boolean" namespace="QICore" name="cadavericDonor" identifier="http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor" label="cadavericDonor" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="delta" identifier="http://hl7.org/fhir/StructureDefinition/observation-delta" label="delta" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.Concept" namespace="QICore" name="disability" identifier="http://hl7.org/fhir/StructureDefinition/patient-disability" label="disability" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="dueTo" identifier="http://hl7.org/fhir/StructureDefinition/condition-dueTo" label="dueTo" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -11692,7 +11692,7 @@
    <typeInfo baseType="System.Quantity" namespace="QICore" name="duration" identifier="http://hl7.org/fhir/StructureDefinition/allergyintolerance-duration" label="duration" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.DateTime" namespace="QICore" name="incisionDateTime" identifier="http://hl7.org/fhir/StructureDefinition/procedure-incisionDateTime" label="incisionDateTime" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="QICore.Reference" namespace="QICore" name="locationPerformed" identifier="http://hl7.org/fhir/StructureDefinition/diagnosticReport-locationPerformed" label="locationPerformed" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.Extension" namespace="QICore" name="nationality" identifier="http://hl7.org/fhir/StructureDefinition/patient-nationality" label="nationality" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%parent.extension[url='code'].value)" description="Nationality Code" definition="Code representing nationality of patient.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -11714,7 +11714,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -11881,7 +11881,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12048,7 +12048,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12215,7 +12215,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12382,7 +12382,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12565,7 +12565,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12732,7 +12732,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -12899,7 +12899,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -13066,7 +13066,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -13233,7 +13233,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="QICore.DomainResource" namespace="QICore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="QICore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -13396,7 +13396,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" namespace="QICore" name="occurredFollowing" identifier="http://hl7.org/fhir/StructureDefinition/condition-occurredFollowing" label="occurredFollowing" retrievable="false">
       <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
          <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
          <choice namespace="QICore" name="Reference" xsi:type="NamedTypeSpecifier"/>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/quick-modelinfo-3.0.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/quick-modelinfo-3.0.0.xml
@@ -4,12 +4,12 @@
  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns4="urn:hl7-org:elm-modelinfo:r1" name="QUICK"
  patientBirthDatePropertyName="birthDate" patientClassName="Patient" targetQualifier="quick"
  url="http://cimi.hl7.org" version="3.0.0">
-  <ns4:typeInfo baseType="QUICK.MedicationDoseQuantity" name="QUICK.DoseRange" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.MedicationDoseQuantity" name="QUICK.DoseRange" retrievable="false">
     <ns4:element name="value">
       <ns4:typeSpecifier pointType="System.Quantity" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Goal" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Goal" retrievable="false">
     <ns4:element name="lifecycleStatus" type="System.String"/>
     <ns4:element name="description" type="System.Concept"/>
     <ns4:element name="start">
@@ -35,7 +35,7 @@
     </ns4:element>
     <ns4:element name="expressedBy" type="QUICK.Party"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.ProfessionalQualification" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.ProfessionalQualification" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="period">
@@ -43,7 +43,7 @@
     </ns4:element>
     <ns4:element name="issuer" type="QUICK.Organization"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.CareRecipient" name="QUICK.Group" primaryCodePath="code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.CareRecipient" name="QUICK.Group" primaryCodePath="code" retrievable="true">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="type" type="System.String"/>
     <ns4:element name="actual" type="System.Boolean"/>
@@ -54,16 +54,16 @@
     <ns4:element name="characteristic" type="QUICK.GroupCharacteristic"/>
     <ns4:element name="member" type="QUICK.GroupMember"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Finding" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Finding" retrievable="false">
     <ns4:element name="status" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Reference" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Reference" retrievable="false">
     <ns4:element name="reference" type="System.String"/>
     <ns4:element name="type" type="System.String"/>
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="display" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.CareGiver" name="QUICK.CareTeam" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.CareGiver" name="QUICK.CareTeam" retrievable="false">
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="category" type="System.Concept"/>
     <ns4:element name="name" type="System.String"/>
@@ -79,7 +79,7 @@
     <ns4:element name="telecom" type="QUICK.ContactPoint"/>
     <ns4:element name="note" type="QUICK.Annotation"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Location" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Location" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="operationalStatus" type="System.Code"/>
@@ -97,15 +97,15 @@
     <ns4:element name="hoursOfOperation" type="QUICK.AvailableTime"/>
     <ns4:element name="availabilityExceptions" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.MedicationAdministration" primaryCodePath="medication.code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.MedicationAdministration" primaryCodePath="medication.code" retrievable="true">
     <ns4:element name="medication" type="QUICK.Medication"/>
     <ns4:element name="dosage" type="QUICK.DosageTaken"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Narrative" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Narrative" retrievable="false">
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="div" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Hospitalization" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Hospitalization" retrievable="false">
     <ns4:element name="preAdmissionIdentifier" type="QUICK.Identifier"/>
     <ns4:element name="origin">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
@@ -126,7 +126,7 @@
     </ns4:element>
     <ns4:element name="dischargeDisposition" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Meta" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Meta" retrievable="false">
     <ns4:element name="versionId" type="System.String"/>
     <ns4:element name="lastUpdated" type="System.DateTime"/>
     <ns4:element name="source" type="System.String"/>
@@ -134,7 +134,7 @@
     <ns4:element name="security" type="System.Code"/>
     <ns4:element name="tag" type="System.Code"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DosageTaken" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DosageTaken" retrievable="false">
     <ns4:element name="text" type="System.String"/>
     <ns4:element name="site" type="System.Concept"/>
     <ns4:element name="route" type="System.Concept"/>
@@ -142,7 +142,7 @@
     <ns4:element name="dose" type="QUICK.DoseQuantity"/>
     <ns4:element name="rate" type="QUICK.MedicationDosePointRate"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DeviceUdiCarrier" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DeviceUdiCarrier" retrievable="false">
     <ns4:element name="deviceIdentifier" type="System.String"/>
     <ns4:element name="issuer" type="System.String"/>
     <ns4:element name="jurisdiction" type="System.String"/>
@@ -150,7 +150,7 @@
     <ns4:element name="carrierHRF" type="System.String"/>
     <ns4:element name="entryType" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.EncounterDiagnosisOrProcedure" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.EncounterDiagnosisOrProcedure" retrievable="false">
     <ns4:element name="reference">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="QUICK" name="Condition" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -161,7 +161,7 @@
     <ns4:element name="rank" type="System.Integer"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.MedicationDoseQuantity" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.AdverseEvent" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.AdverseEvent" retrievable="false">
     <ns4:element name="event" type="System.Concept"/>
     <ns4:element name="subject" type="QUICK.Party"/>
     <ns4:element name="date" type="System.DateTime"/>
@@ -171,13 +171,13 @@
     <ns4:element name="location" type="QUICK.Location"/>
     <ns4:element name="suspectEntity" type="QUICK.SuspectEntity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.Immunization" primaryCodePath="vaccineCode" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.Immunization" primaryCodePath="vaccineCode" retrievable="true">
     <ns4:element name="vaccineCode" type="System.Concept"/>
     <ns4:element name="doseQuantity" type="System.Quantity"/>
     <ns4:element name="route" type="System.Concept"/>
     <ns4:element name="primarySource" type="System.Boolean"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Address" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Address" retrievable="false">
     <ns4:element name="use" type="System.String"/>
     <ns4:element name="type" type="System.String"/>
     <ns4:element name="text" type="System.String"/>
@@ -191,7 +191,7 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.IndividualCareRecipient" name="QUICK.Patient" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.IndividualCareRecipient" name="QUICK.Patient" retrievable="false">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="name" type="QUICK.HumanName"/>
     <ns4:element name="telecom" type="QUICK.ContactPoint"/>
@@ -218,7 +218,7 @@
     <ns4:element name="managingOrganization" type="QUICK.Organization"/>
     <ns4:element name="link" type="QUICK.RecordLink"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.Appointment" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.Appointment" retrievable="false">
     <ns4:element name="serviceCategory" type="System.Concept"/>
     <ns4:element name="serviceType" type="System.Concept"/>
     <ns4:element name="specialty" type="System.Concept"/>
@@ -238,7 +238,7 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.IndividualCareGiver" name="QUICK.PractitionerRole" primaryCodePath="code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.IndividualCareGiver" name="QUICK.PractitionerRole" primaryCodePath="code" retrievable="true">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="period">
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
@@ -254,35 +254,35 @@
     <ns4:element name="notAvailable" type="QUICK.NonAvailability"/>
     <ns4:element name="availabilityExceptions" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Resource" name="QUICK.DomainResource" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Resource" name="QUICK.DomainResource" retrievable="false">
     <ns4:element name="text" type="QUICK.Narrative"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.LanguageCompetency" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.LanguageCompetency" retrievable="false">
     <ns4:element name="language" type="System.Concept"/>
     <ns4:element name="preferred" type="System.Boolean"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DeviceName" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DeviceName" retrievable="false">
     <ns4:element name="name" type="System.String"/>
     <ns4:element name="type" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.RecordLink" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.RecordLink" retrievable="false">
     <ns4:element name="other" type="QUICK.IndividualCareRecipient"/>
     <ns4:element name="type" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.GroupMember" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.GroupMember" retrievable="false">
     <ns4:element name="entity" type="QUICK.Party"/>
     <ns4:element name="period">
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
     <ns4:element name="inactive" type="System.Boolean"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.AvailableTime" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.AvailableTime" retrievable="false">
     <ns4:element name="daysOfWeek" type="System.String"/>
     <ns4:element name="allDay" type="System.Boolean"/>
     <ns4:element name="availableStartTime" type="System.Time"/>
     <ns4:element name="availableEndTime" type="System.Time"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Ingredient" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Ingredient" retrievable="false">
     <ns4:element name="item">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="QUICK" name="DomainResource" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -292,7 +292,7 @@
     <ns4:element name="isActive" type="System.Boolean"/>
     <ns4:element name="strength" type="QUICK.Ratio"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Party" name="QUICK.Device" primaryCodePath="type" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Party" name="QUICK.Device" primaryCodePath="type" retrievable="true">
     <ns4:element name="udiCarrier" type="QUICK.DeviceUdiCarrier"/>
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="deviceName" type="QUICK.DeviceName"/>
@@ -316,7 +316,7 @@
     <ns4:element name="safety" type="System.Concept"/>
     <ns4:element name="parent" type="QUICK.Device"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Slot" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Slot" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="serviceCategory" type="System.Concept"/>
     <ns4:element name="serviceType" type="System.Concept"/>
@@ -329,7 +329,7 @@
     <ns4:element name="overbooked" type="System.Boolean"/>
     <ns4:element name="comment" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.IndividualCareRecipient" name="QUICK.RelatedPerson" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.IndividualCareRecipient" name="QUICK.RelatedPerson" retrievable="false">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="patient" type="QUICK.Patient"/>
     <ns4:element name="relationship" type="System.Concept"/>
@@ -344,7 +344,7 @@
     </ns4:element>
     <ns4:element name="communication" type="QUICK.LanguageCompetency"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.GroupCharacteristic" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.GroupCharacteristic" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="value">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
@@ -365,7 +365,7 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.SampledData" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.SampledData" retrievable="false">
     <ns4:element name="origin" type="System.Quantity"/>
     <ns4:element name="period" type="System.Decimal"/>
     <ns4:element name="factor" type="System.Decimal"/>
@@ -377,31 +377,31 @@
   <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.MedicationDoseRate" retrievable="false" xsi:type="ns4:ClassInfo"/>
   <ns4:typeInfo baseType="QUICK.Party" name="QUICK.CareGiver" retrievable="false" xsi:type="ns4:ClassInfo"/>
   <ns4:typeInfo baseType="QUICK.Element" name="QUICK.ChoiceElement" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DoseAndRate" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DoseAndRate" retrievable="false">
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="dose" type="QUICK.MedicationDoseQuantity"/>
     <ns4:element name="rate" type="QUICK.MedicationDoseRate"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.Party" name="QUICK.CareRecipient" retrievable="false" xsi:type="ns4:ClassInfo"/>
   <ns4:typeInfo baseType="QUICK.CareGiver" name="QUICK.IndividualCareGiver" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Causality" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Causality" retrievable="false">
     <ns4:element name="assessment" type="System.Concept"/>
     <ns4:element name="productRelatedness" type="System.String"/>
     <ns4:element name="author" type="QUICK.IndividualCareGiver"/>
     <ns4:element name="method" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.GpsLocation" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.GpsLocation" retrievable="false">
     <ns4:element name="longitude" type="System.Decimal"/>
     <ns4:element name="latitude" type="System.Decimal"/>
     <ns4:element name="altitude" type="System.Decimal"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.MedicationDoseRate" name="QUICK.MedicationDosePointRate" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Contact" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Contact" retrievable="false">
     <ns4:element name="name" type="QUICK.HumanName"/>
     <ns4:element name="telecom" type="QUICK.ContactPoint"/>
     <ns4:element name="address" type="QUICK.Address"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Medication" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Medication" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="status" type="System.String"/>
@@ -411,7 +411,7 @@
     <ns4:element name="ingredient" type="QUICK.Ingredient"/>
     <ns4:element name="batch" type="QUICK.MedicationBatch"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.Procedure" primaryCodePath="code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.Procedure" primaryCodePath="code" retrievable="true">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="outcome" type="System.Concept"/>
     <ns4:element name="bodySite" type="System.Concept"/>
@@ -429,10 +429,10 @@
     <ns4:element name="partOf" type="QUICK.Event"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.CareRecipient" name="QUICK.IndividualCareRecipient" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.MedicationDosePointRate" name="QUICK.RateQuantity" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.MedicationDosePointRate" name="QUICK.RateQuantity" retrievable="false">
     <ns4:element name="value" type="System.Quantity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.GoalTarget" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.GoalTarget" retrievable="false">
     <ns4:element name="measure" type="System.Concept"/>
     <ns4:element name="detail">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
@@ -449,7 +449,7 @@
       </ns4:elementTypeSpecifier>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.ContactPoint" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.ContactPoint" retrievable="false">
     <ns4:element name="system" type="System.String"/>
     <ns4:element name="value" type="System.String"/>
     <ns4:element name="use" type="System.String"/>
@@ -458,7 +458,7 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.MedicationDispense" primaryCodePath="medication.code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.MedicationDispense" primaryCodePath="medication.code" retrievable="true">
     <ns4:element name="quantity" type="System.Quantity"/>
     <ns4:element name="daysSupply" type="System.Quantity"/>
     <ns4:element name="dosageInstruction" type="QUICK.DosageInstruction"/>
@@ -467,11 +467,11 @@
     <ns4:element name="fillNumber" type="System.Quantity"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.Request" name="QUICK.NutritionRequest" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Money" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Money" retrievable="false">
     <ns4:element name="value" type="System.Decimal"/>
     <ns4:element name="currency" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.DiagnosticReport" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.DiagnosticReport" retrievable="false">
     <ns4:element name="category" type="System.Concept"/>
     <ns4:element name="subject" type="QUICK.Party"/>
     <ns4:element name="encounter" type="QUICK.Encounter"/>
@@ -493,7 +493,7 @@
     <ns4:element name="locationPerformed" type="QUICK.Location"/>
     <ns4:element name="code" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.Condition" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.Condition" retrievable="false">
     <ns4:element name="onset">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="System" name="Quantity" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -519,7 +519,7 @@
     <ns4:element name="clinicalStatus" type="System.Concept"/>
     <ns4:element name="assertedDate" type="System.DateTime"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.FamilyMemberHistoryCondition" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.FamilyMemberHistoryCondition" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="outcome" type="System.Concept"/>
     <ns4:element name="contributedToDeath" type="System.Boolean"/>
@@ -535,13 +535,13 @@
     <ns4:element name="note" type="QUICK.Annotation"/>
   </ns4:typeInfo>
   <ns4:typeInfo name="QUICK.Element" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.NonAvailability" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.NonAvailability" retrievable="false">
     <ns4:element name="description" type="System.String"/>
     <ns4:element name="during">
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.SuspectEntity" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.SuspectEntity" retrievable="false">
     <ns4:element name="instance">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="QUICK" name="Immunization" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -555,7 +555,7 @@
     </ns4:element>
     <ns4:element name="causality" type="QUICK.Causality"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.PatientLocation" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.PatientLocation" retrievable="false">
     <ns4:element name="location" type="QUICK.Location"/>
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="physicalType" type="System.Concept"/>
@@ -563,12 +563,12 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Request" name="QUICK.ServiceRequest" primaryCodePath="code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Request" name="QUICK.ServiceRequest" primaryCodePath="code" retrievable="true">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="bodySite" type="System.Concept"/>
     <ns4:element name="doNotPerform" type="System.Boolean"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.Communication" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.Communication" retrievable="false">
     <ns4:element name="category" type="System.Concept"/>
     <ns4:element name="sender" type="QUICK.Performer"/>
     <ns4:element name="recipient" type="QUICK.Party"/>
@@ -577,7 +577,7 @@
     <ns4:element name="medium" type="System.Concept"/>
     <ns4:element name="payload" type="QUICK.CommunicationPayload"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Contact" name="QUICK.IndividualContact" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Contact" name="QUICK.IndividualContact" retrievable="false">
     <ns4:element name="relationship" type="System.Concept"/>
     <ns4:element name="gender" type="System.String"/>
     <ns4:element name="organization" type="QUICK.Organization"/>
@@ -585,11 +585,11 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.DeviceUseStatement" primaryCodePath="device.code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.DeviceUseStatement" primaryCodePath="device.code" retrievable="true">
     <ns4:element name="bodySite" type="System.Concept"/>
     <ns4:element name="device" type="QUICK.Device"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Signature" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Signature" retrievable="false">
     <ns4:element name="type" type="System.Code"/>
     <ns4:element name="when" type="System.DateTime"/>
     <ns4:element name="who" type="QUICK.Reference"/>
@@ -598,17 +598,17 @@
     <ns4:element name="sigFormat" type="System.String"/>
     <ns4:element name="data" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.SubstancePackage" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.SubstancePackage" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="expiry" type="System.DateTime"/>
     <ns4:element name="quantity" type="System.Quantity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Eligibility" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Eligibility" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="comment" type="System.String"/>
   </ns4:typeInfo>
   <ns4:typeInfo baseType="QUICK.Element" name="QUICK.BackboneElement" retrievable="false" xsi:type="ns4:ClassInfo"/>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.Encounter" primaryCodePath="class" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.Encounter" primaryCodePath="class" retrievable="true">
     <ns4:element name="class" type="System.Code"/>
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="serviceType" type="System.Concept"/>
@@ -630,7 +630,7 @@
     <ns4:element name="serviceProvider" type="QUICK.Organization"/>
     <ns4:element name="partOf" type="QUICK.Encounter"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.Observation" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.Observation" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="value">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
@@ -662,15 +662,15 @@
     <ns4:element name="dataAbsentReason" type="System.Concept"/>
     <ns4:element name="basedOn" type="QUICK.Request"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Event" name="QUICK.MedicationStatement" primaryCodePath="medication.code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Event" name="QUICK.MedicationStatement" primaryCodePath="medication.code" retrievable="true">
     <ns4:element name="dosage" type="QUICK.DosageInstruction"/>
     <ns4:element name="medication" type="QUICK.Medication"/>
     <ns4:element name="informationSource" type="QUICK.Party"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.MedicationDoseQuantity" name="QUICK.DoseQuantity" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.MedicationDoseQuantity" name="QUICK.DoseQuantity" retrievable="false">
     <ns4:element name="value" type="System.Quantity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.AllergyIntolerance" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.AllergyIntolerance" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="criticality" type="System.String"/>
     <ns4:element name="patient" type="QUICK.Patient"/>
@@ -690,7 +690,7 @@
     <ns4:element name="note" type="QUICK.Annotation"/>
     <ns4:element name="reaction" type="QUICK.Reaction"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Request" name="QUICK.DeviceRequest" primaryCodePath="code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Request" name="QUICK.DeviceRequest" primaryCodePath="code" retrievable="true">
     <ns4:element name="code">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="QUICK" name="DomainResource" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -698,24 +698,24 @@
       </ns4:elementTypeSpecifier>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.MedicationDoseRate" name="QUICK.RateRange" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.MedicationDoseRate" name="QUICK.RateRange" retrievable="false">
     <ns4:element name="value">
       <ns4:typeSpecifier pointType="System.Quantity" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Timing" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Timing" retrievable="false">
     <ns4:element name="event" type="System.DateTime"/>
     <ns4:element name="repeat" type="QUICK.TimingRepeat"/>
     <ns4:element name="code" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Contact" name="QUICK.OrganizationalContact" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Contact" name="QUICK.OrganizationalContact" retrievable="false">
     <ns4:element name="purpose" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.InitialFill" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.InitialFill" retrievable="false">
     <ns4:element name="quantity" type="System.Quantity"/>
     <ns4:element name="duration" type="System.Quantity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.HumanName" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.HumanName" retrievable="false">
     <ns4:element name="use" type="System.String"/>
     <ns4:element name="text" type="System.String"/>
     <ns4:element name="family" type="System.String"/>
@@ -726,13 +726,13 @@
       <ns4:typeSpecifier pointType="System.DateTime" xsi:type="ns4:IntervalTypeSpecifier"/>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Party" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Party" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.MedicationDosePointRate" name="QUICK.RateRatio" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.MedicationDosePointRate" name="QUICK.RateRatio" retrievable="false">
     <ns4:element name="value" type="QUICK.Ratio"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Request" name="QUICK.CommunicationRequest" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Request" name="QUICK.CommunicationRequest" retrievable="false">
     <ns4:element name="category" type="System.Concept"/>
     <ns4:element name="doNotPerform" type="System.Boolean"/>
     <ns4:element name="medium" type="System.Concept"/>
@@ -740,15 +740,15 @@
     <ns4:element name="sender" type="QUICK.Party"/>
     <ns4:element name="recipient" type="QUICK.Party"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Performer" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Performer" retrievable="false">
     <ns4:element name="function" type="System.Concept"/>
     <ns4:element name="actor" type="QUICK.Party"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.MedicationBatch" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.MedicationBatch" retrievable="false">
     <ns4:element name="lotNumber" type="System.String"/>
     <ns4:element name="expirationDate" type="System.DateTime"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.IndividualCareGiver" name="QUICK.Practitioner" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.IndividualCareGiver" name="QUICK.Practitioner" retrievable="false">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="name" type="QUICK.HumanName"/>
     <ns4:element name="telecom" type="QUICK.ContactPoint"/>
@@ -759,13 +759,13 @@
     <ns4:element name="qualification" type="QUICK.ProfessionalQualification"/>
     <ns4:element name="communication" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DosageInstruction" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DosageInstruction" retrievable="false">
     <ns4:element name="doseAndRate" type="QUICK.DoseAndRate"/>
     <ns4:element name="timing" type="QUICK.Timing"/>
     <ns4:element name="route" type="System.Concept"/>
     <ns4:element name="method" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Participation" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Participation" retrievable="false">
     <ns4:element name="role" type="System.Concept"/>
     <ns4:element name="member" type="QUICK.Party"/>
     <ns4:element name="onBehalfOf" type="QUICK.Organization"/>
@@ -775,7 +775,7 @@
     <ns4:element name="required" type="System.String"/>
     <ns4:element name="status" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DispenseRequest" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DispenseRequest" retrievable="false">
     <ns4:element name="initialFill" type="QUICK.InitialFill"/>
     <ns4:element name="dispenseInterval" type="System.Quantity"/>
     <ns4:element name="validityPeriod">
@@ -786,13 +786,13 @@
     <ns4:element name="expectedSupplyDuration" type="System.Quantity"/>
     <ns4:element name="performer" type="QUICK.Organization"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Resource" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Resource" retrievable="false">
     <ns4:element name="id" type="System.String"/>
     <ns4:element name="meta" type="QUICK.Meta"/>
     <ns4:element name="implicitRules" type="System.String"/>
     <ns4:element name="language" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.CareGiver" name="QUICK.HealthcareService" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.CareGiver" name="QUICK.HealthcareService" retrievable="false">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="providedBy" type="QUICK.Organization"/>
     <ns4:element name="category" type="System.Concept"/>
@@ -816,7 +816,7 @@
     <ns4:element name="notAvailable" type="QUICK.NonAvailability"/>
     <ns4:element name="availabilityException" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.CareGiver" name="QUICK.Organization" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.CareGiver" name="QUICK.Organization" retrievable="false">
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="name" type="System.String"/>
@@ -826,19 +826,19 @@
     <ns4:element name="partOf" type="QUICK.Organization"/>
     <ns4:element name="contact" type="QUICK.OrganizationalContact"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Request" name="QUICK.MedicationRequest" primaryCodePath="medication.code" retrievable="true" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Request" name="QUICK.MedicationRequest" primaryCodePath="medication.code" retrievable="true">
     <ns4:element name="dosageInstruction" type="QUICK.DosageInstruction"/>
     <ns4:element name="dispenseRequest" type="QUICK.DispenseRequest"/>
     <ns4:element name="category" type="System.Concept"/>
     <ns4:element name="medication" type="QUICK.Medication"/>
     <ns4:element name="doNotPerform" type="System.Boolean"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.DeviceVersion" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.DeviceVersion" retrievable="false">
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="component" type="QUICK.Identifier"/>
     <ns4:element name="value" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Request" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Request" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="intent" type="System.String"/>
     <ns4:element name="reasonCode" type="System.Concept"/>
@@ -848,13 +848,13 @@
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="statusReason" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Finding" name="QUICK.FamilyMemberHistory" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Finding" name="QUICK.FamilyMemberHistory" retrievable="false">
     <ns4:element name="date" type="System.DateTime"/>
     <ns4:element name="relationship" type="System.Concept"/>
     <ns4:element name="condition" type="QUICK.FamilyMemberHistoryCondition"/>
     <ns4:element name="patient" type="QUICK.Patient"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Event" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Event" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="statusReason" type="System.Concept"/>
@@ -873,7 +873,7 @@
     <ns4:element name="basedOn" type="QUICK.Request"/>
     <ns4:element name="recorded" type="System.DateTime"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Identifier" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Identifier" retrievable="false">
     <ns4:element name="use" type="System.String"/>
     <ns4:element name="type" type="System.Concept"/>
     <ns4:element name="system" type="System.String"/>
@@ -883,7 +883,7 @@
     </ns4:element>
     <ns4:element name="assigner" type="QUICK.Reference"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.ObservationComponent" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.ObservationComponent" retrievable="false">
     <ns4:element name="code" type="System.Concept"/>
     <ns4:element name="value">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
@@ -902,7 +902,7 @@
     <ns4:element name="dataAbsentReason" type="System.Concept"/>
     <ns4:element name="interpretation" type="System.Concept"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.Reaction" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.Reaction" retrievable="false">
     <ns4:element name="substance" type="System.Concept"/>
     <ns4:element name="manifestation" type="System.Concept"/>
     <ns4:element name="description" type="System.String"/>
@@ -911,11 +911,11 @@
     <ns4:element name="exposureRoute" type="System.Concept"/>
     <ns4:element name="note" type="QUICK.Annotation"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Ratio" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Ratio" retrievable="false">
     <ns4:element name="numerator" type="System.Quantity"/>
     <ns4:element name="denominator" type="System.Quantity"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.CommunicationPayload" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.CommunicationPayload" retrievable="false">
     <ns4:element name="content">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="System" name="String" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -924,7 +924,7 @@
       </ns4:elementTypeSpecifier>
     </ns4:element>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Annotation" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Annotation" retrievable="false">
     <ns4:element name="author">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="QUICK" name="DomainResource" xsi:type="ns4:NamedTypeSpecifier"/>
@@ -934,7 +934,7 @@
     <ns4:element name="time" type="System.DateTime"/>
     <ns4:element name="text" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Schedule" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Schedule" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="active" type="System.Boolean"/>
     <ns4:element name="serviceCategory" type="System.Concept"/>
@@ -946,7 +946,7 @@
     </ns4:element>
     <ns4:element name="comment" type="System.String"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.DomainResource" name="QUICK.Substance" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.DomainResource" name="QUICK.Substance" retrievable="false">
     <ns4:element name="identifier" type="QUICK.Identifier"/>
     <ns4:element name="status" type="System.String"/>
     <ns4:element name="category" type="System.Concept"/>
@@ -955,7 +955,7 @@
     <ns4:element name="instance" type="QUICK.SubstancePackage"/>
     <ns4:element name="ingredient" type="QUICK.Ingredient"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.Element" name="QUICK.Attachment" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.Element" name="QUICK.Attachment" retrievable="false">
     <ns4:element name="contentType" type="System.String"/>
     <ns4:element name="language" type="System.String"/>
     <ns4:element name="data" type="System.String"/>
@@ -965,7 +965,7 @@
     <ns4:element name="title" type="System.String"/>
     <ns4:element name="creation" type="System.DateTime"/>
   </ns4:typeInfo>
-  <ns4:typeInfo baseType="QUICK.BackboneElement" name="QUICK.TimingRepeat" retrievable="false" xsi:type="ns4:ClassInfo">
+  <ns4:typeInfo xsi:type="ns4:ClassInfo" baseType="QUICK.BackboneElement" name="QUICK.TimingRepeat" retrievable="false">
     <ns4:element name="bounds">
       <ns4:elementTypeSpecifier xsi:type="ns4:ChoiceTypeSpecifier">
         <ns4:choice modelName="System" name="Quantity" xsi:type="ns4:NamedTypeSpecifier"/>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/uscore-modelinfo-3.1.0.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/uscore-modelinfo-3.1.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="USCore" version="3.1.0" url="http://hl7.org/fhir/us/core" targetUrl="http://hl7.org/fhir" targetQualifier="uscore" patientClassName="PatientProfile" patientBirthDatePropertyName="birthDate">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="USCore.AddressUse"/>
       <element name="type" elementType="USCore.AddressType"/>
       <element name="text" elementType="System.String" target="%value.value"/>
@@ -22,7 +22,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance" label="US  Core AllergyIntolerance Profile" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance" label="US  Core AllergyIntolerance Profile" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -63,7 +63,7 @@
       <contextRelationship context="Patient" relatedKeyElement="recorder"/>
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manifestation" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -80,7 +80,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" target="USCore.Reference:null;System.String:%value.value">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="USCore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -90,7 +90,7 @@
       <element name="time" elementType="System.DateTime" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="USCore.MimeType"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
@@ -100,7 +100,7 @@
       <element name="title" elementType="System.String" target="%value.value"/>
       <element name="creation" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension">
          <elementTypeSpecifier elementType="USCore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -109,7 +109,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="BodyLengthUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="BodyTempUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="BodyWeightUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -122,7 +122,7 @@
       <element name="reference" elementType="USCore.Reference"/>
       <element name="detail" elementType="USCore.CarePlan.Activity.Detail"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="USCore.CarePlanActivityKind"/>
       <element name="instantiatesCanonical" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -168,7 +168,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="CarePlanProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan" label="US Core CarePlan Profile" target="CarePlan" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="CarePlanProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan" label="US Core CarePlan Profile" target="CarePlan" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -226,7 +226,7 @@
          <elementTypeSpecifier elementType="USCore.Annotation" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="CareTeam" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam" label="US Core CareTeam Profile" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="CareTeam" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam" label="US Core CareTeam Profile" retrievable="true" primaryCodePath="category">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -263,7 +263,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="member"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CareTeam.Participant" retrievable="false">
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="member" elementType="USCore.Reference"/>
       <element name="onBehalfOf" elementType="USCore.Reference"/>
@@ -273,7 +273,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Condition" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition" label="US Core Condition Profile" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Condition" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition" label="US Core Condition Profile" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -330,7 +330,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Evidence" retrievable="false">
       <element name="code" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -338,20 +338,20 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="assessment">
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="telecom">
          <elementTypeSpecifier elementType="USCore.ContactPoint" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="USCore.ContactPointSystem"/>
       <element name="value" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="USCore.ContactPointUse"/>
@@ -364,7 +364,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="USCore.ContributorType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="contact">
@@ -372,7 +372,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="USCore.FHIRAllTypes"/>
       <element name="profile" target="%value.value">
          <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
@@ -397,7 +397,7 @@
          <elementTypeSpecifier elementType="USCore.DataRequirement.Sort" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="valueSet" elementType="System.String" target="%value.value"/>
@@ -405,7 +405,7 @@
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="searchParam" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value)">
@@ -418,17 +418,17 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value"/>
       <element name="direction" elementType="USCore.SortDirection"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="USCore.DeviceNameType"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Property" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="valueQuantity" target="FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
@@ -437,11 +437,11 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="version" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="System.String" target="%value.value"/>
       <element name="issuer" elementType="System.String" target="%value.value"/>
       <element name="jurisdiction" elementType="System.String" target="%value.value"/>
@@ -449,17 +449,17 @@
       <element name="carrierHRF" elementType="System.String" target="%value.value"/>
       <element name="entryType" elementType="USCore.UDIEntryType"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Version" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="component" elementType="USCore.Identifier"/>
       <element name="value" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="System.String" target="%value.value"/>
       <element name="link" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileLaboratoryReporting" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab" label="US Core DiagnosticReport Profile for Laboratory Results Reporting" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileLaboratoryReporting" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab" label="US Core DiagnosticReport Profile for Laboratory Results Reporting" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -509,7 +509,7 @@
          <elementTypeSpecifier elementType="USCore.Attachment" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileNoteExchange" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note" label="US Core DiagnosticReport Profile for Report and Note exchange" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileNoteExchange" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note" label="US Core DiagnosticReport Profile for Report and Note exchange" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -558,11 +558,11 @@
          <elementTypeSpecifier elementType="USCore.Attachment" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Content" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Content" retrievable="false">
       <element name="attachment" elementType="USCore.Attachment"/>
       <element name="format" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Context" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Context" retrievable="false">
       <element name="encounter" elementType="USCore.Reference"/>
       <element name="event" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -579,11 +579,11 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.RelatesTo" retrievable="false">
       <element name="code" elementType="USCore.DocumentRelationshipType"/>
       <element name="target" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DocumentReferenceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference" label="US Core DocumentReference Profile" target="DocumentReference" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DocumentReferenceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference" label="US Core DocumentReference Profile" target="DocumentReference" retrievable="true">
       <element name="masterIdentifier" elementType="USCore.Identifier"/>
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
@@ -612,7 +612,7 @@
       <element name="context" elementType="USCore.DocumentReference.Context"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DocumentRelationshipType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Resource" namespace="USCore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Resource" namespace="USCore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="USCore.Narrative"/>
       <element name="contained">
          <elementTypeSpecifier elementType="USCore.Resource" xsi:type="ListTypeSpecifier"/>
@@ -624,7 +624,7 @@
          <elementTypeSpecifier elementType="USCore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="additionalInstruction" target="FHIRHelpers.ToConcept(%value)">
@@ -648,7 +648,7 @@
       <element name="maxDosePerAdministration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="maxDosePerLifetime" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="dose" target="System.Quantity:FHIRHelpers.ToQuantity(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -668,13 +668,13 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="USCore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="USCore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="extension">
          <elementTypeSpecifier elementType="USCore.Extension" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -682,12 +682,12 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="USCore.Reference"/>
       <element name="use" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="rank" elementType="System.Integer" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="USCore.Identifier"/>
       <element name="origin" elementType="USCore.Reference"/>
       <element name="admitSource" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -704,7 +704,7 @@
       <element name="destination" elementType="USCore.Reference"/>
       <element name="dischargeDisposition" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="USCore.Reference"/>
       <element name="status" elementType="USCore.EncounterLocationStatus"/>
       <element name="physicalType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -714,7 +714,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Participant" retrievable="false">
       <element name="type" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -725,7 +725,7 @@
       </element>
       <element name="individual" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="USCore.EncounterStatus"/>
       <element name="period">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -734,7 +734,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="EncounterProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter" label="US Core Encounter Profile" target="Encounter" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="EncounterProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter" label="US Core Encounter Profile" target="Encounter" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -790,7 +790,7 @@
       <element name="partOf" elementType="USCore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Extension" namespace="USCore" name="EthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Extension" namespace="USCore" name="EthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false">
       <element name="ombCategory" elementType="System.Code" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)"/>
       <element name="detailed" target="FHIRHelpers.ToCode(%parent.extension[url='detailed'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
@@ -799,14 +799,14 @@
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
       <element name="expression" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="System.String" target="%value.value"/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;USCore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);USCore.Annotation:null;USCore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);USCore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);USCore.HumanName:null;USCore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);USCore.Reference:null;USCore.SampledData:null;USCore.Signature:null;USCore.Timing:null;USCore.ContactDetail:null;USCore.Contributor:null;USCore.DataRequirement:null;USCore.Expression:null;USCore.ParameterDefinition:null;USCore.RelatedArtifact:null;USCore.TriggerDefinition:null;USCore.UsageContext:null;USCore.Dosage:null;USCore.Meta:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -869,7 +869,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="FHIRAllTypes" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="detail" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Ratio:FHIRHelpers.ToRatio(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -886,7 +886,7 @@
       </element>
       <element name="due" elementType="System.Date" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="GoalProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal" label="US Core Goal Profile" target="Goal" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="GoalProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal" label="US Core Goal Profile" target="Goal" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -923,7 +923,7 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="USCore.NameUse"/>
       <element name="text" elementType="System.String" target="%value.value"/>
       <element name="family" elementType="System.String" target="%value.value"/>
@@ -942,7 +942,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="USCore.IdentifierUse"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="system" elementType="System.String" target="%value.value"/>
@@ -955,17 +955,17 @@
       <element name="assigner" elementType="USCore.Reference"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="System.String" target="%value.value"/>
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="publicationDate" elementType="System.DateTime" target="%value.value"/>
       <element name="presentationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="System.String" target="%value.value"/>
       <element name="authority" elementType="USCore.Reference"/>
       <element name="targetDisease" target="FHIRHelpers.ToConcept(%value)">
@@ -984,12 +984,12 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="System.DateTime" target="%value.value"/>
       <element name="detail" elementType="USCore.Reference"/>
       <element name="reported" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ImmunizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization" label="US Core Immunization Profile" target="Immunization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ImmunizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization" label="US Core Immunization Profile" target="Immunization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1044,7 +1044,7 @@
          <elementTypeSpecifier elementType="USCore.Immunization.ProtocolApplied" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1090,7 +1090,7 @@
       </element>
       <element name="parent" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="LaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="LaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1167,7 +1167,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Location" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-location" label="US Core Location Profile" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Location" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-location" label="US Core Location Profile" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1198,7 +1198,7 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="USCore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1206,18 +1206,18 @@
       <element name="openingTime" elementType="System.Time" target="%value.value"/>
       <element name="closingTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="System.Decimal" target="%value.value"/>
       <element name="latitude" elementType="System.Decimal" target="%value.value"/>
       <element name="altitude" elementType="System.Decimal" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="LocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="System.String" target="%value.value"/>
       <element name="expirationDate" elementType="System.DateTime" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Ingredient" retrievable="false">
       <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);USCore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
@@ -1227,7 +1227,7 @@
       <element name="isActive" elementType="System.Boolean" target="%value.value"/>
       <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="MedicationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication" label="US Core Medication Profile" target="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="MedicationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication" label="US Core Medication Profile" target="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1241,7 +1241,7 @@
       </element>
       <element name="batch" elementType="USCore.Medication.Batch"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="initialFill" elementType="USCore.MedicationRequest.DispenseRequest.InitialFill"/>
       <element name="dispenseInterval" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="validityPeriod">
@@ -1254,11 +1254,11 @@
       <element name="expectedSupplyDuration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="performer" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -1268,7 +1268,7 @@
       <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="MedicationRequestProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest" label="US Core MedicationRequest Profile" target="MedicationRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="MedicationRequestProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest" label="US Core MedicationRequest Profile" target="MedicationRequest" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1339,7 +1339,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="System.String" target="%value.value"/>
       <element name="lastUpdated" elementType="System.DateTime" target="%value.value"/>
       <element name="source" elementType="System.String" target="%value.value"/>
@@ -1355,12 +1355,12 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="USCore.NarrativeStatus"/>
       <element name="div" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="NarrativeStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Observation.Component" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;;System.Ratio:FHIRHelpers.ToRatio(%value);USCore.SampledData:null;System.Time:%value.value;System.DateTime:%value.value;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -1395,7 +1395,7 @@
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.DiastolicBP" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.FlowRate" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.SystolicBP" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="high" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
@@ -1409,7 +1409,7 @@
       </element>
       <element name="text" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="name" elementType="USCore.HumanName"/>
       <element name="telecom">
@@ -1417,7 +1417,7 @@
       </element>
       <element name="address" elementType="USCore.Address"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="OrganizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization" label="US Core Organization Profile" target="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="OrganizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization" label="US Core Organization Profile" target="Organization" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1445,7 +1445,7 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="use" elementType="USCore.ParameterUse"/>
       <element name="min" elementType="System.Integer" target="%value.value"/>
@@ -1455,11 +1455,11 @@
       <element name="profile" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="preferred" elementType="System.Boolean" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Contact" retrievable="false">
       <element name="relationship" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1476,11 +1476,11 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Link" retrievable="false">
       <element name="other" elementType="USCore.Reference"/>
       <element name="type" elementType="USCore.LinkType"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PatientProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" label="US Core Patient Profile" target="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PatientProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" label="US Core Patient Profile" target="Patient" retrievable="true">
       <element name="race" elementType="USCore.RaceExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']"/>
       <element name="ethnicity" elementType="USCore.EthnicityExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']"/>
       <element name="birthsex" elementType="USCore.BirthSexExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'].value.value"/>
@@ -1529,7 +1529,7 @@
          <elementTypeSpecifier elementType="USCore.Patient.Link" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1587,7 +1587,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1645,7 +1645,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1657,7 +1657,7 @@
       </element>
       <element name="issuer" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PractitionerProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner" label="US Core Practitioner Profile" target="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PractitionerProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner" label="US Core Practitioner Profile" target="Practitioner" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1684,7 +1684,7 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek">
          <elementTypeSpecifier elementType="USCore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1692,7 +1692,7 @@
       <element name="availableStartTime" elementType="System.Time" target="%value.value"/>
       <element name="availableEndTime" elementType="System.Time" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value"/>
       <element name="during">
          <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
@@ -1700,7 +1700,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PractitionerRoleProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole" label="US Core PractitionerRole Profile" target="PractitionerRole" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PractitionerRoleProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole" label="US Core PractitionerRole Profile" target="PractitionerRole" retrievable="true">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1738,16 +1738,16 @@
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="manipulated" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="actor" elementType="USCore.Reference"/>
       <element name="onBehalfOf" elementType="USCore.Reference"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ProcedureProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure" label="US Core Procedure Profile" target="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ProcedureProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure" label="US Core Procedure Profile" target="Procedure" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1818,7 +1818,7 @@
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Provenance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance" label="US Core Provenance Profile" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Provenance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance" label="US Core Provenance Profile" retrievable="true">
       <element name="target">
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1854,7 +1854,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="where(resolve() is Patient)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Agent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Agent" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
       <element name="role" target="FHIRHelpers.ToConcept(%value)">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
@@ -1864,7 +1864,7 @@
    </typeInfo>
    <typeInfo baseType="USCore.Provenance.Agent" namespace="USCore" name="Provenance.Agent.ProvenanceAuthor" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Provenance.Agent" namespace="USCore" name="Provenance.Agent.ProvenanceTransmitter" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Entity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Entity" retrievable="false">
       <element name="role" elementType="USCore.ProvenanceEntityRole"/>
       <element name="what" elementType="USCore.Reference"/>
       <element name="agent">
@@ -1874,7 +1874,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ProvenanceEntityRole" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1937,7 +1937,7 @@
       <element name="Concentration" elementType="USCore.Observation.Component"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Extension" namespace="USCore" name="RaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Extension" namespace="USCore" name="RaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false">
       <element name="ombCategory" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1947,14 +1947,14 @@
       <element name="text" elementType="System.String" target="%parent.extension[url='text'].value.value"/>
       <element name="url" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="System.String" target="%value.value"/>
       <element name="type" elementType="System.String" target="%value.value"/>
       <element name="identifier" elementType="USCore.Identifier"/>
       <element name="display" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ReferredDocumentStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="USCore.RelatedArtifactType"/>
       <element name="label" elementType="System.String" target="%value.value"/>
       <element name="display" elementType="System.String" target="%value.value"/>
@@ -1964,13 +1964,13 @@
       <element name="resource" elementType="System.String" target="%value.value"/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="System.Any" namespace="USCore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="USCore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="System.String" target="%value.value"/>
       <element name="meta" elementType="USCore.Meta"/>
       <element name="implicitRules" elementType="System.String" target="%value.value"/>
       <element name="language" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
       <element name="period" elementType="System.Decimal" target="%value.value"/>
       <element name="factor" elementType="System.Decimal" target="%value.value"/>
@@ -1979,7 +1979,7 @@
       <element name="dimensions" elementType="System.Integer" target="%value.value"/>
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" target="FHIRHelpers.ToCode(%value)">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -1990,7 +1990,7 @@
       <element name="sigFormat" elementType="USCore.MimeType"/>
       <element name="data" elementType="System.String" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="SmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="SmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2051,14 +2051,14 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="Status" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" target="%value.value">
          <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
       </element>
       <element name="repeat" elementType="USCore.Timing.Repeat"/>
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Timing.Repeat" retrievable="false">
       <element name="bounds" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -2091,7 +2091,7 @@
       </element>
       <element name="offset" elementType="System.Integer" target="%value.value"/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="USCore.TriggerType"/>
       <element name="name" elementType="System.String" target="%value.value"/>
       <element name="timing" target="USCore.Timing:null;USCore.Reference:null;System.Date:%value.value;System.DateTime:%value.value">
@@ -2110,7 +2110,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
       <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;USCore.Reference:null">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -2123,7 +2123,7 @@
          </elementTypeSpecifier>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2182,7 +2182,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2241,7 +2241,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2300,7 +2300,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2359,7 +2359,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2420,7 +2420,7 @@
       <element name="SystolicBP" elementType="USCore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8480-6']"/>
       <element name="DiastolicBP" elementType="USCore.Observation.Component" target="%parent.component[code.coding.system='http://loinc.org',code.coding.code='8462-4']"/>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2479,7 +2479,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2538,7 +2538,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2597,7 +2597,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>
@@ -2656,7 +2656,7 @@
          <elementTypeSpecifier elementType="USCore.Observation.Component" xsi:type="ListTypeSpecifier"/>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
       </element>

--- a/Src/java/quick/src/main/resources/org/hl7/fhir/uscore-modelinfo-3.1.1.xml
+++ b/Src/java/quick/src/main/resources/org/hl7/fhir/uscore-modelinfo-3.1.1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="USCore" version="3.1.1" url="http://hl7.org/fhir/us/core" targetUrl="http://hl7.org/fhir" targetQualifier="uscore" patientClassName="PatientProfile" patientBirthDatePropertyName="birthDate">
    <requiredModelInfo name="System" version="1.0.0"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false">
       <element name="use" elementType="USCore.AddressUse" description="home | work | temp | old | billing - purpose of this address" definition="The purpose of this address." comment="Applications can assume that an address is current unless it explicitly says that it is temporary or old.">
          <binding name="AddressUse" description="The use of an address." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -62,7 +62,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance" label="US  Core AllergyIntolerance Profile" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="AllergyIntolerance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance" label="US  Core AllergyIntolerance Profile" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External ids for this item" definition="Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -168,7 +168,7 @@
       <contextRelationship context="Patient" relatedKeyElement="recorder"/>
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="AllergyIntolerance.Reaction" retrievable="false">
       <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Specific substance or pharmaceutical product considered to be responsible for event" definition="Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance." comment="Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, &quot;penicillins&quot;), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, &quot;amoxycillin&quot;). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.">
          <binding name="SubstanceCode" description="Codes defining the type of the substance (including pharmaceutical products)." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -215,7 +215,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false">
       <element name="author" target="USCore.Reference:null;System.String:%value.value" description="Individual responsible for the annotation" definition="The individual responsible for making the annotation." comment="Organization is used when there's no need for specific attribution as to who made the comment.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="USCore" name="Reference" xsi:type="NamedTypeSpecifier"/>
@@ -236,7 +236,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false">
       <element name="contentType" elementType="USCore.MimeType" description="Mime type of the content, with charset etc." definition="Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.">
          <binding name="MimeType" description="The mime type of an attachment. Any valid mime type is allowed." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -280,7 +280,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false">
       <element name="modifierExtension" description="Extensions that cannot be ignored even if unrecognized" definition="May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.&#xa;&#xa;Modifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself)." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="USCore.Extension" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -295,7 +295,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="BodyLengthUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="BodyTempUnits" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="BodyWeightUnits" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity" retrievable="false">
       <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)" description="Results of the activity" definition="Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not)." comment="Note that this should not duplicate the activity status (e.g. completed or in progress).">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="CarePlanActivityOutcome" description="Identifies the results of the activity." strength="Example"/>
@@ -326,7 +326,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CarePlan.Activity.Detail" retrievable="false">
       <element name="kind" elementType="USCore.CarePlanActivityKind" description="Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription" definition="A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.">
          <binding name="CarePlanActivityKind" description="Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -437,7 +437,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="CarePlanProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan" label="US Core CarePlan Profile" target="CarePlan" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="CarePlanProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan" label="US Core CarePlan Profile" target="CarePlan" retrievable="true">
       <element name="identifier" description="External Ids for this plan" definition="Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -583,7 +583,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="CareTeam" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam" label="US Core CareTeam Profile" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="CareTeam" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam" label="US Core CareTeam Profile" retrievable="true" primaryCodePath="category">
       <element name="identifier" description="External Ids for this team" definition="Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -669,7 +669,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="member"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="CareTeam.Participant" retrievable="false">
       <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of involvement" definition="Indicates specific responsibility of an individual within the care team, such as &quot;Primary care physician&quot;, &quot;Trained social worker counselor&quot;, &quot;Caregiver&quot;, etc." comment="Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly." mustSupport="true">
          <binding description="Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -695,7 +695,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Condition" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition" label="US Core Condition Profile" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Condition" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition" label="US Core Condition Profile" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External Ids for this condition" definition="Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -824,7 +824,7 @@
       <contextRelationship context="Patient" relatedKeyElement="patient"/>
       <contextRelationship context="Patient" relatedKeyElement="asserter"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Evidence" retrievable="false">
       <element name="code" target="FHIRHelpers.ToConcept(%value)" description="Manifestation/symptom" definition="A manifestation or symptom that led to the recording of this condition.">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ManifestationOrSymptom" description="Codes that describe the manifestation or symptoms of a condition." strength="Example"/>
@@ -839,7 +839,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Condition.Stage" retrievable="false">
       <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Simple summary (disease specific)" definition="A simple summary of the stage such as &quot;Stage 3&quot;. The determination of the stage is disease-specific.">
          <binding name="ConditionStage" description="Codes describing condition stages (e.g. Cancer stages)." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -859,7 +859,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="Name of an individual to contact" definition="The name of an individual to contact." comment="If there is no named individual, the telecom information is for the organization as a whole.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -872,7 +872,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false">
       <element name="system" elementType="USCore.ContactPointSystem" description="phone | fax | email | pager | url | sms | other" definition="Telecommunications form for contact point - what communications system is required to make use of the contact.">
          <binding name="ContactPointSystem" description="Telecommunications form for contact point." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -906,7 +906,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false">
       <element name="type" elementType="USCore.ContributorType" description="author | editor | reviewer | endorser" definition="The type of contributor.">
          <binding name="ContributorType" description="The type of contributor." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -926,7 +926,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false">
       <element name="type" elementType="USCore.FHIRAllTypes" description="The type of the required data" definition="The type of the required data, specified as the type name of a resource. For profiles, this value is set to the type of the base resource of the profile.">
          <binding name="FHIRAllTypes" description="A list of all the concrete types defined in this version of the FHIR specification - Abstract Types, Data Types and Resource Types." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -985,7 +985,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.CodeFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="A code-valued attribute to filter on" definition="The code-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type code, Coding, or CodeableConcept." comment="The path attribute contains a [Simple FHIRPath Subset](fhirpath.html#simple) that allows path traversal, but not calculation.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1008,7 +1008,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.DateFilter" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="A date-valued attribute to filter on" definition="The date-valued attribute of the filter. The specified path SHALL be a FHIRPath resolveable on the specified type of the DataRequirement, and SHALL consist only of identifiers, constant indexers, and .resolve(). The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements (see the [Simple FHIRPath Profile](fhirpath.html#simple) for full details). Note that the index must be an integer constant. The path must resolve to an element of type date, dateTime, Period, Schedule, or Timing." comment="The path attribute contains a [Simple FHIR Subset](fhirpath.html#simple) that allows path traversal, but not calculation.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1032,7 +1032,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="DataRequirement.Sort" retrievable="false">
       <element name="path" elementType="System.String" target="%value.value" description="The name of the attribute to perform the sort" definition="The attribute of the sort. The specified path must be resolvable from the type of the required data. The path is allowed to contain qualifiers (.) to traverse sub-elements, as well as indexers ([x]) to traverse multiple-cardinality sub-elements. Note that the index must be an integer constant.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1047,7 +1047,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.DeviceName" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="The name of the device" definition="The name of the device.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1060,7 +1060,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Property" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Code that specifies the property DeviceDefinitionPropetyCode (Extensible)" definition="Code that specifies the property DeviceDefinitionPropetyCode (Extensible).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1079,7 +1079,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Specialization" retrievable="false">
       <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The standard that is used to operate and communicate" definition="The standard that is used to operate and communicate.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1091,7 +1091,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.UdiCarrier" retrievable="false">
       <element name="deviceIdentifier" elementType="System.String" target="%value.value" description="Mandatory fixed portion of UDI" definition="The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1124,7 +1124,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Device.Version" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The type of the device version" definition="The type of the device version.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1142,7 +1142,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DiagnosticReport.Media" retrievable="false">
       <element name="comment" elementType="System.String" target="%value.value" description="Comment about the image (e.g. explanation)" definition="A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features." comment="The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1154,7 +1154,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileLaboratoryReporting" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab" label="US Core DiagnosticReport Profile for Laboratory Results Reporting" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileLaboratoryReporting" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab" label="US Core DiagnosticReport Profile for Laboratory Results Reporting" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for report" definition="Identifiers assigned to this report by the performer or other systems." comment="Usually assigned by the Information System of the diagnostic service provider (filler id).">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1273,7 +1273,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileNoteExchange" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note" label="US Core DiagnosticReport Profile for Report and Note exchange" target="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DiagnosticReportProfileNoteExchange" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note" label="US Core DiagnosticReport Profile for Report and Note exchange" target="DiagnosticReport" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for report" definition="Identifiers assigned to this report by the performer or other systems." comment="Usually assigned by the Information System of the diagnostic service provider (filler id).">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1386,7 +1386,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Content" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Content" retrievable="false">
       <element name="attachment" elementType="USCore.Attachment" description="Where to access the document" definition="The document or URL of the document along with critical metadata to prove content has integrity." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1402,7 +1402,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Context" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.Context" retrievable="false">
       <element name="encounter" elementType="USCore.Reference" description="Context of the document  content" definition="Describes the clinical encounter or type of care that the document content is associated with." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1447,7 +1447,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="DocumentReference.RelatesTo" retrievable="false">
       <element name="code" elementType="USCore.DocumentRelationshipType" description="replaces | transforms | signs | appends" definition="The type of relationship that this document has with anther document." comment="If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.">
          <binding name="DocumentRelationshipType" description="The type of relationship between documents." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1460,7 +1460,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="DocumentReferenceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference" label="US Core DocumentReference Profile" target="DocumentReference" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="DocumentReferenceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference" label="US Core DocumentReference Profile" target="DocumentReference" retrievable="true">
       <element name="masterIdentifier" elementType="USCore.Identifier" description="Master Version Specific Identifier" definition="Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document." comment="CDA Document Id extension and root.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1554,7 +1554,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="DocumentRelationshipType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Resource" namespace="USCore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Resource" namespace="USCore" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true">
       <element name="text" elementType="USCore.Narrative" description="Text summary of the resource, for human interpretation" definition="A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it &quot;clinically safe&quot; for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety." comment="Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a &quot;text blob&quot; or where text is additionally entered raw or narrated and encoded information is added later.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1582,7 +1582,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false">
       <element name="sequence" elementType="System.Integer" target="%value.value" description="The order of the dosage instructions" definition="Indicates the order in which the dosage instructions should be applied or interpreted.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1660,7 +1660,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Dosage.DoseAndRate" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The kind of dose or rate specified" definition="The kind of dose or rate specified, for example, ordered or calculated.">
          <binding name="DoseAndRateType" description="The kind of dose or rate specified." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1691,7 +1691,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="System.Any" namespace="USCore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="USCore" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false">
       <element name="id" elementType="System.String" target="%value.value" description="Unique id for inter-element referencing" definition="Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces."/>
       <element name="extension" description="Additional content defined by implementations" definition="May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension." comment="There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.">
          <elementTypeSpecifier elementType="USCore.Extension" xsi:type="ListTypeSpecifier"/>
@@ -1703,7 +1703,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.ClassHistory" retrievable="false">
       <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)" description="inpatient | outpatient | ambulatory | emergency +" definition="inpatient | outpatient | ambulatory | emergency +.">
          <binding name="EncounterClass" description="Classification of the encounter." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1719,7 +1719,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Diagnosis" retrievable="false">
       <element name="condition" elementType="USCore.Reference" description="The diagnosis or procedure relevant to the encounter" definition="Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure." comment="For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1737,7 +1737,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Hospitalization" retrievable="false">
       <element name="preAdmissionIdentifier" elementType="USCore.Identifier" description="Pre-admission identifier" definition="Pre-admission identifier.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1793,7 +1793,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Location" retrievable="false">
       <element name="location" elementType="USCore.Reference" description="Location the encounter takes place" definition="The location where the encounter takes place." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -1820,7 +1820,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.Participant" retrievable="false">
       <element name="type" target="FHIRHelpers.ToConcept(%value)" description="Role of participant in encounter" definition="Role of participant in encounter." comment="The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc." mustSupport="true">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ParticipantType" description="Role of participant in encounter." strength="Extensible"/>
@@ -1842,7 +1842,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Encounter.StatusHistory" retrievable="false">
       <element name="status" elementType="USCore.EncounterStatus" description="planned | arrived | triaged | in-progress | onleave | finished | cancelled +" definition="planned | arrived | triaged | in-progress | onleave | finished | cancelled +.">
          <binding name="EncounterStatus" description="Current state of the encounter." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1859,7 +1859,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="EncounterProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter" label="US Core Encounter Profile" target="Encounter" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="EncounterProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter" label="US Core Encounter Profile" target="Encounter" retrievable="true">
       <element name="identifier" description="Identifier(s) by which this encounter is known" definition="Identifier(s) by which this encounter is known." mustSupport="true">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -1999,7 +1999,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Extension" namespace="USCore" name="EthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Extension" namespace="USCore" name="EthnicityExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity" label="US Core Ethnicity Extension" retrievable="false">
       <element name="ombCategory" elementType="System.Code" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)" description="Hispanic or Latino|Not Hispanic or Latino" definition="The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf)." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2028,7 +2028,7 @@
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value" description="Natural language description of the condition" definition="A brief, natural language description of the condition that effectively communicates the intended semantics.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2056,7 +2056,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false">
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
       <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;USCore.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);USCore.Annotation:null;USCore.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);USCore.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);USCore.HumanName:null;USCore.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);USCore.Reference:null;USCore.SampledData:null;USCore.Signature:null;USCore.Timing:null;USCore.ContactDetail:null;USCore.Contributor:null;USCore.DataRequirement:null;USCore.Expression:null;USCore.ParameterDefinition:null;USCore.RelatedArtifact:null;USCore.TriggerDefinition:null;USCore.UsageContext:null;USCore.Dosage:null;USCore.Meta:null" description="Value of extension" definition="Value of extension - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
@@ -2122,7 +2122,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="FHIRAllTypes" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Goal.Target" retrievable="false">
       <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The parameter whose value is being tracked" definition="The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.">
          <binding name="GoalTargetMeasure" description="Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2152,7 +2152,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="GoalProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal" label="US Core Goal Profile" target="Goal" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="GoalProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal" label="US Core Goal Profile" target="Goal" retrievable="true">
       <element name="identifier" description="External Ids for this goal" definition="Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2255,7 +2255,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false">
       <element name="use" elementType="USCore.NameUse" description="usual | official | temp | nickname | anonymous | old | maiden" definition="Identifies the purpose for this name." comment="Applications can assume that a name is current unless it explicitly says that it is temporary or old.">
          <binding name="NameUse" description="The use of a human name." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2299,7 +2299,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false">
       <element name="use" elementType="USCore.IdentifierUse" description="usual | official | temp | secondary | old (If known)" definition="The purpose of this identifier." comment="Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.">
          <binding name="IdentifierUse" description="Identifies the purpose for this identifier, if known ." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2337,7 +2337,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Education" retrievable="false">
       <element name="documentType" elementType="System.String" target="%value.value" description="Educational material document identifier" definition="Identifier of the material presented to the patient.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2359,7 +2359,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="What type of performance was done" definition="Describes the type of performance (e.g. ordering provider, administering provider, etc.).">
          <binding name="ImmunizationFunction" description="The role a practitioner or organization plays in the immunization event." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2372,7 +2372,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.ProtocolApplied" retrievable="false">
       <element name="series" elementType="System.String" target="%value.value" description="Name of vaccine series" definition="One possible path to achieve presumed immunity against a disease - within the context of an authority.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2409,7 +2409,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Immunization.Reaction" retrievable="false">
       <element name="date" elementType="System.DateTime" target="%value.value" description="When reaction started" definition="Date of reaction to the immunization.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -2426,7 +2426,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ImmunizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization" label="US Core Immunization Profile" target="Immunization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ImmunizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization" label="US Core Immunization Profile" target="Immunization" retrievable="true">
       <element name="identifier" description="Business identifier" definition="A unique identifier assigned to this immunization record.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2598,7 +2598,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ImplantableDeviceProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device" label="US Core Implantable Device Profile" target="Device" retrievable="true">
       <element name="identifier" description="Instance identifier" definition="Unique instance identifiers assigned to a device by manufacturers other organizations or owners." comment="The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2742,7 +2742,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="LaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="LaboratoryResultObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab" label="US Core Laboratory Result Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -2925,7 +2925,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Location" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-location" label="US Core Location Profile" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Location" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-location" label="US Core Location Profile" retrievable="true">
       <element name="identifier" description="Unique code or number identifying the location to its users" definition="Unique code or number identifying the location to its users.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3023,7 +3023,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Location.HoursOfOperation" retrievable="false">
       <element name="daysOfWeek" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="USCore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -3047,7 +3047,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Location.Position" retrievable="false">
       <element name="longitude" elementType="System.Decimal" target="%value.value" description="Longitude with WGS84 datum" definition="Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3066,7 +3066,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="LocationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Batch" retrievable="false">
       <element name="lotNumber" elementType="System.String" target="%value.value" description="Identifier assigned to batch" definition="The assigned lot number of a batch of the specified product.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3078,7 +3078,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Medication.Ingredient" retrievable="false">
       <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);USCore.Reference:null" description="The actual ingredient or content" definition="The actual ingredient - either a substance (simple ingredient) or another medication of a medication.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
@@ -3099,7 +3099,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="MedicationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication" label="US Core Medication Profile" target="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="MedicationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication" label="US Core Medication Profile" target="Medication" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business identifier for this medication" definition="Business identifier for this medication." comment="The serial number could be included as an identifier.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3146,7 +3146,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest" retrievable="false">
       <element name="initialFill" elementType="USCore.MedicationRequest.DispenseRequest.InitialFill" description="First fill details" definition="Indicates the quantity or duration for the first dispense of the medication." comment="If populating this element, either the quantity or the duration must be included.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3186,7 +3186,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false">
       <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="First fill quantity" definition="The amount or quantity to provide as part of the first dispense.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3198,7 +3198,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="MedicationRequest.Substitution" retrievable="false">
       <element name="allowed" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)" description="Whether substitution is allowed or not" definition="True if the prescriber allows a different drug to be dispensed from what was prescribed." comment="This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
@@ -3217,7 +3217,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="MedicationRequestProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest" label="US Core MedicationRequest Profile" target="MedicationRequest" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="MedicationRequestProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest" label="US Core MedicationRequest Profile" target="MedicationRequest" retrievable="true">
       <element name="identifier" description="External ids for this request" definition="Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server." comment="This is a business identifier, not a resource identifier.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3410,7 +3410,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false">
       <element name="versionId" elementType="System.String" target="%value.value" description="Version specific identifier" definition="The version specific identifier, as it appears in the version portion of the URL. This value changes when the resource is created, updated, or deleted." comment="The server assigns this value, and ignores what the client specifies, except in the case that the server is imposing version integrity on updates/deletes.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3449,7 +3449,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false">
       <element name="status" elementType="USCore.NarrativeStatus" description="generated | extensions | additional | empty" definition="The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.">
          <binding name="NarrativeStatus" description="The status of a resource narrative." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3469,7 +3469,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="NarrativeStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Observation.Component" retrievable="false">
       <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of component observation (code / type)" definition="Describes what was observed. Sometimes this is called the observation &quot;code&quot;." comment="*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation." mustSupport="true">
          <binding name="VitalSigns" description="This identifies the vital sign result type." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3525,7 +3525,7 @@
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.DiastolicBP" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.FlowRate" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Observation.Component" namespace="USCore" name="Observation.Component.SystolicBP" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Observation.ReferenceRange" retrievable="false">
       <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="Low Range, if relevant" definition="The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - &lt;=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is &lt;=2.3).">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3563,7 +3563,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Organization.Contact" retrievable="false">
       <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The type of contact" definition="Indicates a purpose for which the contact can be reached.">
          <binding name="ContactPartyType" description="The purpose for which you would contact a contact party." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3587,7 +3587,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="OrganizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization" label="US Core Organization Profile" target="Organization" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="OrganizationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization" label="US Core Organization Profile" target="Organization" retrievable="true">
       <element name="identifier" description="Identifies this organization  across multiple systems" definition="Identifier for the organization that is used to identify the organization across multiple disparate systems." comment="NPI preferred." mustSupport="true">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3663,7 +3663,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false">
       <element name="name" elementType="System.String" target="%value.value" description="Name used to access the parameter value" definition="The name of the parameter used to allow access to the value of the parameter in evaluation contexts.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3703,7 +3703,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Communication" retrievable="false">
       <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="The language which can be used to communicate with the patient about his or her health" definition="The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English versus &quot;en-EN&quot; for England English." comment="The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type." mustSupport="true">
          <binding strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -3716,7 +3716,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Contact" retrievable="false">
       <element name="relationship" target="FHIRHelpers.ToConcept(%value)" description="The kind of relationship" definition="The nature of the relationship between the patient and the contact person.">
          <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
          <binding name="ContactRelationship" description="The nature of the relationship between a patient and a contact person for that patient." strength="Extensible"/>
@@ -3760,7 +3760,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Patient.Link" retrievable="false">
       <element name="other" elementType="USCore.Reference" description="The other patient or related person resource that the link refers to" definition="The other patient resource that the link refers to." comment="Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3773,7 +3773,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PatientProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" label="US Core Patient Profile" target="Patient" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PatientProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient" label="US Core Patient Profile" target="Patient" retrievable="true">
       <element name="race" elementType="USCore.RaceExtension" target="%parent.extension[url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']" description="US Core Race Extension" definition="Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:&#xa;&#xa;   - American Indian or Alaska Native&#xa;   - Asian&#xa;   - Black or African American&#xa;   - Native Hawaiian or Other Pacific Islander&#xa;   - White." mustSupport="true">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -3904,7 +3904,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PediatricBMIforAgeObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age" label="US Core Pediatric BMI for Age Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4066,7 +4066,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PediatricWeightForHeightObservationProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height" label="US Core Pediatric Weight for Height Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4228,7 +4228,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Practitioner.Qualification" retrievable="false">
       <element name="identifier" description="An identifier for this qualification for the practitioner" definition="An identifier that applies to this person's qualification in this role.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4255,7 +4255,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PractitionerProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner" label="US Core Practitioner Profile" target="Practitioner" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PractitionerProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner" label="US Core Practitioner Profile" target="Practitioner" retrievable="true">
       <element name="identifier" description="An identifier for the person as this agent" definition="An identifier that applies to this person in this role." comment="NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number." mustSupport="true">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4321,7 +4321,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.AvailableTime" retrievable="false">
       <element name="daysOfWeek" description="mon | tue | wed | thu | fri | sat | sun" definition="Indicates which days of the week are available between the start and end Times.">
          <elementTypeSpecifier elementType="USCore.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
          <binding name="DaysOfWeek" description="The days of the week." strength="Required"/>
@@ -4345,7 +4345,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="PractitionerRole.NotAvailable" retrievable="false">
       <element name="description" elementType="System.String" target="%value.value" description="Reason presented to the user explaining why time not available" definition="The reason that can be presented to the user as to why this time is not available.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -4360,7 +4360,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PractitionerRoleProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole" label="US Core PractitionerRole Profile" target="PractitionerRole" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PractitionerRoleProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole" label="US Core PractitionerRole Profile" target="PractitionerRole" retrievable="true">
       <element name="identifier" description="Business Identifiers that are specific to a role/location" definition="Business Identifiers that are specific to a role/location.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4446,7 +4446,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.FocalDevice" retrievable="false">
       <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Kind of change to device" definition="The kind of change that happened to the device during the procedure.">
          <binding name="DeviceActionKind" description="A kind of change that happened to the device during the procedure." strength="Preferred"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4459,7 +4459,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Procedure.Performer" retrievable="false">
       <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="Type of performance" definition="Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.">
          <binding name="ProcedurePerformerRole" description="A code that identifies the role of a performer of the procedure." strength="Example"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4477,7 +4477,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="ProcedureProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure" label="US Core Procedure Profile" target="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="ProcedureProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure" label="US Core Procedure Profile" target="Procedure" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="External Identifiers for this procedure" definition="Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server." comment="This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4652,7 +4652,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="Provenance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance" label="US Core Provenance Profile" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="Provenance" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance" label="US Core Provenance Profile" retrievable="true">
       <element name="target" description="The Resource this Provenance record supports" definition="The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity." comment="Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion." mustSupport="true">
          <elementTypeSpecifier elementType="USCore.Reference" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4730,7 +4730,7 @@
       </element>
       <contextRelationship context="Patient" relatedKeyElement="where(resolve() is Patient)"/>
    </typeInfo>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Agent" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Agent" retrievable="false">
       <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)" description="How the agent participated" definition="The participation the agent had with respect to the activity." comment="For example: author, performer, enterer, attester, etc." mustSupport="true">
          <binding strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4760,7 +4760,7 @@
    </typeInfo>
    <typeInfo baseType="USCore.Provenance.Agent" namespace="USCore" name="Provenance.Agent.ProvenanceAuthor" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="USCore.Provenance.Agent" namespace="USCore" name="Provenance.Agent.ProvenanceTransmitter" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Entity" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Provenance.Entity" retrievable="false">
       <element name="role" elementType="USCore.ProvenanceEntityRole" description="derivation | revision | quotation | source | removal" definition="How the entity was used during the activity.">
          <binding name="ProvenanceEntityRole" description="How an entity was used in an activity." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4782,7 +4782,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ProvenanceEntityRole" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="PulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="PulseOximetryProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry" label="US Core Pulse Oximetry Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -4971,7 +4971,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Extension" namespace="USCore" name="RaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Extension" namespace="USCore" name="RaceExtension" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" label="US Core Race Extension" retrievable="false">
       <element name="ombCategory" target="FHIRHelpers.ToCode(%parent.extension[url='ombCategory'].value)" description="American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White" definition="The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf)." mustSupport="true">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5000,7 +5000,7 @@
       </element>
       <element name="url" elementType="System.String" target="%value.value" description="identifies the meaning of the extension" definition="Source of the definition for the extension code - a logical name or a URL." comment="The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension."/>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false">
       <element name="reference" elementType="System.String" target="%value.value" description="Literal reference, Relative, internal or absolute URL" definition="A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources." comment="Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure &quot;/[type]/[id]&quot; then it should be assumed that the reference is to a FHIR RESTful server.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5024,7 +5024,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="ReferredDocumentStatus" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false">
       <element name="type" elementType="USCore.RelatedArtifactType" description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of" definition="The type of relationship to the related artifact.">
          <binding name="RelatedArtifactType" description="The type of relationship to the related artifact." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5063,7 +5063,7 @@
       </element>
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="System.Any" namespace="USCore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="System.Any" namespace="USCore" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true">
       <element name="id" elementType="System.String" target="%value.value" description="Logical id of this artifact" definition="The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes." comment="The only time that a resource does not have an id is when it is being submitted to the server using a create operation."/>
       <element name="meta" elementType="USCore.Meta" description="Metadata about the resource" definition="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5082,7 +5082,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false">
       <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)" description="Zero value and units" definition="The base quantity that a measured value of zero represents. In addition, this provides the units of the entire measurement series.">
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
             <expression language="text/fhirpath" expression="hasValue() or (children().count() > id.count())"/>
@@ -5119,7 +5119,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false">
       <element name="type" target="FHIRHelpers.ToCode(%value)" description="Indication of the reason the entity signed the object(s)" definition="An indication of the reason that the entity signed this document. This may be explicitly included as part of the signature information and can be used when determining accountability for various actions concerning the document." comment="Examples include attesting to: authorship, correct transcription, and witness of specific event. Also known as a &amp;quot;Commitment Type Indication&amp;quot;.">
          <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
          <binding name="SignatureType" description="An indication of the reason that an entity signed the object." strength="Preferred"/>
@@ -5160,7 +5160,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="SmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="SmokingStatusProfile" identifier="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus" label="US Core Smoking Status Observation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5314,7 +5314,7 @@
    </typeInfo>
    <typeInfo baseType="System.String" namespace="USCore" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="Status" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.BackboneElement" namespace="USCore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.BackboneElement" namespace="USCore" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code">
       <element name="event" target="%value.value" description="When the event occurs" definition="Identifies specific times when the event occurs.">
          <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5360,7 +5360,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="Timing.Repeat" retrievable="false">
       <element name="bounds" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;" description="Length/Range of lengths, or (Start and/or end) limits" definition="Either a duration for the length of the timing schedule, a range of possible length, or outer bounds for start and/or end limits of the timing schedule.">
          <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
             <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
@@ -5453,7 +5453,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false">
       <element name="type" elementType="USCore.TriggerType" description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended" definition="The type of triggering event.">
          <binding name="TriggerType" description="The type of trigger." strength="Required"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5491,7 +5491,7 @@
    <typeInfo baseType="System.String" namespace="USCore" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
    <typeInfo baseType="System.String" namespace="USCore" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
-   <typeInfo baseType="USCore.Element" namespace="USCore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.Element" namespace="USCore" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code">
       <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)" description="Type of context being specified" definition="A code that identifies the type of context being specified by this usage context.">
          <binding name="UsageContextType" description="A code that specifies a type of context being specified by a usage context." strength="Extensible"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5513,7 +5513,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bmi" identifier="http://hl7.org/fhir/StructureDefinition/bmi" label="Observation Body Mass Index Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5680,7 +5680,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyheight" identifier="http://hl7.org/fhir/StructureDefinition/bodyheight" label="Observation Body Height Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -5847,7 +5847,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodytemp" identifier="http://hl7.org/fhir/StructureDefinition/bodytemp" label="Observation Body Temperature Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6014,7 +6014,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bodyweight" identifier="http://hl7.org/fhir/StructureDefinition/bodyweight" label="Observation Body Weight Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6181,7 +6181,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-bp" identifier="http://hl7.org/fhir/StructureDefinition/bp" label="Observation Blood Pressure Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6364,7 +6364,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-headcircum" identifier="http://hl7.org/fhir/StructureDefinition/headcircum" label="Observation Head Circumference Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6531,7 +6531,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-heartrate" identifier="http://hl7.org/fhir/StructureDefinition/heartrate" label="Observation Heart Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6698,7 +6698,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-oxygensat" identifier="http://hl7.org/fhir/StructureDefinition/oxygensat" label="Observation Oxygen Saturation Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -6865,7 +6865,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-resprate" identifier="http://hl7.org/fhir/StructureDefinition/resprate" label="Observation Respiratory Rate Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">
@@ -7032,7 +7032,7 @@
          </constraint>
       </element>
    </typeInfo>
-   <typeInfo baseType="USCore.DomainResource" namespace="USCore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+   <typeInfo xsi:type="ClassInfo" baseType="USCore.DomainResource" namespace="USCore" name="observation-vitalspanel" identifier="http://hl7.org/fhir/StructureDefinition/vitalspanel" label="Observation Vital Signs Panel Profile" target="Observation" retrievable="true" primaryCodePath="code">
       <element name="identifier" description="Business Identifier for observation" definition="A unique identifier assigned to this observation.">
          <elementTypeSpecifier elementType="USCore.Identifier" xsi:type="ListTypeSpecifier"/>
          <constraint name="ele-1" severity="ERROR" message="All FHIR elements must have a @value or children">


### PR DESCRIPTION
This PR replaces JAXB with Jackson for loading ModelInfo files, making it suitable for use on Android. It fixes #640

Notice that:
1 - There were typos on the modelinfo files: `primaryCocdePath` and `primaryCOdePath` (Jackson XML is case sensitive)
2 - There is a [bug](https://github.com/FasterXML/jackson-dataformat-xml/issues/525) on Jackson's XML mapper that requires `xsi:type` to be the first property on XML elements with polymorphic nested objects.