### PR TITLE
Removes  Antlr's code generation dependencies from the runtimeClasspath.

### DIFF
--- a/Src/java/cqf-fhir/build.gradle
+++ b/Src/java/cqf-fhir/build.gradle
@@ -19,7 +19,4 @@ dependencies {
 
     // FHIR r5
     implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
-
-    // HAPI client (for FHIR API)
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-client', version: '6.0.1'
 }

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -13,6 +13,10 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 
     testImplementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+
+    // needs javax.json.JsonException when using SAXUnmarshaller.getNewXMLReader
+    testImplementation group: 'org.glassfish', 'name': 'javax.json', 'version': '1.0.4'
+
     testImplementation project(':elm-jackson')
     testImplementation project(':elm-jaxb')
     testImplementation project(':model-jackson')

--- a/Src/java/cql/build.gradle
+++ b/Src/java/cql/build.gradle
@@ -5,17 +5,15 @@ mainClassName = 'org.cqframework.cql.Main'
 run.args = ["${projectDir}/../../../Examples/ChlamydiaScreening_CQM.cql"]
 
 configurations {
-    implementation {
+    api {
+        // Undo extendsFrom relationship between the 'antlr' configuration and the 'api' configuration
+        // See https://github.com/gradle/gradle/blob/master/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java#L60
         extendsFrom = extendsFrom.findAll { it != configurations.antlr }
     }
 }
-
 dependencies {
-    antlr  group: "org.antlr", name: "antlr4", version: "4.9.1"
-    implementation (group: "org.antlr", name: "antlr4-runtime", version: "4.9.1") {
-        // antlr 4.5 includes these classes directly
-        exclude(group: "org.abego.treelayout", module: "org.abego.treelayout.core")
-    }
+    antlr  group: "org.antlr", name: "antlr4", version: "4.10.1"
+    implementation group: "org.antlr", name: "antlr4-runtime", version: "4.10.1"
 }
 
 ext.antlr = [

--- a/Src/java/cql/build.gradle
+++ b/Src/java/cql/build.gradle
@@ -13,7 +13,8 @@ configurations {
 }
 dependencies {
     antlr  group: "org.antlr", name: "antlr4", version: "4.10.1"
-    implementation group: "org.antlr", name: "antlr4-runtime", version: "4.10.1"
+    // Exports Antlr runtime packages to cql-to-elm
+    api group: "org.antlr", name: "antlr4-runtime", version: "4.10.1"
 }
 
 ext.antlr = [

--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -4,6 +4,5 @@ dependencies {
     implementation project(':elm')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.2'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 }

--- a/Src/java/model-jackson/build.gradle
+++ b/Src/java/model-jackson/build.gradle
@@ -3,6 +3,5 @@
 dependencies {
     implementation project(':model')
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.2'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 }


### PR DESCRIPTION
Dependency cleanup: 
- Removing Antlr's dependencies
- Removing hapi-fhir-client (http client not available on android)
- Removing duplicated entires on the build. 