### PR TITLE
Fix date precision

### DIFF
--- a/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
+++ b/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
@@ -939,7 +939,7 @@ public class DataRequirementsProcessorTest {
         CqlCompilerOptions compilerOptions = getCompilerOptions();
         var manager = setupDataRequirementsAnalysis("TestCases/TestCase2e.cql", compilerOptions);
         // Evaluate this test as of 12/31/2022
-        ZonedDateTime evaluationDateTime = ZonedDateTime.of(2022, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime evaluationDateTime = ZonedDateTime.of(2022, 12, 31, 0, 0, 0, 0, ZoneId.of("Z"));
         org.hl7.fhir.r5.model.Library moduleDefinitionLibrary = getModuleDefinitionLibrary(manager, compilerOptions, new HashMap<String, Object>(), evaluationDateTime);
 
         /*
@@ -975,7 +975,7 @@ public class DataRequirementsProcessorTest {
                     for (DataRequirement.DataRequirementDateFilterComponent dfc : dr.getDateFilter()) {
                         if ("onset".equals(dfc.getPath())) {
                             if (dfc.getValue() instanceof Period) {
-                                String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace(":00-", ":00.000-"); //"2022-10-02T00:00:00.000-07:00"
+                                String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace(":00Z", ":00.000Z"); //"2022-10-02T00:00:00.000-07:00"
                                 String expectedPeriodEndString = expectedPeriodEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); //"2022-12-30T23:59:59.999-07:00"
                                 if (((Period)dfc.getValue()).hasStart() && ((Period)dfc.getValue()).getStartElement().asStringValue().equals(expectedPeriodStartString)
                                         && ((Period)dfc.getValue()).hasEnd() && ((Period)dfc.getValue()).getEndElement().asStringValue().equals(expectedPeriodEndString)) {

--- a/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
+++ b/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
@@ -975,7 +975,7 @@ public class DataRequirementsProcessorTest {
                     for (DataRequirement.DataRequirementDateFilterComponent dfc : dr.getDateFilter()) {
                         if ("onset".equals(dfc.getPath())) {
                             if (dfc.getValue() instanceof Period) {
-                                String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); //"2022-10-02T00:00:00-07:00"
+                                String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace(":00-", ":00.000-"); //"2022-10-02T00:00:00.000-07:00"
                                 String expectedPeriodEndString = expectedPeriodEnd.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); //"2022-12-30T23:59:59.999-07:00"
                                 if (((Period)dfc.getValue()).hasStart() && ((Period)dfc.getValue()).getStartElement().asStringValue().equals(expectedPeriodStartString)
                                         && ((Period)dfc.getValue()).hasEnd() && ((Period)dfc.getValue()).getEndElement().asStringValue().equals(expectedPeriodEndString)) {
@@ -1079,7 +1079,7 @@ public class DataRequirementsProcessorTest {
                     DataRequirement.DataRequirementDateFilterComponent dfc = dr.getDateFilterFirstRep();
                     if ("onset".equals(dfc.getPath())) {
                         if (dfc.getValue() instanceof Period) {
-                            String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); // "2022-10-02T00:00:00-07:00"
+                            String expectedPeriodStartString = expectedPeriodStart.format(DateTimeFormatter.ISO_LOCAL_DATE); // "2022-10-02"
                             if (((Period)dfc.getValue()).hasStart() && ((Period)dfc.getValue()).hasEnd() && ((Period)dfc.getValue()).getStartElement().asStringValue().equals(expectedPeriodStartString)) {
                                 expectedDataRequirement = dr;
                             }
@@ -1138,10 +1138,10 @@ public class DataRequirementsProcessorTest {
                     for (DataRequirement.DataRequirementDateFilterComponent dfc : dr.getDateFilter()) {
                         if ("onset".equals(dfc.getPath())) {
                             if (dfc.getValue() instanceof Period) {
-                                String expectedPeriodStart1String = expectedPeriodStart1.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); // "2022-10-02T00:00:00-07:00"
+                                String expectedPeriodStart1String = expectedPeriodStart1.format(DateTimeFormatter.ISO_LOCAL_DATE); // "2022-10-02"
                                 String expectedPeriodEnd1String = expectedPeriodEnd1.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); // "9999-12-31T23:59:59.999Z"
-                                String expectedPeriodStart2String = expectedPeriodStart2.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); // "0001-01-01T00:00:00Z"
-                                String expectedPeriodEnd2String = expectedPeriodEnd2.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME); // "2022-12-31T00:00:00-07:00"
+                                String expectedPeriodStart2String = expectedPeriodStart2.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace(":00Z", ":00.000Z"); // "0001-01-01T00:00:00.000Z"
+                                String expectedPeriodEnd2String = expectedPeriodEnd2.format(DateTimeFormatter.ISO_LOCAL_DATE); // "2022-12-31"
                                 if (((Period)dfc.getValue()).hasStart() && ((Period)dfc.getValue()).getStartElement().asStringValue().equals(expectedPeriodStart1String)
                                         && ((Period)dfc.getValue()).hasEnd() && ((Period)dfc.getValue()).getEndElement().asStringValue().equals(expectedPeriodEnd1String)) {
                                     hasFilter1 = true;

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/BaseFhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/BaseFhirTypeConverter.java
@@ -21,11 +21,14 @@ import org.opencds.cqf.cql.engine.runtime.CqlType;
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.TemporalHelper;
 import org.opencds.cqf.cql.engine.runtime.Time;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 abstract class BaseFhirTypeConverter implements FhirTypeConverter {
 
@@ -424,5 +427,23 @@ abstract class BaseFhirTypeConverter implements FhirTypeConverter {
             case Calendar.DAY_OF_MONTH: return new org.opencds.cqf.cql.engine.runtime.Date(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
             default: throw new InvalidPrecision(String.format("Invalid temporal precision %s", calendarConstant));
         }
+    }
+
+    protected TemporalPrecisionEnum toFhirPrecision(Precision precision) {
+      String name = null;
+      switch (precision) {
+        case WEEK:
+        case HOUR:
+        case MINUTE:
+          name = TemporalPrecisionEnum.DAY.name();
+          break;
+        case MILLISECOND:
+          name = TemporalPrecisionEnum.MILLI.name();
+          break;
+        default:
+          name = precision.name();
+          break;
+      }
+      return TemporalPrecisionEnum.valueOf(name);
     }
 }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
@@ -74,7 +74,9 @@ class Dstu2FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
+        var result = new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        result.setPrecision(toFhirPrecision(value.getPrecision()));
+        return result;
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
@@ -11,7 +11,9 @@ import org.hl7.fhir.dstu2.model.*;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
-import org.opencds.cqf.cql.engine.runtime.Tuple;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -72,7 +74,7 @@ class Dstu2FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
@@ -72,7 +72,9 @@ class Dstu3FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
+        var result = new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        result.setPrecision(toFhirPrecision(value.getPrecision()));
+        return result;
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
@@ -9,7 +9,9 @@ import org.hl7.fhir.dstu3.model.*;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
-import org.opencds.cqf.cql.engine.runtime.Tuple;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -70,7 +72,7 @@ class Dstu3FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
@@ -73,7 +73,9 @@ class R4FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
+        var result = new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        result.setPrecision(toFhirPrecision(value.getPrecision()));
+        return result;
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
@@ -10,6 +10,9 @@ import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -70,7 +73,7 @@ class R4FhirTypeConverter extends BaseFhirTypeConverter {
             return null;
         }
 
-        return new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        return new DateTimeType(value.toJavaDate(), TemporalPrecisionEnum.valueOf(value.getPrecision().name()));
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
@@ -75,10 +75,10 @@ class R5FhirTypeConverter extends BaseFhirTypeConverter {
         if (value == null) {
             return null;
         }
+
         var result = new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         result.setPrecision(toFhirPrecision(value.getPrecision()));
         return result;
-//        return new DateTimeType(value.toJavaDate(), toFhirPrecision(value.getPrecision()), TimeZone.getTimeZone(value.getDateTime().getOffset().getId()));
     }
 
     @Override

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.r5.model.*;
@@ -12,6 +13,9 @@ import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -71,8 +75,10 @@ class R5FhirTypeConverter extends BaseFhirTypeConverter {
         if (value == null) {
             return null;
         }
-
-        return new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        var result = new DateTimeType(value.getDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        result.setPrecision(toFhirPrecision(value.getPrecision()));
+        return result;
+//        return new DateTimeType(value.toJavaDate(), toFhirPrecision(value.getPrecision()), TimeZone.getTimeZone(value.getDateTime().getOffset().getId()));
     }
 
     @Override

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -259,6 +259,7 @@ public class Dstu2TypeConverterTests {
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
         expectedDate = new DateTimeType("2019-10-10T01:00:00-06:00");
+        ((DateTimeType) expectedDate).setTimeZone(TimeZone.getTimeZone("MST"));
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -258,11 +258,6 @@ public class Dstu2TypeConverterTests {
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
-        expectedDate = new DateTimeType("2019-10-10T19:35:53");
-        ((DateTimeType) expectedDate).setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
-        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
-        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
-
         expectedDate = new DateTimeType("2019-10-10T01:00:00-06:00");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.dstu2.model.Attachment;
@@ -42,12 +43,15 @@ import org.opencds.cqf.cql.engine.runtime.CqlType;
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Time;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 public class Dstu2TypeConverterTests {
 
@@ -252,7 +256,21 @@ public class Dstu2TypeConverterTests {
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53");
+        ((DateTimeType) expectedDate).setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T01:00:00-06:00");
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53.000Z");
+        ((DateTimeType) expectedDate).setPrecision(TemporalPrecisionEnum.MILLI);
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.UTC).withPrecision(Precision.MILLISECOND));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
     }
 
     @Test

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.dstu2.model.IdType;
@@ -42,12 +43,15 @@ import org.opencds.cqf.cql.engine.runtime.CqlType;
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Time;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 public class Dstu3TypeConverterTests {
 
@@ -252,7 +256,20 @@ public class Dstu3TypeConverterTests {
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53.000Z");
+        ((DateTimeType) expectedDate).setPrecision(TemporalPrecisionEnum.MILLI);
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.UTC).withPrecision(Precision.MILLISECOND));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
     }
 
     @Test

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
@@ -258,10 +258,6 @@ public class Dstu3TypeConverterTests {
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
-        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
-        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
-        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
-
         expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
@@ -257,10 +257,6 @@ public class R4TypeConverterTests {
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
-        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
-        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
-        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
-
         expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -41,12 +42,15 @@ import org.opencds.cqf.cql.engine.runtime.CqlType;
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Time;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 public class R4TypeConverterTests {
 
@@ -243,15 +247,28 @@ public class R4TypeConverterTests {
         IPrimitiveType<java.util.Date> expectedDate = new DateTimeType("2019-02-03");
         IPrimitiveType<java.util.Date> actualDate = this.typeConverter
                 .toFhirDateTime(new DateTime("2019-02-03", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53.000Z");
+        ((DateTimeType) expectedDate).setPrecision(TemporalPrecisionEnum.MILLI);
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.UTC).withPrecision(Precision.MILLISECOND));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
     }
 
     @Test

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.dstu2.model.IdType;
@@ -41,12 +42,15 @@ import org.opencds.cqf.cql.engine.runtime.CqlType;
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
 import org.opencds.cqf.cql.engine.runtime.Time;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 public class R5TypeConverterTests {
 
@@ -243,16 +247,29 @@ public class R5TypeConverterTests {
         IPrimitiveType<java.util.Date> expectedDate = new DateTimeType("2019-02-03");
         IPrimitiveType<java.util.Date> actualDate = this.typeConverter
                 .toFhirDateTime(new DateTime("2019-02-03", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
         expectedDate = new DateTimeType("2019");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
-        assertEquals(expectedDate.getValue(), actualDate.getValue());
-    }
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+
+        expectedDate = new DateTimeType("2019-10-10T19:35:53.000Z");
+        ((DateTimeType) expectedDate).setPrecision(TemporalPrecisionEnum.MILLI);
+        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.UTC).withPrecision(Precision.MILLISECOND));
+        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
+      }
 
     @Test
     public void TestQuantityToFhirQuantity() {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
@@ -257,10 +257,6 @@ public class R5TypeConverterTests {
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019", null));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
 
-        expectedDate = new DateTimeType("2019-10-10T19:35:53").setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(-6).normalized()));
-        actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T19:35:53", ZoneOffset.ofHours(-6)));
-        assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());
-
         expectedDate = new DateTimeType("2019-10-10T00:00:00-07:00");
         actualDate = this.typeConverter.toFhirDateTime(new DateTime("2019-10-10T00:00:00", ZoneOffset.ofHours(-7)));
         assertEquals(expectedDate.getValueAsString(), actualDate.getValueAsString());


### PR DESCRIPTION
When converting a CQL DateTime to a FHIR DateTimeType the precision and timezone should be persisted.