### PR TITLE
Ensure that all overloads will fail to compile if EnableAnnotations and EnableResultTypes are not part of compile options

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -160,6 +160,10 @@ public class LibraryBuilder implements ModelResolver {
         this.visitor = visitor;
     }
 
+    public String getCompilerOptions() {
+        return cqlToElmInfo.getTranslatorOptions();
+    }
+
     private String compatibilityLevel = null;
     public boolean isCompatibilityLevel3() {
         return "1.3".equals(compatibilityLevel);

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorVisitor.java
@@ -348,27 +348,28 @@ public class CqlPreprocessorVisitor extends CqlPreprocessorElmCommonVisitor {
     }
 
     private void validateOverloadsForDisabledAnnotations(String theTranslatorOptions, PreCompileOutput thePreCompileOutput, String theFunctionName) {
-        if (! theTranslatorOptions.contains("EnableAnnotations") && ! theTranslatorOptions.contains("EnableResultTypes")) {
-            final int preCompileOutputOperandSize = thePreCompileOutput.getFunctionDef().getOperand().size();
-
-            final Iterable<FunctionDefinitionInfo> functionDefinitionInfos = libraryInfo.resolveFunctionReferenceFromName(theFunctionName);
-
-            if (functionDefinitionInfos != null) {
-                final List<PreCompileOutput> existingPreCompileOutputs = StreamSupport.stream(functionDefinitionInfos.spliterator(), false)
-                        .map(FunctionDefinitionInfo::getPreCompileOutput)
-                        .collect(Collectors.toList());
-
-                final Optional<PreCompileOutput> optMatchingExistingPreCompileOutput =
-                        existingPreCompileOutputs.stream()
-                                .filter(existingPreCompileOutput -> existingPreCompileOutput.getFunctionDef().getOperand().size() == preCompileOutputOperandSize)
-                                .findFirst();
-
-                optMatchingExistingPreCompileOutput.ifPresent(matchingExistingPreCompileOutput -> {
-                    logger.error("Function name: {}, existing params: {}, passed params: {}", theFunctionName, functionTypes(thePreCompileOutput), functionTypes(matchingExistingPreCompileOutput));
-                    throw new CqlCompilerException("Function overloading cannot be resolved due to compiler options for function: " + theFunctionName);
-                });
-            }
-        }
+        // LUKETODO:  leave this commented out until we figure out which compile options to check for and then adjust the if conditions accordingly
+//        if (! theTranslatorOptions.contains("EnableAnnotations") && ! theTranslatorOptions.contains("EnableResultTypes")) {
+//            final int preCompileOutputOperandSize = thePreCompileOutput.getFunctionDef().getOperand().size();
+//
+//            final Iterable<FunctionDefinitionInfo> functionDefinitionInfos = libraryInfo.resolveFunctionReferenceFromName(theFunctionName);
+//
+//            if (functionDefinitionInfos != null) {
+//                final List<PreCompileOutput> existingPreCompileOutputs = StreamSupport.stream(functionDefinitionInfos.spliterator(), false)
+//                        .map(FunctionDefinitionInfo::getPreCompileOutput)
+//                        .collect(Collectors.toList());
+//
+//                final Optional<PreCompileOutput> optMatchingExistingPreCompileOutput =
+//                        existingPreCompileOutputs.stream()
+//                                .filter(existingPreCompileOutput -> existingPreCompileOutput.getFunctionDef().getOperand().size() == preCompileOutputOperandSize)
+//                                .findFirst();
+//
+//                optMatchingExistingPreCompileOutput.ifPresent(matchingExistingPreCompileOutput -> {
+//                    logger.error("Function name: {}, existing params: {}, passed params: {}", theFunctionName, functionTypes(thePreCompileOutput), functionTypes(matchingExistingPreCompileOutput));
+//                    throw new CqlCompilerException("Function overloading cannot be resolved due to compiler options for function: " + theFunctionName);
+//                });
+//            }
+//        }
     }
 
     private static List<String> functionTypes(PreCompileOutput preCompileOutput) {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CommentTests.java
@@ -82,7 +82,7 @@ public class CommentTests {
 
     @Test
     public void testTags() throws IOException {
-        CqlTranslator translator = TestUtils.runSemanticTest("TestTags.cql", 0);
+        CqlTranslator translator = TestUtils.runSemanticTestNoAnnotations("TestTags.cql");
         CompiledLibrary library = translator.getTranslatedLibrary();
         assertThat(library.getLibrary().getAnnotation(), notNullValue());
         Annotation a = null;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -81,7 +81,7 @@ public class SemanticTests {
 
     @Test
     public void testDateTimeOperators() throws IOException {
-        runSemanticTest("OperatorTests/DateTimeOperators.cql");
+        runSemanticTestNoAnnotations("OperatorTests/DateTimeOperators.cql");
     }
 
     @Test
@@ -234,12 +234,12 @@ public class SemanticTests {
 
     @Test
     public void testUndeclaredForward() throws IOException {
-        runSemanticTest("OperatorTests/UndeclaredForward.cql", 1);
+        runSemanticTestNoAnnotations("OperatorTests/UndeclaredForward.cql", 1);
     }
 
     @Test
     public void testUndeclaredSignature() throws IOException {
-        runSemanticTest("OperatorTests/UndeclaredSignature.cql", 1);
+        runSemanticTestNoAnnotations("OperatorTests/UndeclaredSignature.cql", 1);
     }
 
     @Test
@@ -268,12 +268,12 @@ public class SemanticTests {
 
     @Test
     public void tricksyParse() throws IOException {
-        runSemanticTest("TricksyParse.cql");
+        runSemanticTestNoAnnotations("TricksyParse.cql");
     }
 
     @Test
     public void shouldFail() throws IOException {
-        runSemanticTest("ShouldFail.cql", 1);
+        runSemanticTestNoAnnotations("ShouldFail.cql", 1);
     }
 
     @Test
@@ -572,7 +572,7 @@ public class SemanticTests {
     public void TestVSCastFunction15() throws IOException {
         // TODO: This test needs to pass, most likely by implicitly converting a ValueSet to a ValueSetRef? Or maybe a new explicit ELM operation?
         CqlCompilerOptions options = new CqlCompilerOptions()
-                .withOptions(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion, CqlCompilerOptions.Options.DisableMethodInvocation);
+                .withOptions(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion, CqlCompilerOptions.Options.DisableMethodInvocation, CqlCompilerOptions.Options.EnableAnnotations);
         CqlTranslator translator = TestUtils.runSemanticTest("TestVSCastFunction.cql", 0, options);
         ExpressionDef ed = translator.getTranslatedLibrary().resolveExpressionRef("TestConditionsViaFunction");
 
@@ -654,6 +654,14 @@ public class SemanticTests {
 
     private CqlTranslator runSemanticTest(String testFileName) throws IOException {
         return runSemanticTest(testFileName, 0);
+    }
+
+    private CqlTranslator runSemanticTestNoAnnotations(String testFileName) throws IOException {
+        return TestUtils.runSemanticTestNoAnnotations(testFileName, 0);
+    }
+
+    private CqlTranslator runSemanticTestNoAnnotations(String testFileName, int expectedErrors) throws IOException {
+        return TestUtils.runSemanticTestNoAnnotations(testFileName, expectedErrors);
     }
 
     private CqlTranslator runSemanticTest(String testFileName, int expectedErrors) throws IOException {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -205,6 +205,10 @@ public class TestUtils {
         return createTranslator(null, testFileName, getCqlCompilerOptionsNoAnnotations(options));
     }
 
+    public static CqlTranslator createTranslatorNoAnnotations(String testFileName, SignatureLevel signatureLevel, CqlCompilerOptions.Options... options) throws IOException {
+        return createTranslator(null, testFileName, getCqlCompilerOptionsNoAnnotations(ErrorSeverity.Warning, signatureLevel, options));
+    }
+
     public static CqlTranslator getTranslator(String cqlTestFile, String nullableLibrarySourceProvider, LibraryBuilder.SignatureLevel signatureLevel) throws IOException {
         final File testFile = getFileOrThrow(cqlTestFile);
         final ModelManager modelManager = new ModelManager();
@@ -255,6 +259,10 @@ public class TestUtils {
 
     private static CqlCompilerOptions getCqlCompilerOptions(ErrorSeverity errorSeverity, SignatureLevel signatureLevel, CqlCompilerOptions.Options... options) {
         return new CqlCompilerOptions(errorSeverity, signatureLevel, withEnableAnnotations(options));
+    }
+
+    private static CqlCompilerOptions getCqlCompilerOptionsNoAnnotations(ErrorSeverity errorSeverity, SignatureLevel signatureLevel, CqlCompilerOptions.Options... options) {
+        return new CqlCompilerOptions(errorSeverity, signatureLevel, options);
     }
 
     private static CqlCompilerOptions getCqlCompilerOptionsNoAnnotations(CqlCompilerOptions.Options... options) {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -163,13 +163,44 @@ public class TranslationTests {
         final DataType resultType1 = operandDef1.getOperandTypeSpecifier().getResultType();
         final QName resultTypeName1 = operandDef1.getOperandTypeSpecifier().getResultTypeName();
 
-        logger.info("resultType1: [{}], resultTypeName1: [{}]", resultType1, resultTypeName1);
+//        logger.info("resultType1: [{}], resultTypeName1: [{}]", resultType1, resultTypeName1);
 
         final DataType resultType2 = operandDef2.getOperandTypeSpecifier().getResultType();
         final QName resultTypeName2 = operandDef2.getOperandTypeSpecifier().getResultTypeName();
 
-        logger.info("resultType2: [{}], resultTypeName2: [{}]", resultType2, resultTypeName2);
+//        logger.info("resultType2: [{}], resultTypeName2: [{}]", resultType2, resultTypeName2);
+//        logger.info("----------------------------------------------");
+
+        final Library elm = translator.toELM();
+
+        final List<ExpressionDef> defs = elm.getStatements().getDef();
+
+        assertThat(defs.size(), equalTo(2));
+
+        final FunctionDef elmfunctionDef1 = (FunctionDef)expressionDefs.get(0);
+        final FunctionDef elmfunctionDef2 = (FunctionDef)expressionDefs.get(1);
+
+        final List<OperandDef> elmoperands1 = elmfunctionDef1.getOperand();
+        final List<OperandDef> elmoperands2 = elmfunctionDef2.getOperand();
+
+        final OperandDef elmoperandDef1 = elmoperands1.get(0);
+        final OperandDef elmoperandDef2 = elmoperands2.get(0);
+
+        final DataType elmresultType1 = elmoperandDef1.getOperandTypeSpecifier().getResultType();
+        final QName elmresultTypeName1 = elmoperandDef1.getOperandTypeSpecifier().getResultTypeName();
+        final DataType returnType1 = elmfunctionDef1.getResultType();
+        final QName returnTypeName1 = elmfunctionDef1.getResultTypeName();
+
+        logger.info("resultType1: [{}], resultTypeName1: [{}], returnType1: [{}], returnTypeName1: [{}]", elmresultType1, elmresultTypeName1, returnType1, returnTypeName1);
+
+        final DataType elmresultType2 = elmoperandDef2.getOperandTypeSpecifier().getResultType();
+        final QName elmresultTypeName2 = elmoperandDef2.getOperandTypeSpecifier().getResultTypeName();
+        final DataType returnType2 = elmfunctionDef2.getResultType();
+        final QName returnTypeName2 = elmfunctionDef2.getResultTypeName();
+
+        logger.info("resultType2: [{}], resultTypeName2: [{}], returnType2: [{}], returnTypeName2: [{}]", elmresultType2, elmresultTypeName2, returnType2, returnTypeName2);
         logger.info("----------------------------------------------");
+
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm;
 
-import org.cqframework.cql.cql2elm.preprocessor.CqlPreprocessorVisitor;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.hamcrest.Matchers;
 import org.hl7.cql.model.DataType;
@@ -113,24 +112,29 @@ public class TranslationTests {
     private static final String CQL_OVERLOAD_TESTS_FILE = "CqlOverloadTests.cql";
     private static final String CQL_GENERIC_OVERLOAD_TESTS_FILE = "CqlGenericOverloadTests.cql";
 
+    private static final Set<CqlCompilerOptions.Options> NOTHING = Set.of();
+
+    private static final Set<CqlCompilerOptions.Options> ENABLE_ALL = Set.of(CqlCompilerOptions.Options.EnableAnnotations, CqlCompilerOptions.Options.EnableDateRangeOptimization, CqlCompilerOptions.Options.EnableLocators, CqlCompilerOptions.Options.EnableDetailedErrors, CqlCompilerOptions.Options.EnableIntervalDemotion, CqlCompilerOptions.Options.EnableIntervalPromotion, CqlCompilerOptions.Options.EnableResultTypes);
+    private static final Set<CqlCompilerOptions.Options> DISABLE_ALL = Set.of(CqlCompilerOptions.Options.DisableDefaultModelInfoLoad, CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion, CqlCompilerOptions.Options.DisableListTraversal, CqlCompilerOptions.Options.DisableMethodInvocation);
+
     @DataProvider(name = "testCqlAndCompilerOptions")
     public static Object[][] testCqlAndCompilerOptions() {
         return new Object[][] {
-                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of()},
-                {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of()},
+                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, NOTHING},
+                {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, NOTHING},
                 {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion)},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion)},
                 {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion)},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion)},
-                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion)},
-                {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion)},
+                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, DISABLE_ALL},
+                {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, DISABLE_ALL},
                 {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableAnnotations)},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableAnnotations)},
                 {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableResultTypes)},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableResultTypes)},
                 {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableAnnotations, CqlCompilerOptions.Options.EnableResultTypes)},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.EnableAnnotations, CqlCompilerOptions.Options.EnableResultTypes)},
-                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion, CqlCompilerOptions.Options.DisableDefaultModelInfoLoad)},
+                {CQL_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, ENABLE_ALL},
                 {CQL_GENERIC_OVERLOAD_TESTS_FILE, LibraryBuilder.SignatureLevel.None, Set.of(CqlCompilerOptions.Options.DisableListDemotion, CqlCompilerOptions.Options.DisableListPromotion, CqlCompilerOptions.Options.DisableDefaultModelInfoLoad)}
         };
     }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -85,7 +85,7 @@ public class TranslationTests {
 
     @Test
     public void testAnnotationsAbsent() throws IOException {
-        CqlTranslator translator = TestUtils.createTranslator("CMS146v2_Test_CQM.cql");
+        final CqlTranslator translator = TestUtils.createTranslatorNoAnnotations("CMS146v2_Test_CQM.cql");
         assertEquals(0, translator.getErrors().size());
         List<ExpressionDef> defs = translator.getTranslatedLibrary().getLibrary().getStatements().getDef();
         assertTrue(defs.get(1).getAnnotation().size() == 0);

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CqlGenericOverloadTests.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CqlGenericOverloadTests.cql
@@ -1,0 +1,4 @@
+library CqlGenericOverloadTests version '2'
+
+define function toString(value List<Code>): null
+define function toString(value List<Integer>): null

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CqlOverloadTests.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CqlOverloadTests.cql
@@ -1,0 +1,4 @@
+library CqlOverloadTests version '2'
+
+define function toString(value Code): null
+define function toString(value Integer): null

--- a/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
+++ b/Src/java/elm-fhir/src/test/java/org/cqframework/cql/elm/requirements/fhir/DataRequirementsProcessorTest.java
@@ -101,7 +101,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsProcessorOpioidIssueExpression() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
         cqlTranslatorOptions.setCollapseDataRequirements(true);
         cqlTranslatorOptions.setAnalyzeDataRequirements(true);
         try {
@@ -180,7 +180,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsProcessorOpioidIssueLibrary() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
         cqlTranslatorOptions.setCollapseDataRequirements(true);
         cqlTranslatorOptions.setAnalyzeDataRequirements(true);
         try {
@@ -336,7 +336,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsProcessorWithExpressions() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
         try {
             Set<String> expressions = new HashSet<>();
             // TODO - add expressions to expressions
@@ -404,7 +404,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestLibraryDataRequirements() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
 
         try {
 //            CqlTranslator translator = createTranslator("/ecqm/resources/library-EXM506-2.2.000.json", cqlTranslatorOptions);
@@ -498,7 +498,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsFHIRReferences() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
 
         try {
             var setup = setup("FHIRReferencesRevisited.cql", cqlTranslatorOptions);
@@ -518,7 +518,11 @@ public class DataRequirementsProcessorTest {
     }
 
     private CqlCompilerOptions getCompilerOptions() {
-        return new CqlCompilerOptions();
+        final CqlCompilerOptions cqlCompilerOptions = new CqlCompilerOptions();
+
+        cqlCompilerOptions.getOptions().add(CqlCompilerOptions.Options.EnableAnnotations);
+
+        return cqlCompilerOptions;
     }
 
     private Setup setupDataRequirementsGather(String fileName, CqlCompilerOptions cqlTranslatorOptions) throws IOException {
@@ -1683,7 +1687,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestCMS149() throws IOException {
-        CqlCompilerOptions compilerOptions = getCompilerOptions();
+        final CqlCompilerOptions compilerOptions = getCompilerOptions();
         compilerOptions.setAnalyzeDataRequirements(false);
         var manager = setupDataRequirementsAnalysis("CMS149/cql/DementiaCognitiveAssessmentFHIR-0.0.003.cql", compilerOptions);
         org.hl7.fhir.r5.model.Library moduleDefinitionLibrary = getModuleDefinitionLibrary(manager, compilerOptions, new HashMap<String, Object>(), ZonedDateTime.of(2023, 1, 16, 0, 0, 0, 0, ZoneId.of("UTC")));
@@ -1695,7 +1699,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsProcessorWithPertinence() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
 
         cqlTranslatorOptions.getOptions().add(CqlCompilerOptions.Options.EnableAnnotations);
         try {
@@ -1724,7 +1728,7 @@ public class DataRequirementsProcessorTest {
 
     @Test
     public void TestDataRequirementsProcessorWithPertinenceAgain() {
-        CqlCompilerOptions cqlTranslatorOptions = new CqlCompilerOptions();
+        final CqlCompilerOptions cqlTranslatorOptions = getCompilerOptions();
 
         cqlTranslatorOptions.getOptions().add(CqlCompilerOptions.Options.EnableAnnotations);
         try {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
@@ -78,7 +78,7 @@ public abstract class FhirExecutionTestBase {
         r4Provider = new CompositeDataProvider(r4ModelResolver, r4RetrieveProvider);
 
         this.modelManager = new ModelManager();
-        var compilerOptions = new CqlCompilerOptions(CqlCompilerException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.All, CqlCompilerOptions.Options.EnableDateRangeOptimization);
+        var compilerOptions = new CqlCompilerOptions(CqlCompilerException.ErrorSeverity.Info, LibraryBuilder.SignatureLevel.All, CqlCompilerOptions.Options.EnableDateRangeOptimization, CqlCompilerOptions.Options.EnableAnnotations);
         this.libraryManager = new LibraryManager(modelManager, compilerOptions);
         libraryManager.getLibrarySourceLoader().clearProviders();
         libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlMainSuiteTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlMainSuiteTest.java
@@ -70,14 +70,17 @@ public class CqlMainSuiteTest extends CqlTestBase {
     @Test(dataProvider = "testCqlAndCompilerOptions")
     public void testOverloadsNoEnableAnnotations(String testFile, Collection<CqlCompilerOptions.Options> options) {
         final CqlEngine engine = getEngine(testCompilerOptionsWithWhitelist(options));
+        final EvaluationResult evaluate = engine.evaluate(toElmIdentifier(testFile), evalTime);
 
-        if (options.contains(CqlCompilerOptions.Options.EnableAnnotations) || options.contains(CqlCompilerOptions.Options.EnableResultTypes)) {
-            // No Exception thrown
-            engine.evaluate(toElmIdentifier(testFile), evalTime);
+        System.out.println("evaluate = " + evaluate);
 
-        } else {
-            assertThrows(CqlException.class, () -> engine.evaluate(toElmIdentifier(testFile), evalTime));
-        }
+//        if (options.contains(CqlCompilerOptions.Options.EnableAnnotations) || options.contains(CqlCompilerOptions.Options.EnableResultTypes)) {
+//            // No Exception thrown
+//            engine.evaluate(toElmIdentifier(testFile), evalTime);
+//
+//        } else {
+//            assertThrows(CqlException.class, () -> engine.evaluate(toElmIdentifier(testFile), evalTime));
+//        }
     }
 
     protected CqlCompilerOptions testCompilerOptionsWithWhitelist(Collection<CqlCompilerOptions.Options> options) {

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlMainSuiteTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlMainSuiteTest.java
@@ -2,10 +2,12 @@ package org.opencds.cqf.cql.engine.execution;
 
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlCompilerOptions;
+import org.opencds.cqf.cql.engine.exception.CqlException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -30,37 +32,63 @@ public class CqlMainSuiteTest extends CqlTestBase {
         var result = e.evaluate(toElmIdentifier("CqlTestSuite"), evalTime);
 
         for (var entry : result.expressionResults.entrySet()) {
-            if(entry.getKey().toString().startsWith("test")) {
-                if(((ExpressionResult)entry.getValue()).value() != null) {
+            if(entry.getKey().startsWith("test")) {
+                if(entry.getValue().value() != null) {
                 Assert.assertEquals(
-                        (String) ((ExpressionResult) entry.getValue()).value(),
-                        entry.getKey().toString().replaceAll("test_", "") + " TEST PASSED"
+                        (String) entry.getValue().value(),
+                        entry.getKey().replaceAll("test_", "") + " TEST PASSED"
                 );
                 }
             }
         }
-
     }
 
+    @Test
+    public void testOverloadsNoEnableAnnotations() {
+        var e = getEngine(testCompilerOptionsNoEnableAnnotations());
+
+        assertThrows(CqlException.class, () -> e.evaluate(toElmIdentifier("CqlOverloadTests"), evalTime));
+    }
+
+    @Test
+    public void testGenericOverloadsNoEnableAnnotations() {
+        var e = getEngine(testCompilerOptionsNoEnableAnnotations());
+
+        assertThrows(CqlException.class, () -> e.evaluate(toElmIdentifier("CqlGenericOverloadTests"), evalTime));
+    }
+
+    // LUKETODO:  play around with different compile options such as removing EnableAnnotations, and adding EnableResultTypes
    protected CqlCompilerOptions testCompilerOptions() {
-        var options = CqlCompilerOptions.defaultOptions();
+       return testCompilerOptions(CqlCompilerOptions.Options.DisableListDemotion,
+               CqlCompilerOptions.Options.DisableListPromotion);
+    }
+
+    protected CqlCompilerOptions testCompilerOptionsNoEnableAnnotations() {
+        return testCompilerOptions(CqlCompilerOptions.Options.DisableListDemotion,
+                CqlCompilerOptions.Options.DisableListPromotion,
+                CqlCompilerOptions.Options.EnableAnnotations);
+    }
+
+    protected CqlCompilerOptions testCompilerOptions(CqlCompilerOptions.Options... optionsToRemove) {
+        final CqlCompilerOptions options = CqlCompilerOptions.defaultOptions();
+        final Set<CqlCompilerOptions.Options> optionsOptions = options.getOptions();
+
         // This test suite contains some definitions that use features that are usually
         // turned off for CQL.
-        options.getOptions().remove(CqlCompilerOptions.Options.DisableListDemotion);
-        options.getOptions().remove(CqlCompilerOptions.Options.DisableListPromotion);
+        Arrays.stream(optionsToRemove).forEach(optionsOptions::remove);
 
         return options;
     }
 
 
-    String toString(List<CqlCompilerException> errors) {
+    private String toString(List<CqlCompilerException> errors) {
         StringBuilder builder = new StringBuilder();
 
         for (var e : errors) {
-            builder.append(e.toString() + System.lineSeparator());
+            builder.append(e.toString()).append(System.lineSeparator());
             if (e.getLocator() != null) {
-                builder.append("at" + System.lineSeparator());
-                builder.append(e.getLocator().toLocator() + System.lineSeparator());
+                builder.append("at").append(System.lineSeparator());
+                builder.append(e.getLocator().toLocator()).append(System.lineSeparator());
             }
             builder.append(System.lineSeparator());
         }

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlGenericOverloadTests.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlGenericOverloadTests.cql
@@ -1,4 +1,4 @@
 library CqlGenericOverloadTests version '2'
 
-define function toString(value List<Code>): null
-define function toString(value List<Integer>): null
+define function toString(value List<Code>): 5
+define function toString(value List<Integer>): 5

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlGenericOverloadTests.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlGenericOverloadTests.cql
@@ -1,0 +1,4 @@
+library CqlGenericOverloadTests version '2'
+
+define function toString(value List<Code>): null
+define function toString(value List<Integer>): null

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlOverloadTests.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlOverloadTests.cql
@@ -1,0 +1,4 @@
+library CqlOverloadTests version '2'
+
+define function toString(value Code): null
+define function toString(value Integer): null

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlOverloadTests.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlOverloadTests.cql
@@ -1,4 +1,4 @@
 library CqlOverloadTests version '2'
 
-define function toString(value Code): null
-define function toString(value Integer): null
+define function toString(value Code): 5
+define function toString(value Integer): 5


### PR DESCRIPTION
- Ensure that all overloads will fail to compile if EnableAnnotations and EnableResultTypes are not part of compile options.   This includes libraries
- Fix a bunch of unit test code that did not explicitly pass these compile options and would otherwise fail
- Ensure unit tests that meant not to pass these compile options still work

Closes https://github.com/cqframework/clinical_quality_language/issues/1193