### PR TITLE
QuickFix: Fixing the calling of static methods.

### DIFF
--- a/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmJsonMapper.java
+++ b/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmJsonMapper.java
@@ -12,7 +12,7 @@ import org.hl7.cql_annotations.r1.CqlToElmBase;
 import org.hl7.elm.r1.TypeSpecifier;
 
 public class ElmJsonMapper {
-    private static JsonMapper mapper = new JsonMapper().builder()
+    private static JsonMapper mapper = JsonMapper.builder()
             .defaultMergeable(true)
             .enable(SerializationFeature.INDENT_OUTPUT)
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)

--- a/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmXmlMapper.java
+++ b/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmXmlMapper.java
@@ -13,7 +13,7 @@ import org.hl7.cql_annotations.r1.CqlToElmBase;
 import org.hl7.elm.r1.TypeSpecifier;
 
 public class ElmXmlMapper {
-    private static XmlMapper mapper = new XmlMapper().builder()
+    private static XmlMapper mapper = XmlMapper.builder()
             .defaultUseWrapper(true)
             .defaultMergeable(true)
             .enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION)

--- a/Src/java/model-jackson/src/main/java/org/hl7/elm_modelinfo/r1/serializing/jackson/XmlModelInfoReader.java
+++ b/Src/java/model-jackson/src/main/java/org/hl7/elm_modelinfo/r1/serializing/jackson/XmlModelInfoReader.java
@@ -18,7 +18,7 @@ import java.net.URI;
 import java.net.URL;
 
 public class XmlModelInfoReader implements ModelInfoReader {
-    static XmlMapper mapper = new XmlMapper().builder()
+    static XmlMapper mapper = XmlMapper.builder()
             .defaultUseWrapper(false)
             .defaultMergeable(true)
             .enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION)


### PR DESCRIPTION
No need to create the mapper twice. 