### PR TITLE
Add signatureLevel to ELM annotations

### DIFF
--- a/Src/cql-lm/schema/elm/cqlannotations.xsd
+++ b/Src/cql-lm/schema/elm/cqlannotations.xsd
@@ -138,6 +138,7 @@
 		<xs:extension base="CqlToElmBase">
 		    <xs:attribute name="translatorVersion" type="xs:string"/>
 		    <xs:attribute name="translatorOptions" type="xs:string"/>
+		    <xs:attribute name="signatureLevel" type="xs:string"/>
 		</xs:extension>
 	</xs:complexContent>
   </xs:complexType>

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -151,6 +151,7 @@ public class LibraryBuilder implements ModelResolver {
         }
         setCompatibilityLevel(options.getCompatibilityLevel());
         this.cqlToElmInfo.setTranslatorOptions(options.toString());
+        this.cqlToElmInfo.setSignatureLevel(options.getSignatureLevel().name());
     }
 
     public void setVisitor(Cql2ElmVisitor visitor) {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146JsonTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146JsonTest.java
@@ -2,11 +2,14 @@ package org.cqframework.cql.cql2elm;
 
 import org.cqframework.cql.cql2elm.CqlCompilerException.ErrorSeverity;
 import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,15 +17,39 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 public class CMS146JsonTest {
 
-    @Test
-    public void testCms146() throws IOException {
-        File expectedJsonFile = new File(URLDecoder.decode(CMS146JsonTest.class.getResource("CMS146v2_Expected.json").getFile(), "UTF-8"));
-        String expectedJson = new Scanner(expectedJsonFile, "UTF-8").useDelimiter("\\Z").next();
+    @DataProvider(name = "sigFileAndSigLevel")
+    private static Object[][] sigFileAndSigLevel() {
+        return new Object[][] {
+                {"CMS146v2_Expected_SignatureLevel_None.json", SignatureLevel.None},
+                {"CMS146v2_Expected_SignatureLevel_Differing.json", SignatureLevel.Differing},
+                {"CMS146v2_Expected_SignatureLevel_Overloads.json", SignatureLevel.Overloads},
+                {"CMS146v2_Expected_SignatureLevel_All.json", SignatureLevel.All}
+        };
+    }
 
-        File cms146 = new File(URLDecoder.decode(CMS146JsonTest.class.getResource("CMS146v2_Test_CQM.cql").getFile(), "UTF-8"));
-        ModelManager modelManager = new ModelManager();
-        CqlTranslator translator = CqlTranslator.fromFile(cms146, new LibraryManager(modelManager, new CqlCompilerOptions(ErrorSeverity.Warning, SignatureLevel.None)));
-        String actualJson = translator.toJson();
+    @Test(dataProvider = "sigFileAndSigLevel")
+    public void testCms146_SignatureLevels(String fileName, SignatureLevel expectedSignatureLevel) throws IOException {
+        final String expectedJson = getJson(fileName);
+
+        final File cms146 = getFile("CMS146v2_Test_CQM.cql");
+        final ModelManager modelManager = new ModelManager();
+        final CqlTranslator translator = CqlTranslator.fromFile(cms146, new LibraryManager(modelManager, new CqlCompilerOptions(ErrorSeverity.Warning, expectedSignatureLevel)));
+        final String actualJson = translator.toJson();
         assertThat(actualJson, sameJSONAs(expectedJson));
+    }
+
+    private static String getJson(String name) throws IOException {
+        return new Scanner(getFile(name), StandardCharsets.UTF_8)
+                .useDelimiter("\\Z").next();
+    }
+
+    private static File getFile(String name) {
+        final URL resource = CMS146JsonTest.class.getResource(name);
+
+        if (resource == null) {
+            throw new IllegalArgumentException("Cannot find file with name: " + name);
+        }
+
+        return new File(URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8));
     }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
@@ -1,0 +1,57 @@
+package org.cqframework.cql.cql2elm;
+
+import org.cqframework.cql.cql2elm.CqlCompilerException.ErrorSeverity;
+import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CMS146XmlTest {
+
+    @DataProvider(name = "sigFileAndSigLevel")
+    private static Object[][] sigFileAndSigLevel() {
+        return new Object[][] {
+                {"CMS146v2_Expected_SignatureLevel_None.xml", SignatureLevel.None},
+                {"CMS146v2_Expected_SignatureLevel_Differing.xml", SignatureLevel.Differing},
+                {"CMS146v2_Expected_SignatureLevel_Overloads.xml", SignatureLevel.Overloads},
+                {"CMS146v2_Expected_SignatureLevel_All.xml", SignatureLevel.All}
+        };
+    }
+
+    @Test(dataProvider = "sigFileAndSigLevel")
+    public void testCms146_SignatureLevels(String fileName, SignatureLevel expectedSignatureLevel) throws IOException {
+        final String expectedXml = getXml(fileName);
+
+        final File cms146 = getFile("CMS146v2_Test_CQM.cql");
+        final ModelManager modelManager = new ModelManager();
+        final CqlTranslator translator = CqlTranslator.fromFile(cms146, new LibraryManager(modelManager, new CqlCompilerOptions(ErrorSeverity.Warning, expectedSignatureLevel)));
+        final String actualXml = translator.toXml().trim();
+        Assert.assertEquals(actualXml, expectedXml);
+        assertThat(actualXml, equalTo(expectedXml));
+    }
+
+    private static String getXml(String name) throws IOException {
+        return new Scanner(getFile(name), StandardCharsets.UTF_8)
+                .useDelimiter("\\Z").next();
+    }
+
+    private static File getFile(String name) {
+        final URL resource = CMS146XmlTest.class.getResource(name);
+
+        if (resource == null) {
+            throw new IllegalArgumentException("Cannot find file with name: " + name);
+        }
+
+        return new File(URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8));
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
@@ -36,7 +36,6 @@ public class CMS146XmlTest {
         final ModelManager modelManager = new ModelManager();
         final CqlTranslator translator = CqlTranslator.fromFile(cms146, new LibraryManager(modelManager, new CqlCompilerOptions(ErrorSeverity.Warning, expectedSignatureLevel)));
         final String actualXml = translator.toXml().trim();
-        Assert.assertEquals(actualXml, expectedXml);
         assertThat(actualXml, equalTo(expectedXml));
     }
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.json
@@ -1,0 +1,919 @@
+{
+  "library" : {
+    "type" : "Library",
+    "identifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "type" : "Library$Usings",
+      "def" : [ {
+        "type" : "UsingDef",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1"
+      }, {
+        "type" : "UsingDef",
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir"
+      } ]
+    },
+    "parameters" : {
+      "type" : "Library$Parameters",
+      "def" : [ {
+        "type" : "ParameterDef",
+        "default" : {
+          "type" : "Interval",
+          "low" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ]
+          },
+          "high" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ]
+          },
+          "lowClosed" : true,
+          "highClosed" : false
+        },
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "valueSets" : {
+      "type" : "Library$ValueSets",
+      "def" : [ {
+        "type" : "ValueSetDef",
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "contexts" : {
+      "type" : "Library$Contexts",
+      "def" : [ {
+        "type" : "ContextDef",
+        "name" : "Patient"
+      } ]
+    },
+    "statements" : {
+      "type" : "Library$Statements",
+      "def" : [ {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "SingletonFrom",
+          "operand" : {
+            "type" : "Retrieve",
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient"
+          }
+        },
+        "name" : "Patient",
+        "context" : "Patient"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+          } ],
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ],
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              } ],
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "signature" : [ {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }
+                } ],
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2"
+            } ]
+          }, {
+            "type" : "Less",
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ],
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              } ],
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "signature" : [ {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }
+                } ],
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18"
+            } ]
+          } ]
+        },
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Union",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Condition"
+            }
+          }, {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Condition"
+            }
+          } ],
+          "operand" : [ {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Pharyngitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          }, {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Tonsillitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          } ]
+        },
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Retrieve",
+          "codes" : {
+            "type" : "ValueSetRef",
+            "name" : "Antibiotic Medications",
+            "preserve" : true
+          },
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in"
+        },
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "Retrieve",
+              "codes" : {
+                "type" : "ValueSetRef",
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true
+              },
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in"
+            },
+            "alias" : "E"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "signature" : [ {
+                "type" : "IntervalTypeSpecifier",
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }
+              }, {
+                "type" : "IntervalTypeSpecifier",
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }
+              } ],
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "P"
+          }, {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Antibiotics"
+            },
+            "suchThat" : {
+              "type" : "And",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+              } ],
+              "operand" : [ {
+                "type" : "In",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }
+                } ],
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "dateWritten",
+                  "scope" : "A"
+                }, {
+                  "type" : "Interval",
+                  "low" : {
+                    "type" : "Start",
+                    "signature" : [ {
+                      "type" : "IntervalTypeSpecifier",
+                      "pointType" : {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                      }
+                    } ],
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "signature" : [ {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                    }, {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}Quantity"
+                    } ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "signature" : [ {
+                        "type" : "IntervalTypeSpecifier",
+                        "pointType" : {
+                          "type" : "NamedTypeSpecifier",
+                          "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                        }
+                      } ],
+                      "operand" : {
+                        "type" : "Property",
+                        "path" : "period",
+                        "scope" : "E"
+                      }
+                    }, {
+                      "type" : "Quantity",
+                      "value" : 3,
+                      "unit" : "days"
+                    } ]
+                  },
+                  "lowClosed" : false,
+                  "highClosed" : true
+                } ]
+              }, {
+                "type" : "Not",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+                } ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}Any"
+                  } ],
+                  "operand" : {
+                    "type" : "Start",
+                    "signature" : [ {
+                      "type" : "IntervalTypeSpecifier",
+                      "pointType" : {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                      }
+                    } ],
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  }
+                }
+              } ]
+            },
+            "alias" : "A"
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "signature" : [ {
+              "type" : "IntervalTypeSpecifier",
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }
+            }, {
+              "type" : "IntervalTypeSpecifier",
+              "pointType" : {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }
+            } ],
+            "operand" : [ {
+              "type" : "Property",
+              "path" : "period",
+              "scope" : "E"
+            }, {
+              "type" : "ParameterRef",
+              "name" : "MeasurementPeriod"
+            } ]
+          }
+        },
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "alias" : "P"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "TargetEncounters"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "signature" : [ {
+                "type" : "IntervalTypeSpecifier",
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }
+              }, {
+                "type" : "IntervalTypeSpecifier",
+                "pointType" : {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }
+              } ],
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "E"
+          } ]
+        },
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}MedicationPrescription"
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "Antibiotics"
+              },
+              "alias" : "A"
+            } ],
+            "relationship" : [ {
+              "type" : "With",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "TargetDiagnoses"
+              },
+              "suchThat" : {
+                "type" : "And",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+                }, {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+                } ],
+                "operand" : [ {
+                  "type" : "In",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }, {
+                    "type" : "IntervalTypeSpecifier",
+                    "pointType" : {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                    }
+                  } ],
+                  "operand" : [ {
+                    "type" : "Property",
+                    "path" : "dateWritten",
+                    "scope" : "A"
+                  }, {
+                    "type" : "Interval",
+                    "low" : {
+                      "type" : "Subtract",
+                      "signature" : [ {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                      }, {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity"
+                      } ],
+                      "operand" : [ {
+                        "type" : "Property",
+                        "path" : "onsetDateTime",
+                        "scope" : "D"
+                      }, {
+                        "type" : "Quantity",
+                        "value" : 30,
+                        "unit" : "days"
+                      } ]
+                    },
+                    "high" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    },
+                    "lowClosed" : true,
+                    "highClosed" : false
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+                  } ],
+                  "operand" : {
+                    "type" : "IsNull",
+                    "signature" : [ {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}Any"
+                    } ],
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    }
+                  }
+                } ]
+              },
+              "alias" : "D"
+            } ]
+          }
+        },
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Encounter"
+            }
+          } ],
+          "operand" : {
+            "type" : "ExpressionRef",
+            "name" : "TargetEncounters"
+          }
+        },
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "signature" : [ {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+          }, {
+            "type" : "NamedTypeSpecifier",
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+          } ],
+          "operand" : [ {
+            "type" : "ExpressionRef",
+            "name" : "InDemographic"
+          }, {
+            "type" : "ExpressionRef",
+            "name" : "HasTargetEncounter"
+          } ]
+        },
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Literal",
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true"
+        },
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "ExpressionRef",
+          "name" : "HasPriorAntibiotics"
+        },
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Observation"
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "Retrieve",
+                "codes" : {
+                  "type" : "ValueSetRef",
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true
+                },
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in"
+              },
+              "alias" : "R"
+            } ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+              } ],
+              "operand" : [ {
+                "type" : "In",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }
+                } ],
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "issued",
+                  "scope" : "R"
+                }, {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                } ]
+              }, {
+                "type" : "Not",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
+                } ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}Any"
+                  } ],
+                  "operand" : {
+                    "type" : "Property",
+                    "path" : "valueQuantity",
+                    "scope" : "R"
+                  }
+                }
+              } ]
+            }
+          }
+        },
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorOptions" : "",
+      "signatureLevel" : "All"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    } ]
+  }
+}

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.xml
@@ -1,0 +1,461 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<Library type="Library">
+  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
+  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
+  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
+    <wstxns3:def>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+    </wstxns3:def>
+  </wstxns3:usings>
+  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
+    <wstxns4:def>
+      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
+        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
+          <wstxns4:low wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:signature>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+            </wstxns4:signature>
+          </wstxns4:low>
+          <wstxns4:high wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:signature>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+            </wstxns4:signature>
+          </wstxns4:high>
+        </wstxns4:default>
+      </wstxns4:def>
+    </wstxns4:def>
+  </wstxns4:parameters>
+  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
+    <wstxns5:def>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+    </wstxns5:def>
+  </wstxns5:valueSets>
+  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
+    <wstxns6:def>
+      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
+    </wstxns6:def>
+  </wstxns6:contexts>
+  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
+    <wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
+        <wstxns7:expression wstxns7:type="SingletonFrom">
+          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+          </wstxns7:signature>
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="GreaterOrEqual">
+              <wstxns7:signature>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              </wstxns7:signature>
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        </wstxns7:signature>
+                      </wstxns7:signature>
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Less">
+              <wstxns7:signature>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              </wstxns7:signature>
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        </wstxns7:signature>
+                      </wstxns7:signature>
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Union">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Condition"/>
+            </wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Condition"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
+          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
+              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
+                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
+              </wstxns7:expression>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:signature>
+                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                </wstxns7:signature>
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="A">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              <wstxns7:suchThat wstxns7:type="And">
+                <wstxns7:signature>
+                  <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                  <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                </wstxns7:signature>
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="In">
+                    <wstxns7:signature>
+                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                      <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                        <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                      </wstxns7:signature>
+                    </wstxns7:signature>
+                    <wstxns7:operand>
+                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
+                        <wstxns7:low wstxns7:type="Start">
+                          <wstxns7:signature>
+                            <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                              <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                            </wstxns7:signature>
+                          </wstxns7:signature>
+                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                        </wstxns7:low>
+                        <wstxns7:high wstxns7:type="Add">
+                          <wstxns7:signature>
+                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
+                          </wstxns7:signature>
+                          <wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Start">
+                              <wstxns7:signature>
+                                <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                                  <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                                </wstxns7:signature>
+                              </wstxns7:signature>
+                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                            </wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
+                          </wstxns7:operand>
+                        </wstxns7:high>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Not">
+                    <wstxns7:signature>
+                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                    </wstxns7:signature>
+                    <wstxns7:operand wstxns7:type="IsNull">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                      </wstxns7:signature>
+                      <wstxns7:operand wstxns7:type="Start">
+                        <wstxns7:signature>
+                          <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                            <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                          </wstxns7:signature>
+                        </wstxns7:signature>
+                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+          <wstxns7:where wstxns7:type="IncludedIn">
+            <wstxns7:signature>
+              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+              </wstxns7:signature>
+              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+              </wstxns7:signature>
+            </wstxns7:signature>
+            <wstxns7:operand>
+              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+            </wstxns7:operand>
+          </wstxns7:where>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="E">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:signature>
+                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                </wstxns7:signature>
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}MedicationPrescription"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship>
+              <wstxns7:relationship wstxns7:type="With" alias="D">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
+                <wstxns7:suchThat wstxns7:type="And">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="In">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        </wstxns7:signature>
+                      </wstxns7:signature>
+                      <wstxns7:operand>
+                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
+                          <wstxns7:low wstxns7:type="Subtract">
+                            <wstxns7:signature>
+                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
+                            </wstxns7:signature>
+                            <wstxns7:operand>
+                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
+                            </wstxns7:operand>
+                          </wstxns7:low>
+                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                        </wstxns7:operand>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Not">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                      </wstxns7:signature>
+                      <wstxns7:operand wstxns7:type="IsNull">
+                        <wstxns7:signature>
+                          <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                        </wstxns7:signature>
+                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:suchThat>
+              </wstxns7:relationship>
+            </wstxns7:relationship>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Encounter"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+          </wstxns7:signature>
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Observation"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
+                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
+                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
+                </wstxns7:expression>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship/>
+            <wstxns7:where wstxns7:type="And">
+              <wstxns7:signature>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+              </wstxns7:signature>
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="In">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                      <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    </wstxns7:signature>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
+                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Not">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand wstxns7:type="IsNull">
+                    <wstxns7:signature>
+                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                    </wstxns7:signature>
+                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:operand>
+            </wstxns7:where>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+    </wstxns7:def>
+  </wstxns7:statements>
+  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
+    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="All"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
+  </wstxns8:annotation>
+</Library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.json
@@ -362,6 +362,10 @@
                 "type" : "Not",
                 "operand" : {
                   "type" : "IsNull",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}Any"
+                  } ],
                   "operand" : {
                     "type" : "Start",
                     "operand" : {
@@ -490,6 +494,10 @@
                   "type" : "Not",
                   "operand" : {
                     "type" : "IsNull",
+                    "signature" : [ {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}Any"
+                    } ],
                     "operand" : {
                       "type" : "Property",
                       "path" : "onsetDateTime",
@@ -590,6 +598,10 @@
                 "type" : "Not",
                 "operand" : {
                   "type" : "IsNull",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}Any"
+                  } ],
                   "operand" : {
                     "type" : "Property",
                     "path" : "valueQuantity",
@@ -607,7 +619,8 @@
     },
     "annotation" : [ {
       "type" : "CqlToElmInfo",
-      "translatorOptions" : ""
+      "translatorOptions" : "",
+      "signatureLevel" : "Differing"
     }, {
       "type" : "CqlToElmError",
       "libraryId" : "CMS146",

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.xml
@@ -1,0 +1,300 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<Library type="Library">
+  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
+  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
+  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
+    <wstxns3:def>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+    </wstxns3:def>
+  </wstxns3:usings>
+  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
+    <wstxns4:def>
+      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
+        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
+          <wstxns4:low wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:low>
+          <wstxns4:high wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:high>
+        </wstxns4:default>
+      </wstxns4:def>
+    </wstxns4:def>
+  </wstxns4:parameters>
+  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
+    <wstxns5:def>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+    </wstxns5:def>
+  </wstxns5:valueSets>
+  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
+    <wstxns6:def>
+      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
+    </wstxns6:def>
+  </wstxns6:contexts>
+  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
+    <wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
+        <wstxns7:expression wstxns7:type="SingletonFrom">
+          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="GreaterOrEqual">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Less">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Union">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
+          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
+              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
+                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
+              </wstxns7:expression>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="A">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              <wstxns7:suchThat wstxns7:type="And">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="In">
+                    <wstxns7:operand>
+                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
+                        <wstxns7:low wstxns7:type="Start">
+                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                        </wstxns7:low>
+                        <wstxns7:high wstxns7:type="Add">
+                          <wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Start">
+                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                            </wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
+                          </wstxns7:operand>
+                        </wstxns7:high>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Not">
+                    <wstxns7:operand wstxns7:type="IsNull">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                      </wstxns7:signature>
+                      <wstxns7:operand wstxns7:type="Start">
+                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+          <wstxns7:where wstxns7:type="IncludedIn">
+            <wstxns7:operand>
+              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+            </wstxns7:operand>
+          </wstxns7:where>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="E">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship>
+              <wstxns7:relationship wstxns7:type="With" alias="D">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
+                <wstxns7:suchThat wstxns7:type="And">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="In">
+                      <wstxns7:operand>
+                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
+                          <wstxns7:low wstxns7:type="Subtract">
+                            <wstxns7:operand>
+                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
+                            </wstxns7:operand>
+                          </wstxns7:low>
+                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                        </wstxns7:operand>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Not">
+                      <wstxns7:operand wstxns7:type="IsNull">
+                        <wstxns7:signature>
+                          <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                        </wstxns7:signature>
+                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:suchThat>
+              </wstxns7:relationship>
+            </wstxns7:relationship>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
+                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
+                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
+                </wstxns7:expression>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship/>
+            <wstxns7:where wstxns7:type="And">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="In">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
+                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Not">
+                  <wstxns7:operand wstxns7:type="IsNull">
+                    <wstxns7:signature>
+                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
+                    </wstxns7:signature>
+                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:operand>
+            </wstxns7:where>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+    </wstxns7:def>
+  </wstxns7:statements>
+  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
+    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="Differing"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
+  </wstxns8:annotation>
+</Library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.json
@@ -1,0 +1,636 @@
+{
+  "library" : {
+    "type" : "Library",
+    "identifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "type" : "Library$Usings",
+      "def" : [ {
+        "type" : "UsingDef",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1"
+      }, {
+        "type" : "UsingDef",
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir"
+      } ]
+    },
+    "parameters" : {
+      "type" : "Library$Parameters",
+      "def" : [ {
+        "type" : "ParameterDef",
+        "default" : {
+          "type" : "Interval",
+          "low" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            }
+          },
+          "lowClosed" : true,
+          "highClosed" : false
+        },
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "valueSets" : {
+      "type" : "Library$ValueSets",
+      "def" : [ {
+        "type" : "ValueSetDef",
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "contexts" : {
+      "type" : "Library$Contexts",
+      "def" : [ {
+        "type" : "ContextDef",
+        "name" : "Patient"
+      } ]
+    },
+    "statements" : {
+      "type" : "Library$Statements",
+      "def" : [ {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "SingletonFrom",
+          "operand" : {
+            "type" : "Retrieve",
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient"
+          }
+        },
+        "name" : "Patient",
+        "context" : "Patient"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2"
+            } ]
+          }, {
+            "type" : "Less",
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18"
+            } ]
+          } ]
+        },
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Union",
+          "operand" : [ {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Pharyngitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          }, {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Tonsillitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          } ]
+        },
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Retrieve",
+          "codes" : {
+            "type" : "ValueSetRef",
+            "name" : "Antibiotic Medications",
+            "preserve" : true
+          },
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in"
+        },
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "Retrieve",
+              "codes" : {
+                "type" : "ValueSetRef",
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true
+              },
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in"
+            },
+            "alias" : "E"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "P"
+          }, {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Antibiotics"
+            },
+            "suchThat" : {
+              "type" : "And",
+              "operand" : [ {
+                "type" : "In",
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "dateWritten",
+                  "scope" : "A"
+                }, {
+                  "type" : "Interval",
+                  "low" : {
+                    "type" : "Start",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "operand" : [ {
+                      "type" : "Start",
+                      "operand" : {
+                        "type" : "Property",
+                        "path" : "period",
+                        "scope" : "E"
+                      }
+                    }, {
+                      "type" : "Quantity",
+                      "value" : 3,
+                      "unit" : "days"
+                    } ]
+                  },
+                  "lowClosed" : false,
+                  "highClosed" : true
+                } ]
+              }, {
+                "type" : "Not",
+                "operand" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                    "type" : "Start",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  }
+                }
+              } ]
+            },
+            "alias" : "A"
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "operand" : [ {
+              "type" : "Property",
+              "path" : "period",
+              "scope" : "E"
+            }, {
+              "type" : "ParameterRef",
+              "name" : "MeasurementPeriod"
+            } ]
+          }
+        },
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "alias" : "P"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "TargetEncounters"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "E"
+          } ]
+        },
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "Antibiotics"
+              },
+              "alias" : "A"
+            } ],
+            "relationship" : [ {
+              "type" : "With",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "TargetDiagnoses"
+              },
+              "suchThat" : {
+                "type" : "And",
+                "operand" : [ {
+                  "type" : "In",
+                  "operand" : [ {
+                    "type" : "Property",
+                    "path" : "dateWritten",
+                    "scope" : "A"
+                  }, {
+                    "type" : "Interval",
+                    "low" : {
+                      "type" : "Subtract",
+                      "operand" : [ {
+                        "type" : "Property",
+                        "path" : "onsetDateTime",
+                        "scope" : "D"
+                      }, {
+                        "type" : "Quantity",
+                        "value" : 30,
+                        "unit" : "days"
+                      } ]
+                    },
+                    "high" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    },
+                    "lowClosed" : true,
+                    "highClosed" : false
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "operand" : {
+                    "type" : "IsNull",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    }
+                  }
+                } ]
+              },
+              "alias" : "D"
+            } ]
+          }
+        },
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "operand" : {
+            "type" : "ExpressionRef",
+            "name" : "TargetEncounters"
+          }
+        },
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "operand" : [ {
+            "type" : "ExpressionRef",
+            "name" : "InDemographic"
+          }, {
+            "type" : "ExpressionRef",
+            "name" : "HasTargetEncounter"
+          } ]
+        },
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Literal",
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true"
+        },
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "ExpressionRef",
+          "name" : "HasPriorAntibiotics"
+        },
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "Retrieve",
+                "codes" : {
+                  "type" : "ValueSetRef",
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true
+                },
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in"
+              },
+              "alias" : "R"
+            } ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "operand" : [ {
+                "type" : "In",
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "issued",
+                  "scope" : "R"
+                }, {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                } ]
+              }, {
+                "type" : "Not",
+                "operand" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                    "type" : "Property",
+                    "path" : "valueQuantity",
+                    "scope" : "R"
+                  }
+                }
+              } ]
+            }
+          }
+        },
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorOptions" : "",
+      "signatureLevel" : "None"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    } ]
+  }
+}

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.xml
@@ -1,0 +1,291 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<Library type="Library">
+  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
+  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
+  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
+    <wstxns3:def>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+    </wstxns3:def>
+  </wstxns3:usings>
+  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
+    <wstxns4:def>
+      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
+        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
+          <wstxns4:low wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:low>
+          <wstxns4:high wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:high>
+        </wstxns4:default>
+      </wstxns4:def>
+    </wstxns4:def>
+  </wstxns4:parameters>
+  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
+    <wstxns5:def>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+    </wstxns5:def>
+  </wstxns5:valueSets>
+  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
+    <wstxns6:def>
+      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
+    </wstxns6:def>
+  </wstxns6:contexts>
+  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
+    <wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
+        <wstxns7:expression wstxns7:type="SingletonFrom">
+          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="GreaterOrEqual">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Less">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Union">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
+          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
+              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
+                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
+              </wstxns7:expression>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="A">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              <wstxns7:suchThat wstxns7:type="And">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="In">
+                    <wstxns7:operand>
+                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
+                        <wstxns7:low wstxns7:type="Start">
+                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                        </wstxns7:low>
+                        <wstxns7:high wstxns7:type="Add">
+                          <wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Start">
+                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                            </wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
+                          </wstxns7:operand>
+                        </wstxns7:high>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Not">
+                    <wstxns7:operand wstxns7:type="IsNull">
+                      <wstxns7:operand wstxns7:type="Start">
+                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+          <wstxns7:where wstxns7:type="IncludedIn">
+            <wstxns7:operand>
+              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+            </wstxns7:operand>
+          </wstxns7:where>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="E">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship>
+              <wstxns7:relationship wstxns7:type="With" alias="D">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
+                <wstxns7:suchThat wstxns7:type="And">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="In">
+                      <wstxns7:operand>
+                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
+                          <wstxns7:low wstxns7:type="Subtract">
+                            <wstxns7:operand>
+                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
+                            </wstxns7:operand>
+                          </wstxns7:low>
+                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                        </wstxns7:operand>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Not">
+                      <wstxns7:operand wstxns7:type="IsNull">
+                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:suchThat>
+              </wstxns7:relationship>
+            </wstxns7:relationship>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
+                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
+                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
+                </wstxns7:expression>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship/>
+            <wstxns7:where wstxns7:type="And">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="In">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
+                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Not">
+                  <wstxns7:operand wstxns7:type="IsNull">
+                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:operand>
+            </wstxns7:where>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+    </wstxns7:def>
+  </wstxns7:statements>
+  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
+    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="None"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
+  </wstxns8:annotation>
+</Library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.json
@@ -1,0 +1,712 @@
+{
+  "library" : {
+    "type" : "Library",
+    "identifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "type" : "VersionedIdentifier",
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "type" : "Library$Usings",
+      "def" : [ {
+        "type" : "UsingDef",
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1"
+      }, {
+        "type" : "UsingDef",
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir"
+      } ]
+    },
+    "parameters" : {
+      "type" : "Library$Parameters",
+      "def" : [ {
+        "type" : "ParameterDef",
+        "default" : {
+          "type" : "Interval",
+          "low" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "year" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014"
+            },
+            "month" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "day" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1"
+            },
+            "hour" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "minute" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "second" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            },
+            "millisecond" : {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0"
+            }
+          },
+          "lowClosed" : true,
+          "highClosed" : false
+        },
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "valueSets" : {
+      "type" : "Library$ValueSets",
+      "def" : [ {
+        "type" : "ValueSetDef",
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ValueSetDef",
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "contexts" : {
+      "type" : "Library$Contexts",
+      "def" : [ {
+        "type" : "ContextDef",
+        "name" : "Patient"
+      } ]
+    },
+    "statements" : {
+      "type" : "Library$Statements",
+      "def" : [ {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "SingletonFrom",
+          "operand" : {
+            "type" : "Retrieve",
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient"
+          }
+        },
+        "name" : "Patient",
+        "context" : "Patient"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ],
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              } ],
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2"
+            } ]
+          }, {
+            "type" : "Less",
+            "signature" : [ {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            }, {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{urn:hl7-org:elm-types:r1}Integer"
+            } ],
+            "operand" : [ {
+              "type" : "CalculateAgeAt",
+              "signature" : [ {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              }, {
+                "type" : "NamedTypeSpecifier",
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+              } ],
+              "operand" : [ {
+                "type" : "Property",
+                "source" : {
+                  "type" : "ExpressionRef",
+                  "name" : "Patient"
+                },
+                "path" : "birthDate"
+              }, {
+                "type" : "Start",
+                "operand" : {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                }
+              } ],
+              "precision" : "Year"
+            }, {
+              "type" : "Literal",
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18"
+            } ]
+          } ]
+        },
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Union",
+          "operand" : [ {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Pharyngitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          }, {
+            "type" : "Retrieve",
+            "codes" : {
+              "type" : "ValueSetRef",
+              "name" : "Acute Tonsillitis",
+              "preserve" : true
+            },
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in"
+          } ]
+        },
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Retrieve",
+          "codes" : {
+            "type" : "ValueSetRef",
+            "name" : "Antibiotic Medications",
+            "preserve" : true
+          },
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in"
+        },
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "Retrieve",
+              "codes" : {
+                "type" : "ValueSetRef",
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true
+              },
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in"
+            },
+            "alias" : "E"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "P"
+          }, {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Antibiotics"
+            },
+            "suchThat" : {
+              "type" : "And",
+              "operand" : [ {
+                "type" : "In",
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "dateWritten",
+                  "scope" : "A"
+                }, {
+                  "type" : "Interval",
+                  "low" : {
+                    "type" : "Start",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "signature" : [ {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                    }, {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}Quantity"
+                    } ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "operand" : {
+                        "type" : "Property",
+                        "path" : "period",
+                        "scope" : "E"
+                      }
+                    }, {
+                      "type" : "Quantity",
+                      "value" : 3,
+                      "unit" : "days"
+                    } ]
+                  },
+                  "lowClosed" : false,
+                  "highClosed" : true
+                } ]
+              }, {
+                "type" : "Not",
+                "operand" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                    "type" : "Start",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "period",
+                      "scope" : "E"
+                    }
+                  }
+                }
+              } ]
+            },
+            "alias" : "A"
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "operand" : [ {
+              "type" : "Property",
+              "path" : "period",
+              "scope" : "E"
+            }, {
+              "type" : "ParameterRef",
+              "name" : "MeasurementPeriod"
+            } ]
+          }
+        },
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Query",
+          "source" : [ {
+            "type" : "AliasedQuerySource",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "Pharyngitis"
+            },
+            "alias" : "P"
+          } ],
+          "relationship" : [ {
+            "type" : "With",
+            "expression" : {
+              "type" : "ExpressionRef",
+              "name" : "TargetEncounters"
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "operand" : [ {
+                "type" : "Interval",
+                "low" : {
+                  "type" : "Property",
+                  "path" : "onsetDateTime",
+                  "scope" : "P"
+                },
+                "high" : {
+                  "type" : "Property",
+                  "path" : "abatementDate",
+                  "scope" : "P"
+                },
+                "lowClosed" : true,
+                "highClosed" : true
+              }, {
+                "type" : "Property",
+                "path" : "period",
+                "scope" : "E"
+              } ]
+            },
+            "alias" : "E"
+          } ]
+        },
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "Antibiotics"
+              },
+              "alias" : "A"
+            } ],
+            "relationship" : [ {
+              "type" : "With",
+              "expression" : {
+                "type" : "ExpressionRef",
+                "name" : "TargetDiagnoses"
+              },
+              "suchThat" : {
+                "type" : "And",
+                "operand" : [ {
+                  "type" : "In",
+                  "signature" : [ {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }, {
+                    "type" : "IntervalTypeSpecifier",
+                    "pointType" : {
+                      "type" : "NamedTypeSpecifier",
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                    }
+                  } ],
+                  "operand" : [ {
+                    "type" : "Property",
+                    "path" : "dateWritten",
+                    "scope" : "A"
+                  }, {
+                    "type" : "Interval",
+                    "low" : {
+                      "type" : "Subtract",
+                      "signature" : [ {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                      }, {
+                        "type" : "NamedTypeSpecifier",
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity"
+                      } ],
+                      "operand" : [ {
+                        "type" : "Property",
+                        "path" : "onsetDateTime",
+                        "scope" : "D"
+                      }, {
+                        "type" : "Quantity",
+                        "value" : 30,
+                        "unit" : "days"
+                      } ]
+                    },
+                    "high" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    },
+                    "lowClosed" : true,
+                    "highClosed" : false
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "operand" : {
+                    "type" : "IsNull",
+                    "operand" : {
+                      "type" : "Property",
+                      "path" : "onsetDateTime",
+                      "scope" : "D"
+                    }
+                  }
+                } ]
+              },
+              "alias" : "D"
+            } ]
+          }
+        },
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Encounter"
+            }
+          } ],
+          "operand" : {
+            "type" : "ExpressionRef",
+            "name" : "TargetEncounters"
+          }
+        },
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "And",
+          "operand" : [ {
+            "type" : "ExpressionRef",
+            "name" : "InDemographic"
+          }, {
+            "type" : "ExpressionRef",
+            "name" : "HasTargetEncounter"
+          } ]
+        },
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Literal",
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true"
+        },
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "ExpressionRef",
+          "name" : "HasPriorAntibiotics"
+        },
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      }, {
+        "type" : "ExpressionDef",
+        "expression" : {
+          "type" : "Exists",
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "elementType" : {
+              "type" : "NamedTypeSpecifier",
+              "name" : "{http://hl7.org/fhir}Observation"
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "source" : [ {
+              "type" : "AliasedQuerySource",
+              "expression" : {
+                "type" : "Retrieve",
+                "codes" : {
+                  "type" : "ValueSetRef",
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true
+                },
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in"
+              },
+              "alias" : "R"
+            } ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "operand" : [ {
+                "type" : "In",
+                "signature" : [ {
+                  "type" : "NamedTypeSpecifier",
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                    "type" : "NamedTypeSpecifier",
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
+                  }
+                } ],
+                "operand" : [ {
+                  "type" : "Property",
+                  "path" : "issued",
+                  "scope" : "R"
+                }, {
+                  "type" : "ParameterRef",
+                  "name" : "MeasurementPeriod"
+                } ]
+              }, {
+                "type" : "Not",
+                "operand" : {
+                  "type" : "IsNull",
+                  "operand" : {
+                    "type" : "Property",
+                    "path" : "valueQuantity",
+                    "scope" : "R"
+                  }
+                }
+              } ]
+            }
+          }
+        },
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public"
+      } ]
+    },
+    "annotation" : [ {
+      "type" : "CqlToElmInfo",
+      "translatorOptions" : "",
+      "signatureLevel" : "Overloads"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    }, {
+      "type" : "CqlToElmError",
+      "libraryId" : "CMS146",
+      "libraryVersion" : "2",
+      "startLine" : 22,
+      "startChar" : 5,
+      "endLine" : 22,
+      "endChar" : 54,
+      "message" : "Could not resolve membership operator for terminology target of the retrieve.",
+      "errorType" : "semantic",
+      "errorSeverity" : "warning"
+    } ]
+  }
+}

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.xml
@@ -1,0 +1,337 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<Library type="Library">
+  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
+  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
+  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
+    <wstxns3:def>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+    </wstxns3:def>
+  </wstxns3:usings>
+  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
+    <wstxns4:def>
+      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
+        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
+          <wstxns4:low wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:low>
+          <wstxns4:high wstxns4:type="DateTime">
+            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
+            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
+            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
+          </wstxns4:high>
+        </wstxns4:default>
+      </wstxns4:def>
+    </wstxns4:def>
+  </wstxns4:parameters>
+  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
+    <wstxns5:def>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+    </wstxns5:def>
+  </wstxns5:valueSets>
+  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
+    <wstxns6:def>
+      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
+    </wstxns6:def>
+  </wstxns6:contexts>
+  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
+    <wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
+        <wstxns7:expression wstxns7:type="SingletonFrom">
+          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="GreaterOrEqual">
+              <wstxns7:signature>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              </wstxns7:signature>
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Less">
+              <wstxns7:signature>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
+              </wstxns7:signature>
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
+                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Start">
+                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
+              </wstxns7:operand>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Union">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
+            </wstxns7:operand>
+            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
+              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
+            </wstxns7:operand>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
+          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
+              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
+                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
+              </wstxns7:expression>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="A">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              <wstxns7:suchThat wstxns7:type="And">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="In">
+                    <wstxns7:operand>
+                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
+                        <wstxns7:low wstxns7:type="Start">
+                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                        </wstxns7:low>
+                        <wstxns7:high wstxns7:type="Add">
+                          <wstxns7:signature>
+                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
+                          </wstxns7:signature>
+                          <wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Start">
+                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                            </wstxns7:operand>
+                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
+                          </wstxns7:operand>
+                        </wstxns7:high>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Not">
+                    <wstxns7:operand wstxns7:type="IsNull">
+                      <wstxns7:operand wstxns7:type="Start">
+                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+          <wstxns7:where wstxns7:type="IncludedIn">
+            <wstxns7:operand>
+              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+            </wstxns7:operand>
+          </wstxns7:where>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Query">
+          <wstxns7:source>
+            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
+            </wstxns7:source>
+          </wstxns7:source>
+          <wstxns7:relationship>
+            <wstxns7:relationship wstxns7:type="With" alias="E">
+              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
+                <wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
+                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
+                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
+                  </wstxns7:operand>
+                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
+                </wstxns7:operand>
+              </wstxns7:suchThat>
+            </wstxns7:relationship>
+          </wstxns7:relationship>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship>
+              <wstxns7:relationship wstxns7:type="With" alias="D">
+                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
+                <wstxns7:suchThat wstxns7:type="And">
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="In">
+                      <wstxns7:signature>
+                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                        </wstxns7:signature>
+                      </wstxns7:signature>
+                      <wstxns7:operand>
+                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
+                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
+                          <wstxns7:low wstxns7:type="Subtract">
+                            <wstxns7:signature>
+                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
+                            </wstxns7:signature>
+                            <wstxns7:operand>
+                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
+                            </wstxns7:operand>
+                          </wstxns7:low>
+                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                        </wstxns7:operand>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Not">
+                      <wstxns7:operand wstxns7:type="IsNull">
+                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
+                      </wstxns7:operand>
+                    </wstxns7:operand>
+                  </wstxns7:operand>
+                </wstxns7:suchThat>
+              </wstxns7:relationship>
+            </wstxns7:relationship>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Encounter"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="And">
+          <wstxns7:operand>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
+            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
+      </wstxns7:def>
+      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
+        <wstxns7:expression wstxns7:type="Exists">
+          <wstxns7:signature>
+            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
+              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Observation"/>
+            </wstxns7:signature>
+          </wstxns7:signature>
+          <wstxns7:operand wstxns7:type="Query">
+            <wstxns7:source>
+              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
+                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
+                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
+                </wstxns7:expression>
+              </wstxns7:source>
+            </wstxns7:source>
+            <wstxns7:relationship/>
+            <wstxns7:where wstxns7:type="And">
+              <wstxns7:operand>
+                <wstxns7:operand wstxns7:type="In">
+                  <wstxns7:signature>
+                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
+                      <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
+                    </wstxns7:signature>
+                  </wstxns7:signature>
+                  <wstxns7:operand>
+                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
+                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+                <wstxns7:operand wstxns7:type="Not">
+                  <wstxns7:operand wstxns7:type="IsNull">
+                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
+                  </wstxns7:operand>
+                </wstxns7:operand>
+              </wstxns7:operand>
+            </wstxns7:where>
+          </wstxns7:operand>
+        </wstxns7:expression>
+      </wstxns7:def>
+    </wstxns7:def>
+  </wstxns7:statements>
+  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
+    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="Overloads"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
+    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
+  </wstxns8:annotation>
+</Library>

--- a/Src/java/elm-test/src/test/java/org/cqframework/cql/elm/ElmDeserializeTests.java
+++ b/Src/java/elm-test/src/test/java/org/cqframework/cql/elm/ElmDeserializeTests.java
@@ -4,22 +4,27 @@ import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlCompilerOptions;
 import org.cqframework.cql.cql2elm.CompilerOptions;
+import org.cqframework.cql.cql2elm.LibraryBuilder;
+import org.hl7.cql_annotations.r1.CqlToElmInfo;
 import org.hl7.elm.r1.*;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 public class ElmDeserializeTests {
 
     @Test
     public void testElmTests() {
         try {
-            new org.cqframework.cql.elm.serializing.jaxb.ElmXmlLibraryReader().read(ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/ElmTests.xml"));
+            deserializeXmlLibrary("ElmDeserialize/ElmTests.xml");
         } catch (IOException e) {
             e.printStackTrace();
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
@@ -30,8 +35,8 @@ public class ElmDeserializeTests {
     @Test
     public void testJsonANCFHIRDummyLibraryLoad() {
         try {
-            Library library = new org.cqframework.cql.elm.serializing.jaxb.ElmJsonLibraryReader().read(new InputStreamReader(ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/ANCFHIRDummy.json")));
-            Assert.assertTrue(library != null);
+            final Library library = deserializeJsonLibrary("ElmDeserialize/ANCFHIRDummy.json");
+            assertNotNull(library);
 
             EnumSet<CqlCompilerOptions.Options> translatorOptions = EnumSet.of(
                     CqlCompilerOptions.Options.EnableDateRangeOptimization,
@@ -43,16 +48,18 @@ public class ElmDeserializeTests {
                     CqlCompilerOptions.Options.DisableMethodInvocation
             );
 
-            Assert.assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
+            assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
 
-            Assert.assertTrue(library.getStatements() != null);
-            Assert.assertTrue(library.getStatements().getDef() != null);
-            Assert.assertTrue(library.getStatements().getDef().size() >= 2);
-            Assert.assertTrue(library.getStatements().getDef().get(0) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
-            Assert.assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
-            Assert.assertTrue(library.getStatements().getDef().get(1) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Retrieve);
+            assertNotNull(library.getStatements());
+            assertNotNull(library.getStatements().getDef());
+            assertTrue(library.getStatements().getDef().size() >= 2);
+            assertNotNull(library.getStatements().getDef().get(0));
+            assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
+            assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
+            assertNotNull(library.getStatements().getDef().get(1));
+            assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Retrieve);
+
+            verifySigLevels(library, LibraryBuilder.SignatureLevel.All);
         } catch (IOException e) {
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
         }
@@ -61,26 +68,28 @@ public class ElmDeserializeTests {
     @Test
     public void testJsonAdultOutpatientEncounters_FHIR4LibraryLoad() {
         try {
-            Library library = new org.cqframework.cql.elm.serializing.jaxb.ElmJsonLibraryReader().read(new InputStreamReader(ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.json")));
-            Assert.assertTrue(library != null);
+            final Library library = deserializeJsonLibrary("ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.json");
+            assertNotNull(library);
 
             EnumSet<CqlCompilerOptions.Options> translatorOptions = EnumSet.of(
                     CqlCompilerOptions.Options.EnableAnnotations
             );
-            Assert.assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
-            Assert.assertEquals(library.getIdentifier().getId(), "AdultOutpatientEncounters_FHIR4");
-            Assert.assertEquals(library.getIdentifier().getVersion(), "2.0.000");
-            Assert.assertTrue(library.getUsings() != null);
-            Assert.assertTrue(library.getUsings().getDef() != null);
-            Assert.assertTrue(library.getUsings().getDef().size() >= 2);
-            Assert.assertTrue(library.getStatements() != null);
-            Assert.assertTrue(library.getStatements().getDef() != null);
-            Assert.assertTrue(library.getStatements().getDef().get(0) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
-            Assert.assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
-            Assert.assertEquals(library.getStatements().getDef().get(1).getName(), "Qualifying Encounters");
-            Assert.assertTrue(library.getStatements().getDef().get(1) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Query);
+            assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
+            assertEquals(library.getIdentifier().getId(), "AdultOutpatientEncounters_FHIR4");
+            assertEquals(library.getIdentifier().getVersion(), "2.0.000");
+            assertNotNull(library.getUsings());
+            assertNotNull(library.getUsings().getDef());
+            assertTrue(library.getUsings().getDef().size() >= 2);
+            assertNotNull(library.getStatements());
+            assertNotNull(library.getStatements().getDef());
+            assertNotNull(library.getStatements().getDef().get(0));
+            assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
+            assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
+            assertEquals(library.getStatements().getDef().get(1).getName(), "Qualifying Encounters");
+            assertNotNull(library.getStatements().getDef().get(1));
+            assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Query);
+
+            verifySigLevels(library, LibraryBuilder.SignatureLevel.Differing);
         } catch (IOException e) {
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
         }
@@ -89,10 +98,10 @@ public class ElmDeserializeTests {
     @Test
     public void testXmlLibraryLoad() {
         try {
-            Library library = new org.cqframework.cql.elm.serializing.jaxb.ElmXmlLibraryReader().read(new InputStreamReader(ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.xml")));
-            Assert.assertTrue(library != null);
-            Assert.assertEquals(library.getIdentifier().getId(), "AdultOutpatientEncounters_FHIR4");
-            Assert.assertEquals(library.getIdentifier().getVersion(), "2.0.000");
+            final Library library = deserializeXmlLibrary("ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.xml");
+            assertNotNull(library);
+            assertEquals(library.getIdentifier().getId(), "AdultOutpatientEncounters_FHIR4");
+            assertEquals(library.getIdentifier().getVersion(), "2.0.000");
 
             EnumSet<CqlCompilerOptions.Options> translatorOptions = EnumSet.of(
                     CqlCompilerOptions.Options.EnableDateRangeOptimization,
@@ -103,19 +112,21 @@ public class ElmDeserializeTests {
                     CqlCompilerOptions.Options.DisableListPromotion,
                     CqlCompilerOptions.Options.DisableMethodInvocation
             );
-            Assert.assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
+            assertEquals(CompilerOptions.getCompilerOptions(library), translatorOptions);
 
-            Assert.assertTrue(library.getUsings() != null);
-            Assert.assertTrue(library.getUsings().getDef() != null);
-            Assert.assertTrue(library.getUsings().getDef().size() >= 2);
-            Assert.assertTrue(library.getStatements() != null);
-            Assert.assertTrue(library.getStatements().getDef() != null);
-            Assert.assertTrue(library.getStatements().getDef().get(0) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
-            Assert.assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
-            Assert.assertEquals(library.getStatements().getDef().get(1).getName(), "Qualifying Encounters");
-            Assert.assertTrue(library.getStatements().getDef().get(1) instanceof ExpressionDef);
-            Assert.assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Query);
+            assertNotNull(library.getUsings());
+            assertNotNull(library.getUsings().getDef());
+            assertTrue(library.getUsings().getDef().size() >= 2);
+            assertNotNull(library.getStatements());
+            assertNotNull(library.getStatements().getDef());
+            assertNotNull(library.getStatements().getDef().get(0));
+            assertTrue(library.getStatements().getDef().get(0).getExpression() instanceof SingletonFrom);
+            assertTrue(((SingletonFrom)library.getStatements().getDef().get(0).getExpression()).getOperand() instanceof Retrieve);
+            assertEquals(library.getStatements().getDef().get(1).getName(), "Qualifying Encounters");
+            assertNotNull(library.getStatements().getDef().get(1));
+            assertTrue(library.getStatements().getDef().get(1).getExpression() instanceof Query);
+
+            verifySigLevels(library, LibraryBuilder.SignatureLevel.Overloads);
         } catch (IOException e) {
             e.printStackTrace();
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
@@ -125,8 +136,10 @@ public class ElmDeserializeTests {
     @Test
     public void testJsonTerminologyLibraryLoad() {
         try {
-            Library library = new org.cqframework.cql.elm.serializing.jaxb.ElmJsonLibraryReader().read(new InputStreamReader(ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/ANCFHIRTerminologyDummy.json")));
-            Assert.assertTrue(library != null);
+            final Library library = deserializeJsonLibrary("ElmDeserialize/ANCFHIRTerminologyDummy.json");
+            assertNotNull(library);
+
+            verifySigLevels(library, LibraryBuilder.SignatureLevel.None);
         } catch (IOException e) {
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
         }
@@ -153,7 +166,7 @@ public class ElmDeserializeTests {
             if (!equivalent(xmlLibrary, jsonLibrary)) {
                 System.out.println(xmlFileName);
             }
-            Assert.assertTrue(equivalent(xmlLibrary, jsonLibrary));
+            assertTrue(equivalent(xmlLibrary, jsonLibrary));
         }
     }
 
@@ -238,20 +251,20 @@ public class ElmDeserializeTests {
         // Space
         for (ExpressionDef ed : library.getStatements().getDef()) {
             switch (ed.getName()) {
-                case "Null": Assert.assertTrue(ed.getExpression() instanceof Null);
+                case "Null": assertTrue(ed.getExpression() instanceof Null);
                 break;
 
                 case "Empty": {
-                    Assert.assertTrue(ed.getExpression() instanceof Literal);
+                    assertTrue(ed.getExpression() instanceof Literal);
                     Literal l = (Literal)ed.getExpression();
-                    Assert.assertTrue(l.getValue() != null && l.getValue().equals(""));
+                    assertTrue(l.getValue() != null && l.getValue().equals(""));
                 }
                 break;
 
                 case "Space": {
-                    Assert.assertTrue(ed.getExpression() instanceof Literal);
+                    assertTrue(ed.getExpression() instanceof Literal);
                     Literal l = (Literal)ed.getExpression();
-                    Assert.assertTrue(l.getValue() != null && l.getValue().equals(" "));
+                    assertTrue(l.getValue() != null && l.getValue().equals(" "));
                 }
                 break;
             }
@@ -278,7 +291,7 @@ public class ElmDeserializeTests {
     public void emptyStringsTest() throws IOException {
         InputStream inputStream = ElmDeserializeTests.class.getResourceAsStream("ElmDeserialize/EmptyStringsTest.cql");
         CqlTranslator translator = TestUtils.createTranslatorFromStream(inputStream);
-        Assert.assertTrue(translator.getErrors().size() == 0);
+        assertEquals(translator.getErrors().size(), 0);
 
         String jaxbXml = toJaxbXml(translator.toELM());
         String jaxbJson = toJaxbJson(translator.toELM());
@@ -319,4 +332,26 @@ public class ElmDeserializeTests {
         }
     }
 
+    private static Library deserializeJsonLibrary(String filePath) throws IOException {
+        final InputStream resourceAsStream = ElmDeserializeTests.class.getResourceAsStream(filePath);
+        assertNotNull(resourceAsStream);
+        return new org.cqframework.cql.elm.serializing.jaxb.ElmJsonLibraryReader().read(new InputStreamReader(resourceAsStream));
+    }
+
+    private static Library deserializeXmlLibrary(String filePath) throws IOException {
+        final InputStream resourceAsStream = ElmDeserializeTests.class.getResourceAsStream(filePath);
+        assertNotNull(resourceAsStream);
+        return new org.cqframework.cql.elm.serializing.jaxb.ElmXmlLibraryReader().read(resourceAsStream);
+    }
+
+    private static void verifySigLevels(Library theLibrary, LibraryBuilder.SignatureLevel expectedSignatureLevel) {
+        final List<String> sigLevels = theLibrary.getAnnotation().stream()
+                .filter(CqlToElmInfo.class::isInstance)
+                .map(CqlToElmInfo.class::cast)
+                .map(CqlToElmInfo::getSignatureLevel)
+                .collect(Collectors.toList());
+
+        assertEquals(sigLevels.size(), 1);
+        assertEquals(sigLevels.get(0), expectedSignatureLevel.name());
+    }
 }

--- a/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/ANCFHIRDummy.json
+++ b/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/ANCFHIRDummy.json
@@ -104,7 +104,8 @@
     },
     "annotation" : [ {
       "type" : "CqlToElmInfo",
-      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation"
+      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation",
+      "signatureLevel" : "All"
     } ]
   }
 }

--- a/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/ANCFHIRTerminologyDummy.json
+++ b/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/ANCFHIRTerminologyDummy.json
@@ -576,7 +576,8 @@
     },
     "annotation" : [ {
       "type" : "CqlToElmInfo",
-      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation"
+      "translatorOptions" : "EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation",
+      "signatureLevel" : "None"
     } ]
   }
 }

--- a/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.json
+++ b/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.json
@@ -3,7 +3,8 @@
     "annotation": [
       {
         "translatorOptions": "EnableAnnotations",
-        "type": "CqlToElmInfo"
+        "type": "CqlToElmInfo",
+        "signatureLevel" : "Differing"
       }
     ],
     "identifier": {

--- a/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.xml
+++ b/Src/java/elm-test/src/test/resources/org/cqframework/cql/elm/ElmDeserialize/fhir/AdultOutpatientEncounters_FHIR4-2.0.000.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
-   <annotation translatorOptions="EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation" xsi:type="a:CqlToElmInfo"/>
+   <annotation signatureLevel = "Overloads" translatorOptions="EnableDateRangeOptimization,EnableAnnotations,EnableLocators,EnableResultTypes,DisableListDemotion,DisableListPromotion,DisableMethodInvocation" xsi:type="a:CqlToElmInfo"/>
    <identifier id="AdultOutpatientEncounters_FHIR4" version="2.0.000"/>
    <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
    <usings>


### PR DESCRIPTION
- Add signature level to auto-generated CqlToElmInfo
- Populate the signatureLevel when generating the ELM
- Enhance existing unit tests to prove this works
- Delete redundant annotations xsd file.

Closes https://github.com/cqframework/clinical_quality_language/issues/1161