### PR TITLE
Fixes for list Unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/info.cqframework/cql-to-elm/badge.svg)](https://maven-badges.herokuapp.com/maven-central/info.cqframework/cql-to-elm) [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.fhir.org/#narrow/stream/179220-cql)
 
 # Clinical Quality Language
+
 Clinical Quality Language ([CQL](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=400)) is a Health Level 7 ([HL7](http://www.hl7.org/index.cfm)) standard for the expression of clinical knowledge that can be used within a broad range of clinical domains, including Clinical Decision Support (CDS), and Clinical Quality Measurement (CQM).
 
-This repository contains documentation, examples, and tooling in support of the CQL specification, including a CQL verifier/translator.
+This repository contains documentation, examples, and tooling in support of the [CQL specification](https://cql.hl7.org/), including a CQL compiler and ELM runtime.
 
+* [CQL Specification](https://cql.hl7.org/) - Specification for CQL, along with an Authoring Guide and a Developer's guide
 * [Getting Started](https://github.com/cqframework/CQL-Formatting-and-Usage-Wiki/wiki/Getting-Started) - A collection of resources to help new users get started
 * [Cooking with CQL Examples](https://github.com/cqframework/CQL-Formatting-and-Usage-Wiki/wiki/Cooking-with-CQL-Examples) - Examples from Cooking with CQL sessions
 
 # Background
+
 CQL was developed as part of the Clinical Quality Framework ([CQF](https://oncprojectracking.healthit.gov/wiki/display/TechLabSC/CQF+Home)) initiative, a public-private partnership sponsored by the Centers for Medicare & Medicaid Services (CMS) and the U.S. Office of the National Coordinator for Health Information Technology (ONC) to identify, develop, and harmonize standards for clinical decision support and electronic clinical quality measurement.
 
 The Clinical Quality Language specification is maintained by the HL7 Clinical Decision Support ([CDS](http://www.hl7.org/Special/committees/dss/index.cfm)) Work Group with co-sponsorship from the HL7 Clinical Quality Information ([CQI](http://www.hl7.org/Special/committees/cqi/index.cfm)) Work Group.
 
 # Scope
+
 The primary focus of the tooling in this repository is to support and enable adoption and implementation of the Clinical Quality Language specification. In particular, the CQL-to-ELM translator provides a reference implementation for syntactic and semantic validation of Clinical Quality Language. As such, the features and functionality provided by these tools are ultimately defined by the CQL specification, and that specification is the source-of-truth for those requirements. This relationship to the CQL standard heavily informs and shapes the change management policies for maintenance of these tools.
 
 # Community
+
 The CQL community consists of multiple stakeholders including EHR vendors, clinical knowledge content vendors, knowledge artifact authors, and clinical quality content tool vendors. We encourage participation from these and other relevant stakeholders, and the processes and policies described here are intended to enable participation and support of the CQL tooling. Because this community of stakeholders both depends on and provides feedback to these tools, their participation in these processes is vital.
 
 # Change Management
+
 Changes to the tooling maintained within this repository are managed using as lightweight a process as possible, while still ensuring stable, viable, production quality software. These processes are described in the [Change Management](CHANGE_MANAGEMENT.md) topic.
 
 # Contents
@@ -29,9 +35,14 @@ Changes to the tooling maintained within this repository are managed using as li
 * [Java Quickstart](Src/java-quickstart/README.md)
 
 # License
+
 All code in this repository is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). All documentation is licensed under the [Creative Common Attribution 4.0 International license (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
 
+CQL compiler/translator, grammar, and associated tooling:
 Copyright 2014 The MITRE Corporation
+
+ELM runtime and associated components (specifically the `java/engine` and `java/engine-fhir` modules):
+Copyright 2016 University of Utah
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Src/java/README.md
+++ b/Src/java/README.md
@@ -7,6 +7,8 @@ It contains the following sub-projects:
 * **model:** generates and builds Java classes based on the ELM Model Info schema and CQL base type system
 * **elm:** generates and builds Java classes based on the ELM XML schema
 * **elm-fhir:** contains data requirements processor and fhir-related utilities
+* **engine:** contains the ELM runtime (aka "CQL engine")
+* **engine-fhir:** contains fhir-related components for the ELM runtime
 * **qdm:** contains schema and model info resources for QDM (4.2, 5.0, 5.0.1, 5.0.2, 5.3)
 * **quick:** contains schema and model info resources for QUICK and FHIR, DSTU2 (1.0.2), and STU3 (1.4, 1.6, 1.8, and 3.0.1)
 * **cql-to-elm:** generates Expression Logical Model (ELM) XML and JSON from CQL source

--- a/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
+++ b/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
@@ -35,6 +36,7 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
     }
 
     @Test
+    @Ignore("This test depends on the example.fhir.uv.myig package, which is not currently published")
     public void TestSampleContentIGLocal() {
         Resource igResource = (Resource) FhirContext.forR4Cached().newXmlParser().parseResource(
                 NpmPackageManagerTests.class.getResourceAsStream("mycontentig.xml"));
@@ -54,9 +56,9 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
             }
         }
         assertTrue(hasFHIR);
-        //assertTrue(hasMyIG);
-        //assertTrue(hasCommon);
-        //assertTrue(hasCPG);
+        assertTrue(hasMyIG);
+        assertTrue(hasCommon);
+        assertTrue(hasCPG);
     }
 
     @Test
@@ -79,6 +81,7 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
     }
 
     @Test
+    @Ignore("This test depends on the example.fhir.uv.myig package, which is not currently published")
     public void TestLibrarySourceProviderLocal() {
         Resource igResource = (Resource) FhirContext.forR4Cached().newXmlParser().parseResource(
                 NpmPackageManagerTests.class.getResourceAsStream("mycontentig.xml"));

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -1136,42 +1136,42 @@ public class LibraryBuilder implements ModelResolver {
 
         CallContext callContext = new CallContext(libraryName, operatorName, allowPromotionAndDemotion, allowFluent, mustResolve, dataTypes.toArray(new DataType[dataTypes.size()]));
         OperatorResolution resolution = resolveCall(callContext);
-        if (resolution != null || mustResolve) {
-            checkOperator(callContext, resolution);
-
-            List<Expression> convertedOperands = new ArrayList<>();
-            Iterator<Expression> operandIterator = operands.iterator();
-            Iterator<DataType> signatureTypes = resolution.getOperator().getSignature().getOperandTypes().iterator();
-            Iterator<Conversion> conversionIterator = resolution.hasConversions() ? resolution.getConversions().iterator() : null;
-            while (operandIterator.hasNext()) {
-                Expression operand = operandIterator.next();
-                Conversion conversion = conversionIterator != null ? conversionIterator.next() : null;
-                if (conversion != null) {
-                    operand = convertExpression(operand, conversion);
-                }
-
-                DataType signatureType = signatureTypes.next();
-                operand = pruneChoices(operand, signatureType);
-
-                convertedOperands.add(operand);
-            }
-
-            invocation.setOperands(convertedOperands);
-
-            if (options.getSignatureLevel() == SignatureLevel.All || (options.getSignatureLevel() == SignatureLevel.Differing
-                && !resolution.getOperator().getSignature().equals(callContext.getSignature()))
-                    || (options.getSignatureLevel() == SignatureLevel.Overloads && resolution.getOperatorHasOverloads())) {
-                invocation.setSignature(dataTypesToTypeSpecifiers(resolution.getOperator().getSignature().getOperandTypes()));
-            }
-
-            invocation.setResultType(resolution.getOperator().getResultType());
-            if (resolution.getLibraryIdentifier() != null) {
-                resolution.setLibraryName(resolveIncludeAlias(resolution.getLibraryIdentifier()));
-            }
-            invocation.setResolution(resolution);
-            return invocation;
+        if (resolution == null && !mustResolve) {
+            return null;
         }
-        return null;
+
+        checkOperator(callContext, resolution);
+        List<Expression> convertedOperands = new ArrayList<>();
+        Iterator<Expression> operandIterator = operands.iterator();
+        Iterator<DataType> signatureTypes = resolution.getOperator().getSignature().getOperandTypes().iterator();
+        Iterator<Conversion> conversionIterator = resolution.hasConversions() ? resolution.getConversions().iterator() : null;
+        while (operandIterator.hasNext()) {
+            Expression operand = operandIterator.next();
+            Conversion conversion = conversionIterator != null ? conversionIterator.next() : null;
+            if (conversion != null) {
+                operand = convertExpression(operand, conversion);
+            }
+
+            DataType signatureType = signatureTypes.next();
+            operand = pruneChoices(operand, signatureType);
+
+            convertedOperands.add(operand);
+        }
+
+        invocation.setOperands(convertedOperands);
+
+        if (options.getSignatureLevel() == SignatureLevel.All || (options.getSignatureLevel() == SignatureLevel.Differing
+            && !resolution.getOperator().getSignature().equals(callContext.getSignature()))
+                || (options.getSignatureLevel() == SignatureLevel.Overloads && resolution.getOperatorHasOverloads())) {
+            invocation.setSignature(dataTypesToTypeSpecifiers(resolution.getOperator().getSignature().getOperandTypes()));
+        }
+
+        invocation.setResultType(resolution.getOperator().getResultType());
+        if (resolution.getLibraryIdentifier() != null) {
+            resolution.setLibraryName(resolveIncludeAlias(resolution.getLibraryIdentifier()));
+        }
+        invocation.setResolution(resolution);
+        return invocation;
     }
 
     private Expression pruneChoices(Expression expression, DataType targetType) {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryManagerTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryManagerTests.java
@@ -1,0 +1,56 @@
+package org.cqframework.cql.cql2elm;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class LibraryManagerTests {
+
+    ModelManager modelManager;
+    LibraryManager libraryManager;
+
+    @BeforeClass
+    public void setup() {
+        modelManager = new ModelManager();
+        libraryManager = new LibraryManager(modelManager);
+        libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider("LibraryManagerTests"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        libraryManager.getLibrarySourceLoader().clearProviders();
+    }
+
+
+    @Test
+    public void testLibraryStatementsAreSorted() {
+        // Some optimizations depend on the Library statements being sorted in lexicographic order by name
+        // This test validates that they are ordered
+        var lib = libraryManager.resolveLibrary(new VersionedIdentifier().withId("OutOfOrder")).getLibrary();
+
+        assertNotNull(lib);
+        assertNotNull(lib.getStatements().getDef());
+
+        var defs = lib.getStatements().getDef();
+        assertThat(
+            "The list should be larger than 3 elements to validate it actually sorted",
+            defs.size(),
+            greaterThan(3));
+
+
+        for (int i = 0; i < defs.size() - 1; i++) {
+            var left = defs.get(i);
+            var right = defs.get(i +1);
+
+            // Ensure that the left element is always less than or equal to the right element
+            // In other words, they are ordered.
+            assertThat(left.getName().compareTo(right.getName()), lessThanOrEqualTo(0));
+        }
+    }
+}

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/OutOfOrder.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/OutOfOrder.cql
@@ -1,0 +1,25 @@
+library "OutOfOrder"
+
+
+define "Z":
+    1
+
+define "B":
+    2
+
+define "C":
+    3
+
+define "A":
+    4
+
+define "1":
+    5
+
+define "z":
+    6
+
+define "100":
+    7
+
+

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -443,7 +443,7 @@ public class CqlEngine extends ElmBaseLibraryVisitor<Object, State> {
         if (left.getResultType() instanceof ListType || right.getResultType() instanceof ListType || elm.getResultType() instanceof ListType) {
             return UnionEvaluator.unionIterable((Iterable<?>)leftResult, (Iterable<?>)rightResult, state);
         }
-        else if (left.getResultType() instanceof IntervalType || right.getResultType() instanceof IntervalType || elm.getResultType() instanceof ListType) {
+        else if (left.getResultType() instanceof IntervalType || right.getResultType() instanceof IntervalType || elm.getResultType() instanceof IntervalType) {
             return UnionEvaluator.unionInterval((org.opencds.cqf.cql.engine.runtime.Interval)leftResult, (org.opencds.cqf.cql.engine.runtime.Interval)rightResult, state);
         }
         else {

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TestUnion.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TestUnion.java
@@ -1,0 +1,42 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.List;
+
+
+public class TestUnion extends CqlTestBase {
+
+    @Test
+    public void testUnion() {
+
+        EvaluationResult evaluationResult;
+
+        evaluationResult = engineVisitor.evaluate(toElmIdentifier("TestUnion"));
+        Object result = evaluationResult.expressionResults.get("NullAndNull").value();
+        assertNotNull(result);
+        assertTrue(((List<?>)result).isEmpty());
+
+        result = evaluationResult.expressionResults.get("NullAndEmpty").value();
+        assertNotNull(result);
+        assertTrue(((List<?>)result).isEmpty());
+
+        result = evaluationResult.expressionResults.get("EmptyAndNull").value();
+        assertNotNull(result);
+        assertTrue(((List<?>)result).isEmpty());
+
+        result = evaluationResult.expressionResults.get("NullAndSingle").value();
+        assertNotNull(result);
+        assertEquals(1, ((List<?>)result).size());
+        assertEquals(1, ((List<?>)result).get(0));
+
+        result = evaluationResult.expressionResults.get("SingleAndNull").value();
+        assertNotNull(result);
+        assertEquals(1, ((List<?>)result).size());
+        assertEquals(1, ((List<?>)result).get(0));
+    }
+}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
@@ -4567,7 +4567,7 @@ define test_Union_OneToFiveOverlappedWithNulls: TestMessage(Union_OneToFiveOverl
 define test_Union_Disjoint: TestMessage(Union_Disjoint = {1,2,4,5}, 'Union_Disjoint', toString({1,2,4,5}), toString(Union_Disjoint))
 define test_Union_NestedToFifteen: TestMessage(Union_NestedToFifteen = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}, 'Union_NestedToFifteen', toString({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}), toString(Union_NestedToFifteen))
 define test_Union_NullUnion: TestMessage(Union_NullUnion = {1,2,3}, 'Union_NullUnion', toString({1,2,3}), toString(Union_NullUnion))
-define test_Union_UnionNull: TestMessage(Union_NullUnion = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
+define test_Union_UnionNull: TestMessage(Union_UnionNull = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
 
 // Except
 define Except_ExceptThreeFour: {1, 2, 3, 4, 5} except {3, 4}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
@@ -4566,8 +4566,8 @@ define test_Union_OneToFiveOverlapped: TestMessage(Union_OneToFiveOverlapped = {
 define test_Union_OneToFiveOverlappedWithNulls: TestMessage(Union_OneToFiveOverlappedWithNulls ~ {1,null,2,3,4,5}, 'Union_OneToFiveOverlappedWithNulls', toString({1,null,2,3,4,5}), toString(Union_OneToFiveOverlappedWithNulls))
 define test_Union_Disjoint: TestMessage(Union_Disjoint = {1,2,4,5}, 'Union_Disjoint', toString({1,2,4,5}), toString(Union_Disjoint))
 define test_Union_NestedToFifteen: TestMessage(Union_NestedToFifteen = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}, 'Union_NestedToFifteen', toString({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}), toString(Union_NestedToFifteen))
-define test_Union_NullUnion: TestMessage(Union_NullUnion is null, 'Union_NullUnion', 'null', toString(Union_NullUnion))
-define test_Union_UnionNull: TestMessage(Union_UnionNull is null, 'Union_UnionNull', 'null', toString(Union_UnionNull))
+define test_Union_NullUnion: TestMessage(Union_NullUnion = {1,2,3}, 'Union_NullUnion', toString({1,2,3}), toString(Union_NullUnion))
+define test_Union_UnionNull: TestMessage(Union_NullUnion = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
 
 // Except
 define Except_ExceptThreeFour: {1, 2, 3, 4, 5} except {3, 4}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
@@ -4579,8 +4579,8 @@ define test_Union_OneToFiveOverlapped: TestMessage(Union_OneToFiveOverlapped = {
 define test_Union_OneToFiveOverlappedWithNulls: TestMessage(Union_OneToFiveOverlappedWithNulls ~ {1,null,2,3,4,5}, 'Union_OneToFiveOverlappedWithNulls', toString({1,null,2,3,4,5}), toString(Union_OneToFiveOverlappedWithNulls))
 define test_Union_Disjoint: TestMessage(Union_Disjoint = {1,2,4,5}, 'Union_Disjoint', toString({1,2,4,5}), toString(Union_Disjoint))
 define test_Union_NestedToFifteen: TestMessage(Union_NestedToFifteen = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}, 'Union_NestedToFifteen', toString({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}), toString(Union_NestedToFifteen))
-define test_Union_NullUnion: TestMessage(Union_NullUnion is null, 'Union_NullUnion', 'null', toString(Union_NullUnion))
-define test_Union_UnionNull: TestMessage(Union_UnionNull is null, 'Union_UnionNull', 'null', toString(Union_UnionNull))
+define test_Union_NullUnion: TestMessage(Union_NullUnion = {1,2,3}, 'Union_NullUnion', toString({1,2,3}), toString(Union_NullUnion))
+define test_Union_UnionNull: TestMessage(Union_NullUnion = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
 
 // Except
 define Except_ExceptThreeFour: {1, 2, 3, 4, 5} except {3, 4}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
@@ -4580,7 +4580,7 @@ define test_Union_OneToFiveOverlappedWithNulls: TestMessage(Union_OneToFiveOverl
 define test_Union_Disjoint: TestMessage(Union_Disjoint = {1,2,4,5}, 'Union_Disjoint', toString({1,2,4,5}), toString(Union_Disjoint))
 define test_Union_NestedToFifteen: TestMessage(Union_NestedToFifteen = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}, 'Union_NestedToFifteen', toString({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}), toString(Union_NestedToFifteen))
 define test_Union_NullUnion: TestMessage(Union_NullUnion = {1,2,3}, 'Union_NullUnion', toString({1,2,3}), toString(Union_NullUnion))
-define test_Union_UnionNull: TestMessage(Union_NullUnion = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
+define test_Union_UnionNull: TestMessage(Union_UnionNull = {1,2,3}, 'Union_UnionNull', toString({1,2,3}), toString(Union_UnionNull))
 
 // Except
 define Except_ExceptThreeFour: {1, 2, 3, 4, 5} except {3, 4}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/TestUnion.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/TestUnion.cql
@@ -1,0 +1,22 @@
+library TestUnion
+
+// expect {}
+define "NullAndNull":
+    null as List<Integer> union null as List<Integer>
+
+// expect {}
+define "NullAndEmpty":
+    null union {}
+
+// expect {}
+define "EmptyAndNull":
+    {} union null
+
+// expect {1}
+define "NullAndSingle":
+    null union {1}
+
+// expect {1}
+define "SingleAndNull":
+    null union {1}
+


### PR DESCRIPTION
* Correct erroneous tests for list Union behavior
  * According to the spec for List unions `null union {1, 2, 3}` should return `{1, 2, 3}` and not `null`
  * https://cql.hl7.org/09-b-cqlreference.html#union-1
* Engine fixes and additional tests for the above
  * Resolves #887
  * Partially resolves #1132 
* Added a link to the CQL spec in the Readme
* Fixed missing U of U copyright for the CQL engine