### PR TITLE
Bug fix for function overloads

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlTranslatorOptions.java
@@ -9,7 +9,7 @@ import java.util.List;
  * translation options for Cql source files
  */
 public class CqlTranslatorOptions {
-    public static enum Options {
+    public enum Options {
         EnableDateRangeOptimization,
         EnableAnnotations,
         EnableLocators,
@@ -32,7 +32,7 @@ public class CqlTranslatorOptions {
     private boolean enableCqlOnly = false;
     private String compatibilityLevel = "1.5";
     private CqlCompilerException.ErrorSeverity errorLevel = CqlCompilerException.ErrorSeverity.Info;
-    private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
+    private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.Overloads;
     private boolean analyzeDataRequirements = false;
     private boolean collapseDataRequirements = false;
 
@@ -69,11 +69,11 @@ public class CqlTranslatorOptions {
      * @param options
      */
     public CqlTranslatorOptions(Options... options) {
-        this(CqlCompilerException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.None, options);
+        this(CqlCompilerException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.Overloads, options);
     }
 
     public CqlTranslatorOptions(CqlCompilerException.ErrorSeverity errorLevel, Options... options) {
-        this(errorLevel, LibraryBuilder.SignatureLevel.None, options);
+        this(errorLevel, LibraryBuilder.SignatureLevel.Overloads, options);
     }
 
     /**
@@ -406,7 +406,7 @@ public class CqlTranslatorOptions {
         this.analyzeDataRequirements = analyzeDataRequirements;
     }
 
-    /**git 
+    /**git
      * Return this instance of CqlTranslatorOptions with addition of newly assigned analyzedDataRequirements boolean
      * @param analyzeDataRequirements
      * @return

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/options.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/options.json
@@ -1,1 +1,1 @@
-{"options":["EnableAnnotations","EnableLocators","DisableListDemotion","DisableListPromotion"],"formats":[],"validateUnits":true,"verifyOnly":false,"errorLevel":"Info","signatureLevel":"None"}
+{"options":["EnableAnnotations","EnableLocators","DisableListDemotion","DisableListPromotion"],"formats":[],"validateUnits":true,"verifyOnly":false,"errorLevel":"Info","signatureLevel":"Overloads"}

--- a/Src/java/engine-jackson/src/test/java/org/opencds/cqf/cql/engine/execution/CqlFunctionOverloadTest.java
+++ b/Src/java/engine-jackson/src/test/java/org/opencds/cqf/cql/engine/execution/CqlFunctionOverloadTest.java
@@ -27,11 +27,14 @@ public class CqlFunctionOverloadTest {
         Context context = new Context(library);
 
         try {
-            Object result = context.resolveExpressionRef("TestAnyFunctionWithInteger").getExpression().evaluate(context);
+            context.resolveExpressionRef("TestAnyFunctionWithInteger").getExpression().evaluate(context);
             Assert.fail();
         } catch (CqlException e) {
-            assertThat(e.getMessage().startsWith("Signature not provided for overloaded function 'TestAny'"), is(true));
+            assertThat(e.getMessage().startsWith("Signature not provided for overloaded function 'FunctionOverload.TestAny'"), is(true));
         }
+
+        var result = context.resolveExpressionRef("TestAnyFunctionWithNoArgs").getExpression().evaluate(context);
+        assertThat(result, is("any"));
     }
 
     @Test
@@ -46,6 +49,9 @@ public class CqlFunctionOverloadTest {
 
         result = context.resolveExpressionRef("TestAnyFunctionWithDecimal").getExpression().evaluate(context);
         assertThat(result, is(new BigDecimal("12.3")));
+
+        result = context.resolveExpressionRef("TestAnyFunctionWithNoArgs").getExpression().evaluate(context);
+        assertThat(result, is("any"));
     }
 
 }

--- a/Src/java/engine-jackson/src/test/resources/org/opencds/cqf/cql/engine/execution/FunctionOverloadTest.cql
+++ b/Src/java/engine-jackson/src/test/resources/org/opencds/cqf/cql/engine/execution/FunctionOverloadTest.cql
@@ -9,6 +9,9 @@ define function TestAny(b String):
 define function TestAny(c Decimal):
   c
 
+define function TestAny():
+  'any'
+
 define TestAnyFunctionWithInteger:
   TestAny(1)
 
@@ -17,3 +20,6 @@ define TestAnyFunctionWithString:
 
 define TestAnyFunctionWithDecimal:
   TestAny(12.3)
+
+define TestAnyFunctionWithNoArgs:
+  TestAny()

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/FunctionRefEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/FunctionRefEvaluator.java
@@ -12,6 +12,9 @@ import org.opencds.cqf.cql.engine.execution.Variable;
 
 public class FunctionRefEvaluator extends org.cqframework.cql.elm.execution.FunctionRef {
 
+    // Resolve and cache the functionDef
+    private FunctionDef functionDef;
+
     @Override
     protected Object internalEvaluate(Context context) {
         ArrayList<Object> arguments = new ArrayList<>(this.getOperand().size());
@@ -21,7 +24,9 @@ public class FunctionRefEvaluator extends org.cqframework.cql.elm.execution.Func
 
         boolean enteredLibrary = context.enterLibrary(this.getLibraryName());
         try {
-            FunctionDef functionDef = context.resolveFunctionRef(this.getLibraryName(), this.getName(), arguments, this.getSignature());
+            if (functionDef == null) {
+                this. functionDef = context.resolveFunctionRef(this.getLibraryName(), this.getName(), arguments, this.getSignature());
+            }
 
             if (Optional.ofNullable(functionDef.isExternal()).orElse(false)) {
                 return context.getExternalFunctionProvider().evaluate(functionDef.getName(), arguments);


### PR DESCRIPTION
* Default translator to SignatureLevel.Overloads since that produces safe ELM
* Fix overload resolution in CQL engine for no-argument overloads
* Add function expression caching for FunctionRefEvaluator