### PR TITLE
QuickFix: { "translatorOptions" : "" } throws IllegalArgumentException

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TranslatorOptionsUtil.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TranslatorOptionsUtil.java
@@ -54,7 +54,7 @@ public class TranslatorOptionsUtil {
      * @return the set of options
      */
     public static EnumSet<CqlTranslatorOptions.Options> parseTranslatorOptions(String translatorOptions) {
-        if (translatorOptions == null) {
+        if (translatorOptions == null || translatorOptions.isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
Avoids a `CqlTranslatorOptions.Options.valueOf("")` when the json representation of the library is: 

```json
    "annotation" : [ {
      "type" : "CqlToElmInfo",
      "translatorOptions" : ""
    } ]
```

Which today creates a

```
Caused by: java.lang.IllegalArgumentException: No enum constant org.cqframework.cql.cql2elm.CqlTranslatorOptions.Options.
	at java.base/java.lang.Enum.valueOf(Enum.java:240)
	at org.cqframework.cql.cql2elm.CqlTranslatorOptions$Options.valueOf(CqlTranslatorOptions.java:12)
	at org.cqframework.cql.cql2elm.TranslatorOptionsUtil.parseTranslatorOptions(TranslatorOptionsUtil.java:65)
	at org.cqframework.cql.cql2elm.TranslatorOptionsUtil.getTranslatorOptions(TranslatorOptionsUtil.java:34)
	at org.cqframework.cql.cql2elm.LibraryManager.translatorOptionsMatch(LibraryManager.java:352)
	at org.cqframework.cql.cql2elm.LibraryManager.generateCompiledLibraryFromElm(LibraryManager.java:268)
	at org.cqframework.cql.cql2elm.LibraryManager.tryCompiledLibraryElm(LibraryManager.java:251)
	at org.cqframework.cql.cql2elm.LibraryManager.compileLibrary(LibraryManager.java:197)
	at org.cqframework.cql.cql2elm.LibraryManager.resolveLibrary(LibraryManager.java:184)
	at org.opencds.cqf.cql.evaluator.engine.execution.TranslatingLibraryLoader.translate(TranslatingLibraryLoader.java:115)
```