### PR TITLE
Swap xpp3 implementation to support Java 9+

### DIFF
--- a/Src/java/.vscode/settings.json
+++ b/Src/java/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -31,6 +31,14 @@ subprojects {
         testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
     }
 
+    // The xpp3.xpp3 dependency includes the javax.xml packagename, which is invalid in
+    // Java 9+. The FHIR ucum service and the HAPI validation framework both depend on this
+    // so the codelibs.xpp3 package is substituted instead. It's a fork of xpp3, but excludes
+    // the javax.xml packagename
+    configurations.implementation {
+        exclude group: 'xpp3', module: 'xpp3'
+    }
+
     jar {
         manifest {
             attributes('Implementation-Title': project.name,

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':elm')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'org.fhir', name: 'ucum', version: '1.0.3'
+    implementation group: 'org.codelibs', name: 'xpp3', version: '1.1.4c.0'
 
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 

--- a/Src/java/elm-fhir/build.gradle
+++ b/Src/java/elm-fhir/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     // FHIR r5
     implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
 
+    implementation group: 'org.codelibs', name: 'xpp3', version: '1.1.4c.0'
+
     testImplementation project(':model-jackson')
     testImplementation project(':quick')
 }


### PR DESCRIPTION
The HAPI/UCUM dependencies pull in a version of the `xpp3` parser that is no longer maintained. This PR swaps to a fork that has been more recently updated. This fork also removes the `javax.xml.namespace` package from the jar, fixing the "The package javax.xml is accessible from more than one module: <unnamed>, java.xml" error when compiling on recent versions of Java.