### PR TITLE
Add handling for empty source interval

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
 
 public class SemanticTests {
 
@@ -495,6 +496,16 @@ public class SemanticTests {
         assertThat(ivs.getCode(), instanceOf(FunctionRef.class));
         assertThat(ivs.getValueset(), nullValue());
         assertThat(ivs.getValuesetExpression(), instanceOf(OperandRef.class));
+    }
+
+
+    @Test
+    public void testIssueEmptySourceInterval() throws IOException {
+        CqlTranslator translator = TestUtils.runSemanticTest("IssueEmptySourceInterval.cql", 1, CqlTranslator.Options.EnableAnnotations);
+
+        java.util.List<CqlTranslatorException> exceptions = translator.getExceptions();
+
+        assertEquals(1, exceptions.size());
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/IssueEmptySourceInterval.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/IssueEmptySourceInterval.cql
@@ -1,0 +1,4 @@
+library IssueEmptySourceInterval version '0.1.0'
+
+
+define "Meow":  


### PR DESCRIPTION
ANTLR produces an interval of i..i-1 in cases where the interval is empty. This causes the current Annotation code to break since it doesn't know how to compare and create parent/child relationships between empty intervals. This PR skips creating annotations for intervals that are empty. An empty interval _should_ only occur if there are syntax errors (i.e. an invalid CQL library).