### PR TITLE
Move generated sources to standard location

### DIFF
--- a/Src/java/build.gradle
+++ b/Src/java/build.gradle
@@ -179,7 +179,7 @@ configure(subprojects.findAll {it.name in ['model', 'elm', 'quick', 'qdm', 'engi
     }
 
     ext.xjc = [
-            destDir: "${projectDir}/src/generated/java",
+            destDir: "${buildDir}/generated/sources/$name/main/java",
             args: '-disableXmlSecurity -Xfluent-api -Xequals -XhashCode -XtoString'
     ]
 
@@ -205,7 +205,14 @@ configure(subprojects.findAll {it.name in ['model', 'elm', 'quick', 'qdm', 'engi
 
     compileJava.dependsOn generateSources
     sourcesJar.dependsOn generateSources
-    sourceSets.main.java.srcDirs += xjc.destDir
+
+    sourceSets {
+        main {
+            java {
+                srcDir(xjc.destDir)
+            }
+        }
+    }
 
     clean {
         delete xjc.destDir

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -80,7 +80,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         this.libraryBuilder = libraryBuilder;
         this.systemMethodResolver = new SystemMethodResolver(this, libraryBuilder);
     }
-    
+
     public void enableAnnotations() {
         annotate = true;
     }
@@ -3507,6 +3507,7 @@ DATETIME
                 .withCodeProperty(codePath);
 
         if (ctx.contextIdentifier() != null) {
+            @SuppressWarnings("unchecked")
             List<String> identifiers = (List<String>)visit(ctx.contextIdentifier());
             Expression contextExpression = resolveQualifiedIdentifier(identifiers);
             retrieve.setContext(contextExpression);


### PR DESCRIPTION
* Changes the generated source location from `src` to `build`, which is the standard location for gradle
* Fixes a couple build cache invalidation issues
* Fixes the project in IDEs that don't support non-standard locations