### PR TITLE
Removes jackson dependencies from the ELM module

### DIFF
--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -1,6 +1,7 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
+    implementation project(':model')
     implementation project(':elm')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'

--- a/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmJsonMapper.java
+++ b/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmJsonMapper.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.cqframework.cql.elm.serializing.jackson.mixins.CqlToElmBaseMixIn;
+import org.cqframework.cql.elm.serializing.jackson.mixins.TrackableMixIn;
 import org.cqframework.cql.elm.serializing.jackson.mixins.TypeSpecifierMixIn;
+import org.cqframework.cql.elm.tracking.Trackable;
 import org.hl7.cql_annotations.r1.CqlToElmBase;
 import org.hl7.elm.r1.TypeSpecifier;
 
@@ -19,6 +21,7 @@ public class ElmJsonMapper {
             .enable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
             .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
             .addModule(new JaxbAnnotationModule())
+            .addMixIn(Trackable.class, TrackableMixIn.class)
             .addMixIn(TypeSpecifier.class, TypeSpecifierMixIn.class)
             .addMixIn(CqlToElmBase.class, CqlToElmBaseMixIn.class)
             .build();

--- a/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmXmlMapper.java
+++ b/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/ElmXmlMapper.java
@@ -11,7 +11,9 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.cqframework.cql.elm.serializing.jackson.mixins.CqlToElmBaseMixIn;
+import org.cqframework.cql.elm.serializing.jackson.mixins.TrackableMixIn;
 import org.cqframework.cql.elm.serializing.jackson.mixins.TypeSpecifierMixIn;
+import org.cqframework.cql.elm.tracking.Trackable;
 import org.hl7.cql_annotations.r1.CqlToElmBase;
 import org.hl7.elm.r1.TypeSpecifier;
 
@@ -30,7 +32,7 @@ public class ElmXmlMapper {
             .enable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
             .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
             .addModule(new JaxbAnnotationModule())
-            //.addMixIn(TypeInfo.class, TypeInfoMixIn.class)
+            .addMixIn(Trackable.class, TrackableMixIn.class)
             .addMixIn(TypeSpecifier.class, TypeSpecifierMixIn.class)
             .addMixIn(CqlToElmBase.class, CqlToElmBaseMixIn.class)
             .build();

--- a/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/mixins/TrackableMixIn.java
+++ b/Src/java/elm-jackson/src/main/java/org/cqframework/cql/elm/serializing/jackson/mixins/TrackableMixIn.java
@@ -1,0 +1,25 @@
+package org.cqframework.cql.elm.serializing.jackson.mixins;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.hl7.cql.model.DataType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.cqframework.cql.elm.tracking.TrackBack;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+public interface TrackableMixIn {
+    @JsonIgnore
+    public UUID getTrackerId();
+
+    @JsonIgnore
+    public List<TrackBack> getTrackbacks();
+
+    @JsonIgnore
+    public DataType getResultType();
+}

--- a/Src/java/elm/build.gradle
+++ b/Src/java/elm/build.gradle
@@ -2,7 +2,6 @@
 
 dependencies {
     implementation project(':model')
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.2'
 }
 
 generateSources {

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/Trackable.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/tracking/Trackable.java
@@ -1,7 +1,5 @@
 package org.cqframework.cql.elm.tracking;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.hl7.cql.model.DataType;
 
 import javax.xml.bind.annotation.XmlTransient;
@@ -9,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public class Trackable {
     private final UUID trackerId;
     private final List<TrackBack> trackbacks;
@@ -22,19 +19,16 @@ public class Trackable {
     }
 
     @XmlTransient
-    @JsonIgnore
     public UUID getTrackerId() {
         return trackerId;
     }
 
     @XmlTransient
-    @JsonIgnore
     public List<TrackBack> getTrackbacks() {
         return trackbacks;
     }
 
     @XmlTransient
-    @JsonIgnore
     public DataType getResultType() {
         return resultType;
     }


### PR DESCRIPTION
Trackable's Jackson annotations were moved to a MixIn in the `elm-jackson` module

This was creating compilation warnings at the evaluator's main module, which doesn't use Jackson. 