### PR TITLE
Add a clear error when CQL refers to the wrong type (ex FHIR.Code).

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -921,6 +921,9 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
         String identifier = getTypeIdentifier(qualifiers, parseString(ctx.referentialOrTypeNameIdentifier()));
 
         DataType resultType = libraryBuilder.resolveTypeName(modelIdentifier, identifier);
+        if (null == resultType) {
+            throw new CqlCompilerException(String.format("Could not find type for library: %s and name: %s", modelIdentifier, identifier));
+        }
         NamedTypeSpecifier result = of.createNamedTypeSpecifier()
                 .withName(libraryBuilder.dataTypeToQName(resultType));
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -4,7 +4,6 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cqframework.cql.cql2elm.model.invocation.*;
 import org.cqframework.cql.cql2elm.preprocessor.*;
@@ -922,7 +921,7 @@ public class Cql2ElmVisitor extends cqlBaseVisitor {
 
         DataType resultType = libraryBuilder.resolveTypeName(modelIdentifier, identifier);
         if (null == resultType) {
-            throw new CqlCompilerException(String.format("Could not find type for library: %s and name: %s", modelIdentifier, identifier));
+            throw new CqlCompilerException(String.format("Could not find type for model: %s and name: %s", modelIdentifier, identifier));
         }
         NamedTypeSpecifier result = of.createNamedTypeSpecifier()
                 .withName(libraryBuilder.dataTypeToQName(resultType));

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -644,7 +644,7 @@ public class SemanticTests {
 
         final List<CqlCompilerException> errors = translator.getErrors();
 
-        assertTrue(errors.stream().map(Throwable::getMessage).anyMatch("Could not find type for library: FHIR and name: Code"::equals));
+        assertTrue(errors.stream().map(Throwable::getMessage).anyMatch("Could not find type for model: FHIR and name: Code"::equals));
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -4,16 +4,18 @@ import org.hl7.cql.model.ChoiceType;
 import org.hl7.cql.model.DataType;
 import org.hl7.cql.model.NamedType;
 import org.hl7.elm.r1.*;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertThrows;
 
 public class SemanticTests {
 
@@ -634,6 +636,20 @@ public class SemanticTests {
     @Test
     public void TestQuotedForwards() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("TestQuotedForwards.cql", 0);
+    }
+
+    @Test
+    public void testIncorrectParameterType1204() throws IOException {
+        final CqlTranslator translator = runSemanticTest("TestIncorrectParameterType1204.cql", 2);
+
+        final List<CqlCompilerException> errors = translator.getErrors();
+
+        assertTrue(errors.stream().map(Throwable::getMessage).anyMatch("Could not find type for library: FHIR and name: Code"::equals));
+    }
+
+    @Test
+    public void testNonExistentFileName() {
+        assertThrows(IOException.class, () -> TestUtils.runSemanticTest("ThisFileDoesNotExist.cql", 0));
     }
 
     private CqlTranslator runSemanticTest(String testFileName) throws IOException {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -14,13 +14,13 @@ import org.cqframework.cql.cql2elm.preprocessor.CqlPreprocessorVisitor;
 import org.hl7.cql.model.NamespaceInfo;
 import org.hl7.elm.r1.Library;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -204,7 +204,9 @@ public class TestUtils {
         }
         String fileName = segments[segments.length - 1];
 
-        File translationTestFile = new File(URLDecoder.decode(Cql2ElmVisitorTest.class.getResource(testFileName).getFile(), "UTF-8"));
+        final URL resource = Optional.ofNullable(Cql2ElmVisitorTest.class.getResource(testFileName))
+                .orElseThrow(() -> new FileNotFoundException("cannot find file with path: " + testFileName));
+        File translationTestFile = new File(URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8));
         ModelManager modelManager = new ModelManager();
         LibraryManager libraryManager = new LibraryManager(modelManager, options);
         libraryManager.getLibrarySourceLoader().registerProvider(path == null ? new TestLibrarySourceProvider() : new TestLibrarySourceProvider(path));

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestIncorrectParameterType1204.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/TestIncorrectParameterType1204.cql
@@ -1,0 +1,9 @@
+/*
+@issue: [1204](https://github.com/cqframework/clinical_quality_language/issues/1204)
+*/
+library TestQuotedForwards
+
+using FHIR version '4.0.1'
+
+// FHIR.Code is wrong:  it should be FHIR.code
+define function badFuncOne(value FHIR.Code) : null


### PR DESCRIPTION
- Throw a CqlCompilerException with a clear error message if a parameter refers to the wrong type (ex "FHIR.Code" instead of "FHIR.code")
- Throw a clear FileNotFoundException if a CQL filename is not found in the test resources directory.

Closes https://github.com/cqframework/clinical_quality_language/issues/1204
Closes https://github.com/cqframework/clinical_quality_language/issues/1205