### PR TITLE
Fix NpmPackageManagerTests to use a published IG with a recursive dependency

### DIFF
--- a/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
+++ b/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
@@ -27,7 +27,7 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
     private final VersionConvertor_40_50 convertor = new VersionConvertor_40_50(new BaseAdvisor_40_50());
 
     @Test
-    public void TestSampleIGLocal() {
+    public void TestSampleIGLocalNoDependencies() {
         Resource igResource = (Resource) FhirContext.forR4Cached().newXmlParser().parseResource(
                 NpmPackageManagerTests.class.getResourceAsStream("myig.xml"));
         ImplementationGuide ig = (ImplementationGuide) convertor.convertResource(igResource);
@@ -36,33 +36,29 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
     }
 
     @Test
-    @Ignore("This test depends on the example.fhir.uv.myig package, which is not currently published")
-    public void TestSampleContentIGLocal() {
+    public void TestSampleContentIGLocalWithRecursiveDependencies() {
         Resource igResource = (Resource) FhirContext.forR4Cached().newXmlParser().parseResource(
                 NpmPackageManagerTests.class.getResourceAsStream("mycontentig.xml"));
         ImplementationGuide ig = (ImplementationGuide) convertor.convertResource(igResource);
         NpmPackageManager pm = new NpmPackageManager(ig);
         assertTrue(pm.getNpmList().size() >= 3);
         boolean hasFHIR = false;
-        boolean hasMyIG = false;
         boolean hasCommon = false;
         boolean hasCPG = false;
         for (NpmPackage p : pm.getNpmList()) {
             switch (p.canonical()) {
                 case "http://hl7.org/fhir": hasFHIR = true; break;
-                case "http://somewhere.org/fhir/uv/myig": hasMyIG = true; break;
                 case "http://fhir.org/guides/cqf/common": hasCommon = true; break;
                 case "http://hl7.org/fhir/uv/cpg": hasCPG = true; break;
             }
         }
         assertTrue(hasFHIR);
-        assertTrue(hasMyIG);
         assertTrue(hasCommon);
         assertTrue(hasCPG);
     }
 
     @Test
-    public void TestOpioidMMEIGLocal() {
+    public void TestOpioidMMEIGLocalWithSingleFileDependency() {
         Resource igResource = (Resource) FhirContext.forR4Cached().newXmlParser().parseResource(
                 NpmPackageManagerTests.class.getResourceAsStream("opioid-mme-r4.xml"));
         ImplementationGuide ig = (ImplementationGuide) convertor.convertResource(igResource);

--- a/Src/java/cqf-fhir-npm/src/test/resources/org/cqframework/fhir/npm/mycontentig.xml
+++ b/Src/java/cqf-fhir-npm/src/test/resources/org/cqframework/fhir/npm/mycontentig.xml
@@ -39,8 +39,8 @@
   <!-- This is whatever FHIR version(s) the IG artifacts are targeting (not the version of this file, which should always be 'current release') -->
   <fhirVersion value="4.0.1"/>
   <dependsOn>
-    <packageId value="example.fhir.uv.myig"/>
-    <version value="dev"/>
+    <packageId value="hl7.fhir.uv.crmi"/>
+    <version value="1.0.0-ballot"/>
   </dependsOn>
   <definition>
     <!-- You don't need to define any groupings.  The IGPublisher will define them for you.  You only need to do so if your IG is 'special' and it's


### PR DESCRIPTION
- Fix mycontentid.xml to depend on a published IG with a recursive dependency
- Ensure assertions are correct
- Rename test methods to make it clear what they're testing

Closes https://github.com/cqframework/clinical_quality_language/issues/1192