### PR TITLE
Use 'java-library' plugin, clean up dependencies

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -31,18 +31,6 @@ subprojects {
         testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
     }
 
-    // The FHIR ucum service depends on an
-    // XML pull-parser being present on the classpath, and have a compile-time reference to xpp3.
-    // However, some platfoms such as Android provide their own pull-parser implementations.
-    // Additionally, The xpp3.xpp3 dependency includes the javax.xml packagename, which is invalid in
-    // Java 9+ because split packages (i.e. the same packagename being available in multipe jar) are
-    // disallowed. For those reasons xpp3 is excluded here, and included as a runtime dependency for
-    // tests. Users of the CQL translator will need to supply their own implementation or add xpp3
-    // at runtime.
-    // configurations.implementation {
-    //     exclude group: 'xpp3', module: 'xpp3'
-    // }
-
     jar {
         manifest {
             attributes('Implementation-Title': project.name,

--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -9,7 +9,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'jacoco'
 
     sourceCompatibility = JavaVersion.VERSION_11
@@ -28,16 +28,20 @@ subprojects {
         testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
         testImplementation group: 'uk.co.datumedge', name: 'hamcrest-json', version: '0.2'
         testImplementation group: 'junit', name: 'junit', version: '4.12'
-        testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
+        testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
     }
 
-    // The xpp3.xpp3 dependency includes the javax.xml packagename, which is invalid in
-    // Java 9+. The FHIR ucum service and the HAPI validation framework both depend on this
-    // so the codelibs.xpp3 package is substituted instead. It's a fork of xpp3, but excludes
-    // the javax.xml packagename
-    configurations.implementation {
-        exclude group: 'xpp3', module: 'xpp3'
-    }
+    // The FHIR ucum service depends on an
+    // XML pull-parser being present on the classpath, and have a compile-time reference to xpp3.
+    // However, some platfoms such as Android provide their own pull-parser implementations.
+    // Additionally, The xpp3.xpp3 dependency includes the javax.xml packagename, which is invalid in
+    // Java 9+ because split packages (i.e. the same packagename being available in multipe jar) are
+    // disallowed. For those reasons xpp3 is excluded here, and included as a runtime dependency for
+    // tests. Users of the CQL translator will need to supply their own implementation or add xpp3
+    // at runtime.
+    // configurations.implementation {
+    //     exclude group: 'xpp3', module: 'xpp3'
+    // }
 
     jar {
         manifest {
@@ -122,11 +126,36 @@ subprojects {
 }
 
 /*
+FHIR dependencies
+*/
+configure(subprojects.findAll {it.name in ['cqf-fhir', 'elm-fhir', 'cqf-fhir-npm']}) {
+    dependencies {
+        // fhir core dependencies
+        implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.r5', version: '5.6.36'
+        implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.convertors', version: '5.6.36'
+        implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.utilities', version: '5.6.36'
+
+        // HAPI base
+        implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-base', version: '6.0.1'
+        implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-converter', version: '6.0.1'
+
+        // FHIR STU3
+        implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-dstu3', version: '6.0.1'
+
+        // FHIR r4
+        implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.0.1'
+
+        // FHIR r5
+        implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
+    }
+}
+
+/*
 JAXB dependencies:
 https://mkyong.com/java/jaxbexception-implementation-of-jaxb-api-has-not-been-found-on-module-path-or-classpath/
  */
 
-configure(subprojects.findAll {it.name in ['model', 'model-jackson', 'model-jaxb', 'elm', 'elm-jackson', 'elm-fhir', 'elm-jaxb', 'quick', 'qdm', 'cql-to-elm', 'cql-to-elm-cli']}) {
+configure(subprojects.findAll {it.name in ['model', 'elm', 'quick', 'qdm' ]}) {
     configurations {
         xjc
     }
@@ -141,9 +170,10 @@ configure(subprojects.findAll {it.name in ['model', 'model-jackson', 'model-jaxb
         xjc group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
         xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '2.4.0-b180830.0438'
         xjc group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
-        xjc group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
-        implementation group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.13.1'
-        implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
+        xjc group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
+
+        api group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.13.1'
+        api group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
     }
 
     ext.xjc = [

--- a/Src/java/cqf-fhir-npm/build.gradle
+++ b/Src/java/cqf-fhir-npm/build.gradle
@@ -1,24 +1,6 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':model')
     implementation project(':cql-to-elm')
-    // fhir core dependencies
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.r5', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.convertors', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.validation', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.utilities', version: '5.6.36'
-
-    // HAPI base
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-base', version: '6.0.1'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-converter', version: '6.0.1'
-
-    // FHIR STU3
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-dstu3', version: '6.0.1'
-
-    // FHIR r4
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.0.1'
-
-    // FHIR r5
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.1'
 }

--- a/Src/java/cqf-fhir/build.gradle
+++ b/Src/java/cqf-fhir/build.gradle
@@ -1,22 +1,4 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    // fhir core dependencies
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.r5', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.convertors', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.validation', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.utilities', version: '5.6.36'
-
-    // HAPI base
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-base', version: '6.0.1'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-converter', version: '6.0.1'
-
-    // FHIR STU3
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-dstu3', version: '6.0.1'
-
-    // FHIR r4
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.0.1'
-
-    // FHIR r5
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
 }

--- a/Src/java/cql-to-elm-cli/build.gradle
+++ b/Src/java/cql-to-elm-cli/build.gradle
@@ -4,23 +4,16 @@ mainClassName = 'org.cqframework.cql.cql2elm.cli.CqlTranslator'
 run.args = ["--input", "${projectDir}/../../../Examples/CMS146v2_CQM.cql"]
 
 dependencies {
-    implementation project(':cql')
-    implementation project(':model')
-    implementation project(':model-jaxb')
-    implementation project(':elm')
-    implementation project(':elm-jaxb')
     implementation project(':cql-to-elm')
     implementation project(':quick')
     implementation project(':qdm')
+    implementation project(':model-jaxb')
+    implementation project(':elm-jaxb')
     implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
-    implementation group: 'org.fhir', name: 'ucum', version: '1.0.3'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
-    implementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+    runtimeOnly group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+
     testImplementation project(':model-jaxb')
     testImplementation project(':model-jackson')
     testImplementation project(':elm-jaxb')
     testImplementation project(':elm-jackson')
-    testImplementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
 }

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -7,6 +7,15 @@ dependencies {
     api project(':cql')
     api project(':model')
     api project(':elm')
+
+    // The FHIR ucum service depends on an
+    // XML pull-parser being present on the classpath, and have a compile-time reference to xpp3.
+    // However, some platfoms such as Android provide their own pull-parser implementations.
+    // Additionally, The xpp3.xpp3 dependency includes the javax.xml packagename, which is invalid in
+    // Java 9+ because split packages (i.e. the same packagename being available in multipe jar) are
+    // disallowed. For those reasons xpp3 is excluded here, and included as a runtime dependency for
+    // tests. Users of the CQL translator will need to supply their own implementation or add xpp3
+    // at runtime.
     api ('org.fhir:ucum:1.0.3') {
         exclude group: 'xpp3', module: 'xpp3'
     }

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -4,13 +4,14 @@ mainClassName = 'org.cqframework.cql.cql2elm.CqlTranslator'
 run.args = ["--input", "${projectDir}/../../../Examples/CMS146v2_CQM.cql"]
 
 dependencies {
-    implementation project(':cql')
-    implementation project(':model')
-    implementation project(':elm')
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
-    implementation group: 'org.fhir', name: 'ucum', version: '1.0.3'
-    implementation group: 'org.codelibs', name: 'xpp3', version: '1.1.4c.0'
+    api project(':cql')
+    api project(':model')
+    api project(':elm')
+    api ('org.fhir:ucum:1.0.3') {
+        exclude group: 'xpp3', module: 'xpp3'
+    }
 
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 
     testImplementation project(':elm-jackson')
@@ -18,4 +19,5 @@ dependencies {
     testImplementation project(':quick')
     testImplementation project(':qdm')
     testImplementation group: 'com.github.reinert', name: 'jjschema', version: '1.16'
+    testRuntimeOnly group: 'xpp3', name: 'xpp3', version: '1.1.4c'
 }

--- a/Src/java/elm-fhir/build.gradle
+++ b/Src/java/elm-fhir/build.gradle
@@ -1,36 +1,9 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':model')
-    implementation project(':elm')
     implementation project(':cql-to-elm')
 
-    // fhir core dependencies
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.r5', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.convertors', version: '5.6.36'
-    // implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.validation', version: '5.6.36'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'org.hl7.fhir.utilities', version: '5.6.36'
-
-    // HAPI base
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-base', version: '6.0.1'
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-converter', version: '6.0.1'
-
-    // FHIR STU3
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-dstu3', version: '6.0.1'
-
-    // FHIR r4
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r4', version: '6.0.1'
-
-    // FHIR r5
-    implementation group: 'ca.uhn.hapi.fhir', name: 'hapi-fhir-structures-r5', version: '6.0.1'
-
-    implementation group: 'org.codelibs', name: 'xpp3', version: '1.1.4c.0'
-
     testImplementation project(':quick')
-    testImplementation group: 'org.fhir', name: 'ucum', version: '1.0.3'
-    testImplementation group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.13.1'
-    testImplementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
-
     testRuntimeOnly project(':model-jackson')
-
+    testRuntimeOnly group: 'xpp3', name: 'xpp3', version: '1.1.4c'
 }

--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -1,8 +1,8 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':model')
-    implementation project(':elm')
+    api project(':model')
+    api project(':elm')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'

--- a/Src/java/elm-jaxb/build.gradle
+++ b/Src/java/elm-jaxb/build.gradle
@@ -1,6 +1,6 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':elm')
+    api project(':elm')
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
 }

--- a/Src/java/elm-test/build.gradle
+++ b/Src/java/elm-test/build.gradle
@@ -1,14 +1,10 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':model')
-    implementation project(':model-jaxb')
-    implementation project(':elm')
     implementation project(':cql-to-elm')
+    implementation project(':model-jaxb')
     implementation project(':elm-jackson')
     implementation project(':elm-jaxb')
-    implementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
-    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
-    implementation group: 'org.fhir', name: 'ucum', version: '1.0.3'
-    implementation group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics', version: '0.13.1'
+    testRuntimeOnly group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+    testRuntimeOnly group: 'xpp3', name: 'xpp3', version: '1.1.4c'
 }

--- a/Src/java/model-jackson/build.gradle
+++ b/Src/java/model-jackson/build.gradle
@@ -1,7 +1,7 @@
 // Most build configuration comes from the cql-all parent build!
 
 dependencies {
-    implementation project(':model')
+    api project(':model')
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.13.2'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
 

--- a/Src/java/model/build.gradle
+++ b/Src/java/model/build.gradle
@@ -1,8 +1,7 @@
 
 dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
-
-    testImplementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+    testRuntimeOnly group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
 }
 
 generateSources {

--- a/Src/java/tools/xsd-to-modelinfo/build.gradle
+++ b/Src/java/tools/xsd-to-modelinfo/build.gradle
@@ -4,9 +4,8 @@ mainClassName = 'org.cqframework.cql.tools.xsd2modelinfo.Main'
 
 dependencies {
     implementation project(':model')
-    implementation group: 'org.jvnet.jaxb2_commons', name: 'jaxb2-basics-runtime', version: '0.13.1'
     implementation group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '4.7'
     implementation group: 'org.apache.ws.xmlschema', name: 'xmlschema-core', version: '2.2.5'
     implementation group: 'org.apache.ws.xmlschema', name: 'xmlschema-walker', version: '2.2.5'
-    testImplementation group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
+    testRuntimeOnly group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.moxy', version: '2.7.7'
 }


### PR DESCRIPTION
Apologies for the churn on the `xpp3` bits, still discovering better ways to do things.

This PR changes from the `java` gradle plugin to the `java-library` plugin. Documentation for this plugin is available here, but the gist of it is that it extends the `java` plugin with some more flexible dependency options:
https://docs.gradle.org/current/userguide/java_library_plugin.html

Specifically, it introduces a new dependency scope called `api`, which means that a dependency should be included at both compile time and runtime, and should be included transitively for downstream users. This is in contrast to `implementation` which includes a dependency at compile-time only and is not transitive. This meant redeclaring many dependencies throughout the repo, and caused several to be imported at compile time when they were needed only at runtime (xpp3 being the biggest culprit here).

I reworked the dependencies in the cql-translator such that a user of `cql-to-elm` will get all the required upstream dependencies (`cql`, `elm`, `model`, etc.) automatically, which is a common stumbling block for integrators ("why doesn't `cql-to-elm` work out of the box?"). This in conjunction with the previous PR that prompts users to include the specific `elm-jaxb` (or jackson) and `model-jaxb` (or jackson) libraries minimize the amount of churn required to get up and running with the cql-compiler. Best case, a user needs to declare only 3 dependencies:

```
implementation 'info.cqframework:cql-to-elm:2.1.0'
implementation 'info.cqframework:elm-jackson:2.1.0'
implementation 'info.cqframework:model-jackson:2.1.0'
```

With respect to `xpp3`, it's now only being pulled in via the `ucum` dependency. It's been excluded as compile-time dependency and added a test-runtime-only dependency. This should allow end-users to specify their own pull-parser where needed and maximize compatibility with existing use cases.