### PR TITLE
make try elm optional

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
@@ -29,7 +29,7 @@ public class CqlTranslatorOptions {
     private EnumSet<Options> options = EnumSet.noneOf(Options.class);
     private boolean validateUnits = true;
     private boolean verifyOnly = false;
-    private boolean tryElm = true;
+    private boolean enableCqlOnly = false;
     private String compatibilityLevel = "1.5";
     private CqlCompilerException.ErrorSeverity errorLevel = CqlCompilerException.ErrorSeverity.Info;
     private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
@@ -271,19 +271,19 @@ public class CqlTranslatorOptions {
     }
 
     /**
-     * Return instance of CqlTranslatorOptions tryElm boolean
+     * Return instance of CqlTranslatorOptions enableCqlOnly boolean
      * @return
      */
-    public boolean getTryElm() {
-        return this.tryElm;
+    public boolean getEnableCqlOnly() {
+        return this.enableCqlOnly;
     }
 
     /**
-     * Set new tryElm boolean
-     * @param tryElm
+     * Set new enableCqlOnly boolean
+     * @param enableCqlOnly
      */
-    public void setTryElm(boolean tryElm) {
-        this.tryElm = tryElm;
+    public void setEnableCqlOnly(boolean enableCqlOnly) {
+        this.enableCqlOnly = enableCqlOnly;
     }
 
     /**

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
@@ -23,13 +23,13 @@ public class CqlTranslatorOptions {
         DisableMethodInvocation,
         RequireFromKeyword,
         DisableDefaultModelInfoLoad,
-        EnableCqlOnly
     }
 
     private List<CqlTranslator.Format> formats = new ArrayList<>();
     private EnumSet<Options> options = EnumSet.noneOf(Options.class);
     private boolean validateUnits = true;
     private boolean verifyOnly = false;
+    private boolean tryElm = true;
     private String compatibilityLevel = "1.5";
     private CqlCompilerException.ErrorSeverity errorLevel = CqlCompilerException.ErrorSeverity.Info;
     private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
@@ -268,6 +268,22 @@ public class CqlTranslatorOptions {
     public CqlTranslatorOptions withVerifyOnly(boolean verifyOnly) {
         setVerifyOnly(verifyOnly);
         return this;
+    }
+
+    /**
+     * Return instance of CqlTranslatorOptions tryElm boolean
+     * @return
+     */
+    public boolean getTryElm() {
+        return this.tryElm;
+    }
+
+    /**
+     * Set new tryElm boolean
+     * @param tryElm
+     */
+    public void setTryElm(boolean tryElm) {
+        this.tryElm = tryElm;
     }
 
     /**

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
@@ -22,7 +22,8 @@ public class CqlTranslatorOptions {
         EnableIntervalPromotion,
         DisableMethodInvocation,
         RequireFromKeyword,
-        DisableDefaultModelInfoLoad
+        DisableDefaultModelInfoLoad,
+        EnableCqlOnly
     }
 
     private List<CqlTranslator.Format> formats = new ArrayList<>();

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
@@ -22,7 +22,7 @@ public class CqlTranslatorOptions {
         EnableIntervalPromotion,
         DisableMethodInvocation,
         RequireFromKeyword,
-        DisableDefaultModelInfoLoad,
+        DisableDefaultModelInfoLoad
     }
 
     private List<CqlTranslator.Format> formats = new ArrayList<>();

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -194,7 +194,7 @@ public class LibraryManager {
     private CompiledLibrary compileLibrary(VersionedIdentifier libraryIdentifier, CqlTranslatorOptions options, List<CqlCompilerException> errors) {
 
         CompiledLibrary result = null;
-        if(!options.getOptions().contains(CqlTranslatorOptions.Options.EnableCqlOnly)) {
+        if(options.getTryElm()) {
             result = tryCompiledLibraryElm(libraryIdentifier, options);
             if (result != null) {
                 return result;

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -194,9 +194,11 @@ public class LibraryManager {
     private CompiledLibrary compileLibrary(VersionedIdentifier libraryIdentifier, CqlTranslatorOptions options, List<CqlCompilerException> errors) {
 
         CompiledLibrary result = null;
-        result = tryCompiledLibraryElm(libraryIdentifier, options);
-        if (result != null) {
-            return result;
+        if(!options.getOptions().contains(CqlTranslatorOptions.Options.EnableCqlOnly)) {
+            result = tryCompiledLibraryElm(libraryIdentifier, options);
+            if (result != null) {
+                return result;
+            }
         }
 
         String libraryPath = NamespaceManager.getPath(libraryIdentifier.getSystem(), libraryIdentifier.getId());

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -194,7 +194,7 @@ public class LibraryManager {
     private CompiledLibrary compileLibrary(VersionedIdentifier libraryIdentifier, CqlTranslatorOptions options, List<CqlCompilerException> errors) {
 
         CompiledLibrary result = null;
-        if(options.getTryElm()) {
+        if(!options.getEnableCqlOnly()) {
             result = tryCompiledLibraryElm(libraryIdentifier, options);
             if (result != null) {
                 return result;

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
@@ -10,6 +10,9 @@
     "compatibilityLevel" : {
       "type" : "string"
     },
+    "enableCqlOnly" : {
+      "type" : "boolean"
+    },
     "errorLevel" : {
       "enum" : [ "Info", "Warning", "Error" ],
       "type" : "string"
@@ -31,9 +34,6 @@
     "signatureLevel" : {
       "enum" : [ "None", "Differing", "Overloads", "All" ],
       "type" : "string"
-    },
-    "tryElm" : {
-      "type" : "boolean"
     },
     "validateUnits" : {
       "type" : "boolean"

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
@@ -24,13 +24,16 @@
     "options" : {
       "type" : "array",
       "items" : {
-        "enum" : [ "EnableDateRangeOptimization", "EnableAnnotations", "EnableLocators", "EnableResultTypes", "EnableDetailedErrors", "DisableListTraversal", "DisableListDemotion", "DisableListPromotion", "EnableIntervalDemotion", "EnableIntervalPromotion", "DisableMethodInvocation", "RequireFromKeyword", "DisableDefaultModelInfoLoad", "EnableCqlOnly" ],
+        "enum" : [ "EnableDateRangeOptimization", "EnableAnnotations", "EnableLocators", "EnableResultTypes", "EnableDetailedErrors", "DisableListTraversal", "DisableListDemotion", "DisableListPromotion", "EnableIntervalDemotion", "EnableIntervalPromotion", "DisableMethodInvocation", "RequireFromKeyword", "DisableDefaultModelInfoLoad" ],
         "type" : "string"
       }
     },
     "signatureLevel" : {
       "enum" : [ "None", "Differing", "Overloads", "All" ],
       "type" : "string"
+    },
+    "tryElm" : {
+      "type" : "boolean"
     },
     "validateUnits" : {
       "type" : "boolean"

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/json/CqlTranslatorOptions.json
@@ -24,7 +24,7 @@
     "options" : {
       "type" : "array",
       "items" : {
-        "enum" : [ "EnableDateRangeOptimization", "EnableAnnotations", "EnableLocators", "EnableResultTypes", "EnableDetailedErrors", "DisableListTraversal", "DisableListDemotion", "DisableListPromotion", "EnableIntervalDemotion", "EnableIntervalPromotion", "DisableMethodInvocation", "RequireFromKeyword", "DisableDefaultModelInfoLoad" ],
+        "enum" : [ "EnableDateRangeOptimization", "EnableAnnotations", "EnableLocators", "EnableResultTypes", "EnableDetailedErrors", "DisableListTraversal", "DisableListDemotion", "DisableListPromotion", "EnableIntervalDemotion", "EnableIntervalPromotion", "DisableMethodInvocation", "RequireFromKeyword", "DisableDefaultModelInfoLoad", "EnableCqlOnly" ],
         "type" : "string"
       }
     },


### PR DESCRIPTION
I am considering having an option here. However `CqlTranslatorOptions` might not be wise one as the user might use the same options object in the successive translate call. @brynrhodes would you suggest `LibraryManager.resolveLibrary()` have an extra boolean parameter or any other suggestion