### PR TITLE
Cache Function Defs

### DIFF
--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/FunctionRefEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/FunctionRefEvaluator.java
@@ -5,10 +5,15 @@ import java.util.Optional;
 
 import org.cqframework.cql.elm.execution.Expression;
 import org.cqframework.cql.elm.execution.FunctionDef;
+import org.cqframework.cql.elm.execution.FunctionRef;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.Variable;
 
 public class FunctionRefEvaluator extends org.cqframework.cql.elm.execution.FunctionRef {
+
+    // For a given instance of the FunctionDefEvaluator, we'll only resolve to one FunctionDef
+    // Even if it's evaluated multiple times in a given ELM graph.
+    private FunctionDef functionDef;
 
     @Override
     protected Object internalEvaluate(Context context) {
@@ -19,8 +24,12 @@ public class FunctionRefEvaluator extends org.cqframework.cql.elm.execution.Func
 
         boolean enteredLibrary = context.enterLibrary(this.getLibraryName());
         try {
-            // TODO: Use type specifiers from the operands here if they are available
-            FunctionDef functionDef = context.resolveFunctionRef(this.getName(), arguments, this.getLibraryName());
+
+            // TODO: Use type specifiers from the operands here if they are available to resolveFunctionRef
+            if (functionDef == null) {
+                this.functionDef = context.resolveFunctionRef(this.getName(), arguments, this.getLibraryName());
+            }
+
             if (Optional.ofNullable(functionDef.isExternal()).orElse(false)) {
                 return context.getExternalFunctionProvider().evaluate(functionDef.getName(), arguments);
             }


### PR DESCRIPTION
* Cache the functionDefs for a given FunctionRefEvaluator.

The CQL engine uses run-time function overload resolution because type information is frequently missing from the ELM graph. However, the CQL spec actually requires function overloads to be distinguishable at compile-time. This implies that for a given FunctionRef in the ELM graph the CQL engine will only ever resolve one and only one FunctionDef (given a valid set of ELM). This means we can resolve it once and then cache it for future FunctionRef evaluations in the event it's evaluated multiple time (for example, in the case of a `where` clause or a `let` clause).