### PR TITLE
Fix tag parsing

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -438,7 +438,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     }
 
     private List<Tag> parseTags(String header) {
-        header = String.join("\n ", Arrays.asList(header.split("\n[ \t*]+")));
+        header = String.join("\n", Arrays.asList(header.trim().split("\n[ \t]*\\*[ \t\\*]*")));
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -354,7 +354,8 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     // this method returns Pair<tag value, next tag name lookup index> starting from startFrom
     // can return null in cases.
     // for @1980-12-01, it will potentially check to be treated as value date
-    private Pair<String, Integer> looKForTagValue(String header, int startFrom) {
+    // it looks for parameter in double quotes, e.g. @parameter: "Measurement Interval" [@2019,@2020]
+    private Pair<String, Integer> lookForTagValue(String header, int startFrom) {
 
         if(startFrom>= header.length()) {
             return null;
@@ -410,8 +411,8 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
     // this method returns Pair<tag name, next value lookup index> starting from startFrom
     // can return null in cases.
-    // supports both `:` and ` ` for delimeter
-    private Pair<String, Integer> looKForTagName(String header, int startFrom) {
+    // supports both `:` and ` ` for delimiter
+    private Pair<String, Integer> lookForTagName(String header, int startFrom) {
 
         if(startFrom>= header.length()){
             return null;
@@ -453,12 +454,12 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
         int startFrom = 0;
         while (startFrom < header.length()) {
-            Pair<String, Integer> tagNamePair = looKForTagName(header, startFrom);
+            Pair<String, Integer> tagNamePair = lookForTagName(header, startFrom);
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {
                     Tag t = af.createTag().withName(tagNamePair.getLeft());
                     startFrom = tagNamePair.getRight();
-                    Pair<String, Integer> tagValuePair = looKForTagValue(header, startFrom);
+                    Pair<String, Integer> tagValuePair = lookForTagValue(header, startFrom);
                     if (tagValuePair != null) {
                         if (tagValuePair.getLeft().length() > 0) {
                             t = t.withValue(tagValuePair.getLeft());

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -368,13 +368,17 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 if (interimText.length() > 0) {  // interim text has value, regards interim text
                     return Pair.of(interimText, tagStart);
                 } else {
-                    int nextDelimeterIndex = header.indexOf(' ', tagStart);
-                    if (nextDelimeterIndex == -1) {
-                        nextDelimeterIndex = header.indexOf("\n", tagStart);
-                        if (nextDelimeterIndex == -1) {
-                            nextDelimeterIndex = header.length();
-                        }
+                    int nextSpace = header.indexOf(' ', tagStart);
+                    int nextLine = header.indexOf("\n", tagStart);
+                    int mul = nextSpace * nextLine;
+                    int nextDelimeterIndex = header.length();
+
+                    if (mul < 0) {
+                        nextDelimeterIndex = Math.max(nextLine, nextSpace);
+                    } else if(mul > 0) {
+                        nextDelimeterIndex = Math.min(nextLine, nextSpace);
                     }
+
                     return Pair.of(header.substring(tagStart, nextDelimeterIndex), nextDelimeterIndex );
                 }
             } else {   //next `@` is not date
@@ -435,7 +439,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;
-        while (startFrom < header.length()) {
+        int count = 0;
+        while (startFrom < header.length() && count < 10) {
+            count++;
             Pair<String, Integer> tagNamePair = looKForTagName(header, startFrom);
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -375,7 +375,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
                     if (mul < 0) {
                         nextDelimeterIndex = Math.max(nextLine, nextSpace);
-                    } else if(mul > 0) {
+                    } else if(mul > 1) {
                         nextDelimeterIndex = Math.min(nextLine, nextSpace);
                     }
 
@@ -446,17 +446,17 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {
                     Tag t = af.createTag().withName(tagNamePair.getLeft());
-                    startFrom = tagNamePair.getRight().intValue();
+                    startFrom = tagNamePair.getRight();
                     Pair<String, Integer> tagValuePair = looKForTagValue(header, startFrom);
                     if (tagValuePair != null) {
                         if (tagValuePair.getLeft().length() > 0) {
                             t = t.withValue(tagValuePair.getLeft());
-                            startFrom = tagValuePair.getRight().intValue();
+                            startFrom = tagValuePair.getRight();
                         }
                     }
                     tags.add(t);
                 } else {
-                    startFrom = tagNamePair.getRight().intValue();
+                    startFrom = tagNamePair.getRight();
                 }
             }
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -435,9 +435,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;
-        int count = 0;
-        while (startFrom < header.length() && count < 10) {
-            count++;
+        while (startFrom < header.length()) {
             Pair<String, Integer> tagNamePair = looKForTagName(header, startFrom);
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -405,9 +405,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     }
 
     private boolean isStartingWithDigit(String header, int index) {
-        return (index < header.length()) &&
-                (header.charAt(index) >= '0') &&
-                (header.charAt(index) <= '9');
+        return (index < header.length()) && Character.isDigit(header.charAt(index));
     }
 
     // this method returns Pair<tag name, next value lookup index> starting from formIndex
@@ -451,21 +449,16 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
     private List<Tag> parseTags(String header) {
         header = header.trim();
-        //System.out.println("header:"+ header);
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;
-        int count = 0;
-        while (startFrom < header.length() && count < 10) {
-            count++;
+        while (startFrom < header.length()) {
             Pair<String, Integer> tagNamePair = looKForTagName(header, startFrom);
-            //System.out.println("name:"+ tagNamePair);
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {
                     Tag t = af.createTag().withName(tagNamePair.getLeft());
                     startFrom = tagNamePair.getRight();
                     Pair<String, Integer> tagValuePair = looKForTagValue(header, startFrom);
-                    //System.out.println("value:"+ tagValuePair);
                     if (tagValuePair != null) {
                         if (tagValuePair.getLeft().length() > 0) {
                             t = t.withValue(tagValuePair.getLeft());
@@ -480,7 +473,6 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 break;
             }
         }
-        //System.out.println("Count:" + count);
         return tags;
     }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -438,7 +438,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
     }
 
     private List<Tag> parseTags(String header) {
-        header = header.trim();
+        header = String.join("\n ", Arrays.asList(header.split("\n[ \t*]+")));
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -351,16 +351,16 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         return true;
     }
 
-    // this method returns Pair<tag value, next tag name lookup index> starting from formIndex
+    // this method returns Pair<tag value, next tag name lookup index> starting from startFrom
     // can return null in cases.
     // for @1980-12-01, it will potentially check to be treated as value date
-    private Pair<String, Integer> looKForTagValue(String header, int fromIndex) {
+    private Pair<String, Integer> looKForTagValue(String header, int startFrom) {
 
-        if(fromIndex>= header.length()) {
+        if(startFrom>= header.length()) {
             return null;
         }
-        int nextTag = header.indexOf('@', fromIndex);
-        int nextStartDoubleQuote = header.indexOf("\"", fromIndex);
+        int nextTag = header.indexOf('@', startFrom);
+        int nextStartDoubleQuote = header.indexOf("\"", startFrom);
         if ((nextTag < 0 || nextTag > nextStartDoubleQuote) && nextStartDoubleQuote > 0 &&
                 (header.length() > (nextStartDoubleQuote + 1))) {
             int nextEndDoubleQuote = header.indexOf("\"", nextStartDoubleQuote + 1);
@@ -375,10 +375,10 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 return Pair.of(header.substring(nextStartDoubleQuote), header.length());
             }
         }
-        if(nextTag == fromIndex && !isStartingWithDigit(header, nextTag +1)) {  //starts with `@` and not potential date value
-            return Pair.of("",fromIndex);
+        if(nextTag == startFrom && !isStartingWithDigit(header, nextTag +1)) {  //starts with `@` and not potential date value
+            return Pair.of("",startFrom);
         } else if (nextTag > 0) {   // has some text before tag
-            String interimText = header.substring(fromIndex, nextTag).trim();
+            String interimText = header.substring(startFrom, nextTag).trim();
             if (isStartingWithDigit(header, nextTag + 1)) {  // next `@` is a date value
                 if (interimText.length() > 0 && !interimText.equals(":")) {  // interim text has value, regards interim text
                     return Pair.of(interimText, nextTag);
@@ -401,22 +401,22 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
             }
         }
 
-        return Pair.of(header.substring(fromIndex).trim(), header.length());
+        return Pair.of(header.substring(startFrom).trim(), header.length());
     }
 
     private boolean isStartingWithDigit(String header, int index) {
         return (index < header.length()) && Character.isDigit(header.charAt(index));
     }
 
-    // this method returns Pair<tag name, next value lookup index> starting from formIndex
+    // this method returns Pair<tag name, next value lookup index> starting from startFrom
     // can return null in cases.
     // supports both `:` and ` ` for delimeter
-    private Pair<String, Integer> looKForTagName(String header, int fromIndex) {
+    private Pair<String, Integer> looKForTagName(String header, int startFrom) {
 
-        if(fromIndex>= header.length()){
+        if(startFrom>= header.length()){
             return null;
         }
-        int start = header.indexOf("@", fromIndex);
+        int start = header.indexOf("@", startFrom);
         if (start < 0) {
             return null;
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -451,7 +451,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
     private List<Tag> parseTags(String header) {
         header = header.trim();
-        System.out.println("header:"+ header);
+        //System.out.println("header:"+ header);
         List<Tag> tags = new ArrayList<>();
 
         int startFrom = 0;
@@ -459,13 +459,13 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         while (startFrom < header.length() && count < 10) {
             count++;
             Pair<String, Integer> tagNamePair = looKForTagName(header, startFrom);
-            System.out.println("name:"+ tagNamePair);
+            //System.out.println("name:"+ tagNamePair);
             if (tagNamePair != null) {
                 if (tagNamePair.getLeft().length() > 0 && isValidIdentifier(tagNamePair.getLeft())) {
                     Tag t = af.createTag().withName(tagNamePair.getLeft());
                     startFrom = tagNamePair.getRight();
                     Pair<String, Integer> tagValuePair = looKForTagValue(header, startFrom);
-                    System.out.println("value:"+ tagValuePair);
+                    //System.out.println("value:"+ tagValuePair);
                     if (tagValuePair != null) {
                         if (tagValuePair.getLeft().length() > 0) {
                             t = t.withValue(tagValuePair.getLeft());
@@ -480,7 +480,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 break;
             }
         }
-        System.out.println("Count:" + count);
+        //System.out.println("Count:" + count);
         return tags;
     }
 
@@ -494,11 +494,15 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
                 if (!inMultiline) {
                     int start = line.indexOf("/*");
                     if (start >= 0) {
-                        result.add(line.substring(start + 2));
+                        if (line.endsWith("*/")) {
+                            result.add(line.substring(start + 2, line.length() - 2));
+                        } else {
+                            result.add(line.substring(start + 2));
+                        }
                         inMultiline = true;
                     }
                     else start = line.indexOf("//");
-                    if (start >= 0) {
+                    if (start >= 0 && !inMultiline ) {
                         result.add(line.substring(start + 2));
                     }
                 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -300,7 +300,7 @@ public class CommentTests {
                 case 1:
                     assertThat(t.getName(), equalTo("tagname2"));
                     assertThat(t.getValue(), equalTo("tag value2 this is\n" +
-                            " a long tag value"));
+                            "a long tag value"));
                     break;
             }
         }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -280,6 +280,31 @@ public class CommentTests {
             }
         }
 
+        d = library.resolveExpressionRef("AnotherTestCase");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(2));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("tagname"));
+                    assertThat(t.getValue(), equalTo("tag value"));
+                    break;
+                case 1:
+                    assertThat(t.getName(), equalTo("tagname2"));
+                    assertThat(t.getValue(), equalTo("tag value2 this is\n" +
+                            "a long tag value"));
+                    break;
+            }
+        }
+
 
         ExpressionDef dInvalid = library.resolveExpressionRef("TestInvalid");
         assertThat(dInvalid.getAnnotation(), notNullValue());

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -27,6 +27,7 @@ public class CommentTests {
         assertThat(library.getLibrary().getAnnotation(), notNullValue());
     }
 
+    /*
     @Test
     public void testTags() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("TestTags.cql", 0);
@@ -140,5 +141,99 @@ public class CommentTests {
             }
         }
 
+
+        d = library.resolveExpressionRef("TestMultiTagInline");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(2));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("test"));
+                    assertThat(t.getValue(), nullValue());
+                    break;
+                case 1:
+                    assertThat(t.getName(), equalTo("pertinence"));
+                    assertThat(t.getValue(), equalTo("strongly-positive"));
+                    break;
+            }
+        }
+
+
+        d = library.resolveExpressionRef("TestDateMultiTag");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(4));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("test"));
+                    assertThat(t.getValue(), equalTo("@1980-12-01"));
+                    break;
+                case 1:
+                    assertThat(t.getName(), equalTo("val"));
+                    assertThat(t.getValue(), equalTo("val1"));
+                    break;
+                case 2:
+                    assertThat(t.getName(), equalTo("asof"));
+                    assertThat(t.getValue(), equalTo("@2020-10-01"));
+                    break;
+                case 3:
+                    assertThat(t.getName(), equalTo("parameter"));
+                    assertThat(t.getValue(), equalTo("abcd"));
+                    break;
+            }
+        }
+
+        d = library.resolveExpressionRef("TestDateIntervalParameter");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(4));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("test"));
+                    assertThat(t.getValue(), equalTo("@1980-12-01"));
+                    break;
+                case 1:
+                    assertThat(t.getName(), equalTo("val"));
+                    assertThat(t.getValue(), equalTo("val1"));
+                    break;
+                case 2:
+                    assertThat(t.getName(), equalTo("asof"));
+                    assertThat(t.getValue(), equalTo("@2020-10-01"));
+                    break;
+                case 3:
+                    assertThat(t.getName(), equalTo("parameter"));
+                    assertThat(t.getValue(), equalTo("\"Measurement Interval\" [@2019,@2020]"));
+                    break;
+            }
+        }
+
+
+
     }
+
+    */
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -300,7 +300,7 @@ public class CommentTests {
                 case 1:
                     assertThat(t.getName(), equalTo("tagname2"));
                     assertThat(t.getValue(), equalTo("tag value2 this is\n" +
-                            "a long tag value"));
+                            " a long tag value"));
                     break;
             }
         }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -230,6 +230,52 @@ public class CommentTests {
             }
         }
 
+        d = library.resolveExpressionRef("TestMultilineValue");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(1));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("test"));
+                    assertThat(t.getValue(), equalTo("this is a\n" +
+                            "multi-line tag value"));
+                    break;
+            }
+        }
+
+        d = library.resolveExpressionRef("TestParameterAtFirstLine");
+        assertThat(d.getAnnotation(), notNullValue());
+        for (Object o : d.getAnnotation()) {
+            if (o instanceof Annotation) {
+                a = (Annotation)o;
+            }
+        }
+        assertThat(a, notNullValue());
+        assertThat(a.getT(), notNullValue());
+        assertThat(a.getT().size(), equalTo(2));
+        for (int i = 0; i < a.getT().size(); i++) {
+            Tag t = a.getT().get(i);
+            switch (i) {
+                case 0:
+                    assertThat(t.getName(), equalTo("parameter"));
+                    assertThat(t.getValue(), equalTo("\"abcd\" [1,10]"));
+                    break;
+                case 1:
+                    assertThat(t.getName(), equalTo("test"));
+                    assertThat(t.getValue(), equalTo("this is a\n" +
+                            "multi-line tag value"));
+                    break;
+            }
+        }
+
 
         ExpressionDef dInvalid = library.resolveExpressionRef("TestInvalid");
         assertThat(dInvalid.getAnnotation(), notNullValue());

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -260,7 +260,7 @@ public class CommentTests {
         }
         assertThat(a, notNullValue());
         assertThat(a.getT(), notNullValue());
-        assertThat(a.getT().size(), equalTo(2));
+        assertThat(a.getT().size(), equalTo(3));
         for (int i = 0; i < a.getT().size(); i++) {
             Tag t = a.getT().get(i);
             switch (i) {
@@ -272,6 +272,10 @@ public class CommentTests {
                     assertThat(t.getName(), equalTo("test"));
                     assertThat(t.getValue(), equalTo("this is a\n" +
                             "multi-line tag value"));
+                    break;
+                case 2:
+                    assertThat(t.getName(), equalTo("pertinence"));
+                    assertThat(t.getValue(), equalTo("weakly-negative"));
                     break;
             }
         }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -27,7 +27,6 @@ public class CommentTests {
         assertThat(library.getLibrary().getAnnotation(), notNullValue());
     }
 
-    /*
     @Test
     public void testTags() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("TestTags.cql", 0);
@@ -232,8 +231,18 @@ public class CommentTests {
         }
 
 
+        ExpressionDef dInvalid = library.resolveExpressionRef("TestInvalid");
+        assertThat(dInvalid.getAnnotation(), notNullValue());
+        Annotation aInvalid = null;
+        for (Object o : dInvalid.getAnnotation()) {
+            if (o instanceof Annotation) {
+                aInvalid = (Annotation)o;
+            }
+        }
+        assertThat(aInvalid, nullValue());
+
 
     }
 
-    */
+
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -178,7 +178,8 @@ public class TestUtils {
             System.err.println(String.format("(%d,%d): %s",
                     error.getLocator().getStartLine(), error.getLocator().getStartChar(), error.getMessage()));
         }
-        assertThat(translator.getErrors().size(), is(expectedErrors));
+        //assertThat(translator.getErrors().size(), is(expectedErrors));
+        System.out.println(translator.getErrors());
         return translator;
     }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -178,8 +178,7 @@ public class TestUtils {
             System.err.println(String.format("(%d,%d): %s",
                     error.getLocator().getStartLine(), error.getLocator().getStartChar(), error.getMessage()));
         }
-        //assertThat(translator.getErrors().size(), is(expectedErrors));
-        System.out.println(translator.getErrors());
+        assertThat(translator.getErrors().size(), is(expectedErrors));
         return translator;
     }
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -51,6 +51,22 @@ define TestDateMultiTag:
 define TestDateIntervalParameter:
    3 + 3
 
+/*
+@test: this is a
+multi-line tag value
+*/
+define TestMultilineValue:
+   3 + 1
+
+/*
+@parameter: "abcd" [1,10]
+@test: this is a
+multi-line tag value
+*/
+define TestParameterAtFirstLine:
+   3 + 1
+
+
 
 /*@:@*/
 define TestInvalid:

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -29,9 +29,9 @@ define TestMultiline:
   1 + 1
 
 /*
-@test  @pertinence: val2
+@test  @pertinence: strongly-positive
  */
-define TestNewFormat:
+define TestMultiTagInline:
    3 + 3
 
 /*
@@ -39,13 +39,14 @@ define TestNewFormat:
 @asof: @2020-10-01
 @parameter: abcd
  */
-define TestDate:
+define TestDateMultiTag:
    3 + 3
 
 
 /*
 @test @1980-12-01 @val val1
 @asof: @2020-10-01
+@parameter: "Measurement Interval" [@2019,@2020]
 */
-define TestDate2:
+define TestDateIntervalParameter:
    3 + 3

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -41,3 +41,11 @@ define TestNewFormat:
  */
 define TestDate:
    3 + 3
+
+
+/*
+@test @1980-12-01 @val val1
+@asof: @2020-10-01
+*/
+define TestDate2:
+   3 + 3

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -37,6 +37,7 @@ define TestNewFormat:
 /*
 @test @1980-12-01 @val val1
 @asof: @2020-10-01
+@parameter: abcd
  */
 define TestDate:
    3 + 3

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -50,3 +50,8 @@ define TestDateMultiTag:
 */
 define TestDateIntervalParameter:
    3 + 3
+
+
+/*@:@*/
+define TestInvalid:
+  1 + 1

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -68,6 +68,14 @@ define TestParameterAtFirstLine:
    3 + 1
 
 
+/*
+@tagname: tag value
+@tagname2: tag value2 this is
+a long tag value
+*/
+define AnotherTestCase:
+   3 + 1
+
 
 /*@:@*/
 define TestInvalid:

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -28,7 +28,15 @@ define function TestFunction():
 define TestMultiline:
   1 + 1
 
-/*@:@*/
-define TestInvalid:
-  1 + 1
+/*
+@test  @pertinence: val2
+ */
+define TestNewFormat:
+   3 + 3
 
+/*
+@test @1980-12-01 @val val1
+@asof: @2020-10-01
+ */
+define TestDate:
+   3 + 3

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -68,11 +68,11 @@ define TestParameterAtFirstLine:
    3 + 1
 
 
-/*
-@tagname: tag value
-@tagname2: tag value2 this is
-a long tag value
-*/
+/**
+ *  @tagname: tag value
+ *  @tagname2: tag value2 this is
+ *  a long tag value
+ */
 define AnotherTestCase:
    3 + 1
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestTags.cql
@@ -35,7 +35,7 @@ define TestMultiTagInline:
    3 + 3
 
 /*
-@test @1980-12-01 @val val1
+@test: @1980-12-01 @val: val1
 @asof: @2020-10-01
 @parameter: abcd
  */
@@ -44,7 +44,7 @@ define TestDateMultiTag:
 
 
 /*
-@test @1980-12-01 @val val1
+@test: @1980-12-01 @val: val1
 @asof: @2020-10-01
 @parameter: "Measurement Interval" [@2019,@2020]
 */
@@ -62,6 +62,7 @@ define TestMultilineValue:
 @parameter: "abcd" [1,10]
 @test: this is a
 multi-line tag value
+@pertinence : weakly-negative
 */
 define TestParameterAtFirstLine:
    3 + 1


### PR DESCRIPTION
Related [issue](https://github.com/cqframework/clinical_quality_language/issues/771): 
- With the principle, if a tag has a value, it needs the colon to separate it
- Support ` : `as tag delimiter e.g. `@test : value`
- `@test @2010-10-01` produce tag name = test and tag value = @2010-10-01 
- supports multi tags in one line
- For this: `@test  @pertinence: strongly-positive`,  no tag value for test and tag value for pertinence = "strongly-positive"
-For this: `@parameter: "Measurement Interval" [@2019,@2020]`, tag value for parameter= "Measurement Interval" [@2019,@2020]
- Limitation: for parameter it expects to be in one line or be the last tag of a multi tag line.