### PR TITLE
#1146: Added support for terminology filtering through a reference

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
@@ -310,6 +310,44 @@ public class BaseTest {
         assertThat(r.getCodes(), instanceOf(ValueSetRef.class));
         ValueSetRef vsr = (ValueSetRef)r.getCodes();
         assertThat(vsr.getName(), is("Antithrombotic Therapy"));
+
+        def = defs.get("Antithrombotic Therapy at Discharge (2)");
+        assertThat(def, notNullValue());
+        assertThat(def.getExpression(), instanceOf(Union.class));
+        Union u = (Union)def.getExpression();
+        assertThat(u.getOperand().size(), is(2));
+        assertThat(u.getOperand().get(0), instanceOf(Retrieve.class));
+        r = (Retrieve)u.getOperand().get(0);
+        assertThat(r.getTemplateId(), is("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        assertThat(r.getCodeProperty(), is("medication"));
+        assertThat(r.getCodeComparator(), is("in"));
+        assertThat(r.getCodes(), instanceOf(ValueSetRef.class));
+        vsr = (ValueSetRef)r.getCodes();
+        assertThat(vsr.getName(), is("Antithrombotic Therapy"));
+
+        assertThat(u.getOperand().get(1), instanceOf(Query.class));
+        q = (Query)u.getOperand().get(1);
+        assertThat(q.getSource().size(), is(1));
+        assertThat(q.getSource().get(0).getExpression(), instanceOf(Retrieve.class));
+        r = (Retrieve)q.getSource().get(0).getExpression();
+        assertThat(r.getTemplateId(), is("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        assertThat(r.getCodeProperty() == null, is(true));
+        assertThat(r.getCodes() == null, is(true));
+        assertThat(q.getRelationship(), notNullValue());
+        assertThat(q.getRelationship().size(), is(1));
+        assertThat(q.getRelationship().get(0), instanceOf(With.class));
+        With w = (With)q.getRelationship().get(0);
+        assertThat(w.getExpression(), instanceOf(Retrieve.class));
+        r = (Retrieve)w.getExpression();
+        assertThat(r.getTemplateId(), is("http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+        assertThat(r.getCodeProperty() == null, is(true));
+        assertThat(r.getCodes() == null, is(true));
+        assertThat(w.getSuchThat(), instanceOf(And.class));
+        And a = (And)w.getSuchThat();
+        assertThat(a.getOperand().get(0), instanceOf(Equal.class));
+        assertThat(a.getOperand().get(1), instanceOf(InValueSet.class));
+        InValueSet ivs = (InValueSet)a.getOperand().get(1);
+        assertThat(ivs.getValueset().getName(), is("Antithrombotic Therapy"));
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/qicore/v411/TestMedicationRequest.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/qicore/v411/TestMedicationRequest.cql
@@ -10,3 +10,6 @@ context Patient
 
 define "Antithrombotic Therapy at Discharge":
   ["MedicationRequest": medication in "Antithrombotic Therapy"] Antithrombotic
+
+define "Antithrombotic Therapy at Discharge (2)":
+  ["MedicationRequest": "Antithrombotic Therapy"]

--- a/Src/java/elm-fhir/src/test/resources/org/cqframework/cql/elm/requirements/fhir/CMS645/CMS645-ModuleDefinitionLibrary.json
+++ b/Src/java/elm-fhir/src/test/resources/org/cqframework/cql/elm/requirements/fhir/CMS645/CMS645-ModuleDefinitionLibrary.json
@@ -36,5 +36,24 @@
   "dataRequirement": [ {
     "type": "Patient",
     "profile": [ "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" ]
+  }, {
+    "extension": [ {
+      "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-relatedRequirement",
+      "extension": [ {
+        "url": "targetId",
+        "valueString": "G10002"
+      }, {
+        "url": "targetProperty",
+        "valueString": "medication"
+      } ]
+    } ],
+    "type": "Medication",
+    "profile": [ "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication" ],
+    "mustSupport": [ "id" ]
+  }, {
+    "id": "G10002",
+    "type": "MedicationRequest",
+    "profile": [ "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest" ],
+    "mustSupport": [ "medication.reference" ]
   } ]
 }

--- a/Src/java/elm-fhir/src/test/resources/org/cqframework/cql/elm/requirements/fhir/FHIRReferencesRevisited.cql
+++ b/Src/java/elm-fhir/src/test/resources/org/cqframework/cql/elm/requirements/fhir/FHIRReferencesRevisited.cql
@@ -203,3 +203,18 @@ define TestMedicationRequirement:
 define TestBoundDataRequirement:
   TestMedicationRequirement R
     where R.code in "Aspirin"
+
+
+define TestChoiceMedicationRequest:
+  [MedicationRequest: "Aspirin"]
+
+// If the terminology target is a choice of a terminology-valued element and a reference
+
+define TestChoiceMedicationRequestExpanded:
+  [MedicationRequest: medication in "Aspirin"]
+   union (
+     [MedicationRequest] MR
+      with [Medication] M
+        such that M.id = Last(Split(MR.medication.reference, '/'))
+          and M.code in "Aspirin"
+  )


### PR DESCRIPTION
This is an exploratory feature to support terminology filtering in a retrieve through a code path that has a reference. There will need to be ModelInfo support to fully realize this feature, which will require changes that must be introduced in CQL 2.0. The implementation here is special-cased to support exploring the use of this feature as part of working out exactly what needs to be supported in the 2.0 specification.