### PR TITLE
Support compiling CQL on multiple threads

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibrarySourceProviderFactory.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibrarySourceProviderFactory.java
@@ -4,11 +4,10 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public class LibrarySourceProviderFactory {
+    private LibrarySourceProviderFactory() {}
 
-    static ServiceLoader<LibrarySourceProvider> loader = ServiceLoader
-            .load(LibrarySourceProvider.class);
-
-    public static synchronized Iterator<LibrarySourceProvider> providers(boolean refresh) {
+    public static Iterator<LibrarySourceProvider> providers(boolean refresh) {
+        var loader = ServiceLoader.load(LibrarySourceProvider.class);
         if (refresh) {
             loader.reload();
         }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/ModelInfoProviderFactory.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/ModelInfoProviderFactory.java
@@ -6,11 +6,10 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public class ModelInfoProviderFactory {
+    private ModelInfoProviderFactory() {}
 
-    static ServiceLoader<ModelInfoProvider> loader = ServiceLoader
-            .load(ModelInfoProvider.class);
-
-    public static synchronized Iterator<ModelInfoProvider> providers(boolean refresh) {
+    public static Iterator<ModelInfoProvider> providers(boolean refresh) {
+        var loader = ServiceLoader.load(ModelInfoProvider.class);
         if (refresh) {
             loader.reload();
         }

--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
-        // needs javax.json.JsonException when using SAXUnmarshaller.getNewXMLReader
+    // needs javax.json.JsonException when using SAXUnmarshaller.getNewXMLReader
     implementation group: 'org.glassfish', 'name': 'javax.json', 'version': '1.0.4'
 }

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/serializing/ElmLibraryReaderFactory.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/serializing/ElmLibraryReaderFactory.java
@@ -4,11 +4,12 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public class ElmLibraryReaderFactory {
+    private ElmLibraryReaderFactory() {
+    }
 
-    static ServiceLoader<ElmLibraryReaderProvider> loader = ServiceLoader
-            .load(ElmLibraryReaderProvider.class);
-
-    public static synchronized Iterator<ElmLibraryReaderProvider> providers(boolean refresh) {
+    public static Iterator<ElmLibraryReaderProvider> providers(boolean refresh) {
+        var loader = ServiceLoader
+                .load(ElmLibraryReaderProvider.class);
         if (refresh) {
             loader.reload();
         }
@@ -22,8 +23,8 @@ public class ElmLibraryReaderFactory {
             ElmLibraryReaderProvider p = providers.next();
             if (providers.hasNext()) {
                 throw new RuntimeException(String.join(" ",
-                "Multiple ElmLibraryReaderProviders found on the classpath.",
-                "You need to remove a reference to either the 'elm-jackson' or the 'elm-jaxb' package"));
+                        "Multiple ElmLibraryReaderProviders found on the classpath.",
+                        "You need to remove a reference to either the 'elm-jackson' or the 'elm-jaxb' package"));
             }
 
             return p.create(contentType);

--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/serializing/ElmLibraryWriterFactory.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/serializing/ElmLibraryWriterFactory.java
@@ -4,11 +4,11 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public class ElmLibraryWriterFactory {
+    private ElmLibraryWriterFactory() {}
 
-    static ServiceLoader<ElmLibraryWriterProvider> loader = ServiceLoader
+    public static Iterator<ElmLibraryWriterProvider> providers(boolean refresh) {
+        var loader = ServiceLoader
             .load(ElmLibraryWriterProvider.class);
-
-    public static synchronized Iterator<ElmLibraryWriterProvider> providers(boolean refresh) {
         if (refresh) {
             loader.reload();
         }

--- a/Src/java/model/src/main/java/org/hl7/elm_modelinfo/r1/serializing/ModelInfoReaderFactory.java
+++ b/Src/java/model/src/main/java/org/hl7/elm_modelinfo/r1/serializing/ModelInfoReaderFactory.java
@@ -4,10 +4,10 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 public class ModelInfoReaderFactory {
-    static ServiceLoader<ModelInfoReaderProvider> loader = ServiceLoader
+    private ModelInfoReaderFactory() {}
+    public static Iterator<ModelInfoReaderProvider> providers(boolean refresh) {
+        var loader = ServiceLoader
             .load(ModelInfoReaderProvider.class);
-
-    public static synchronized Iterator<ModelInfoReaderProvider> providers(boolean refresh) {
         if (refresh) {
             loader.reload();
         }


### PR DESCRIPTION
Turns out the ServiceLoader returned by `load` isn't safe to use across multiple threads, even if access is synchronized. This PR updates the code to create a ServiceLoader per request and adds a test to detect if compilation on multiple threads is broken.