### PR TITLE
Formalizes compliance with Android 8, SDK 26 (2017+)

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'ru.vyarus.animalsniffer' version '1.6.0'
+}
+
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
@@ -118,6 +122,16 @@ subprojects {
 
     artifacts {
         archives javadocJar, sourcesJar
+    }
+}
+
+// Modules that can be used on Android
+configure(subprojects.findAll {it.name in ['model', 'model-jackson', 'elm', 'cql', 'elm-jackson', 'elm-fhir', 'quick', 'qdm', 'cql-to-elm', 'fhir-all', 'fhir-r4']}) {
+    apply plugin: 'ru.vyarus.animalsniffer'
+
+    dependencies {
+        // Checks compliance with Android API 26
+        signature 'net.sf.androidscents.signature:android-api-level-26:8.0.0_r2@signature'
     }
 }
 


### PR DESCRIPTION
This PR formalizes this project's compliance with Android
1. Adds an Animal Sniffer plugin to check compliance with any runtime API when running `gradle check`
2. Selects modules model, model-jackson, cql, elm, elm-jackson, elm-fhir, quick, qdm, cql-to-elm, fhir-all and fhir-r4 to be checked for Android compliance. 
3. Establishes initial compliance to Android 8 - SDK 26, the minimum Android version the Translator is currently fully compliant with. 

**Important**: The plugin only verifies the source code in this project, not dependencies. 

For testing, add: 

```java
if (Optional.of(UUID.randomUUID()).isEmpty())
   throw new RuntimeException("Test");
```

in the desired module and run `./gradlew check`. 

Since the method `Optional.isEmpty` is not available on Android, the output should look like this: 

![Screen Shot 2022-09-25 at 4 01 33 PM](https://user-images.githubusercontent.com/532031/192163063-fab2cbc6-6079-4332-82fb-02ef7b281a50.png)


