### PR TITLE
Tests to ensure generic overloads are sufficiently specified

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
@@ -1,13 +1,11 @@
 package org.cqframework.cql.cql2elm;
 
 import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
-import org.hl7.cql.model.ClassType;
 import org.hl7.elm.r1.ExpressionDef;
 import org.hl7.elm.r1.FunctionDef;
 import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.ListTypeSpecifier;
 import org.hl7.elm.r1.NamedTypeSpecifier;
-import org.hl7.elm.r1.Library.Statements;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -19,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static java.util.stream.Collectors.toList;
 
 public class GenericOverloadsTests {
@@ -27,8 +24,8 @@ public class GenericOverloadsTests {
     private static final String CQL_TEST_FILE = "SignatureTests/GenericOverloadsTests.cql";
     private Map<String, ExpressionDef> defs;
 
-    private Library getLibrary(boolean enableResultTypes) throws IOException {
-        final CqlTranslator translator = getTranslator(enableResultTypes);
+    private Library getLibrary(boolean enableResultTypes, SignatureLevel level) throws IOException {
+        final CqlTranslator translator = getTranslator(enableResultTypes, level);
         assertThat(translator.getErrors().size(), is(0));
         defs = new HashMap<>();
         Library library = translator.toELM();
@@ -41,10 +38,10 @@ public class GenericOverloadsTests {
     }
 
 
-    private static CqlTranslator getTranslator(boolean enableResultTypes) throws IOException {
+    private static CqlTranslator getTranslator(boolean enableResultTypes, SignatureLevel level) throws IOException {
         var options = new CqlCompilerOptions();
         options.getOptions().clear();
-        options.setSignatureLevel(SignatureLevel.Overloads);
+        options.setSignatureLevel(level);
         if (enableResultTypes) {
             options.getOptions().add(CqlCompilerOptions.Options.EnableResultTypes);
         }
@@ -83,7 +80,7 @@ public class GenericOverloadsTests {
 
     @Test
     public void TestResultTypes() throws IOException {
-        Library library = getLibrary(true);
+        Library library = getLibrary(true, SignatureLevel.Overloads);
 
         var stringifies = stringifies(library);
         stringifies.forEach(this::validateResultTypes);
@@ -91,7 +88,23 @@ public class GenericOverloadsTests {
 
     @Test
     public void TestNoResultTypes() throws IOException {
-        Library library = getLibrary(false);
+        Library library = getLibrary(false, SignatureLevel.Overloads);
+
+        var stringifies = stringifies(library);
+        stringifies.forEach(this::validateResultTypes);
+    }
+
+    @Test
+    public void TestResultTypesSignatureNone() throws IOException {
+        Library library = getLibrary(true, SignatureLevel.None);
+
+        var stringifies = stringifies(library);
+        stringifies.forEach(this::validateResultTypes);
+    }
+
+    @Test
+    public void TestNoResultTypesSignatureNone() throws IOException {
+        Library library = getLibrary(false, SignatureLevel.None);
 
         var stringifies = stringifies(library);
         stringifies.forEach(this::validateResultTypes);

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
@@ -1,0 +1,99 @@
+package org.cqframework.cql.cql2elm;
+
+import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
+import org.hl7.cql.model.ClassType;
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.FunctionDef;
+import org.hl7.elm.r1.Library;
+import org.hl7.elm.r1.ListTypeSpecifier;
+import org.hl7.elm.r1.NamedTypeSpecifier;
+import org.hl7.elm.r1.Library.Statements;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static java.util.stream.Collectors.toList;
+
+public class GenericOverloadsTests {
+
+    private static final String CQL_TEST_FILE = "SignatureTests/GenericOverloadsTests.cql";
+    private Map<String, ExpressionDef> defs;
+
+    private Library getLibrary(boolean enableResultTypes) throws IOException {
+        final CqlTranslator translator = getTranslator(enableResultTypes);
+        assertThat(translator.getErrors().size(), is(0));
+        defs = new HashMap<>();
+        Library library = translator.toELM();
+        if (library.getStatements() != null) {
+            for (ExpressionDef def : library.getStatements().getDef()) {
+                defs.put(def.getName(), def);
+            }
+        }
+        return library;
+    }
+
+
+    private static CqlTranslator getTranslator(boolean enableResultTypes) throws IOException {
+        var options = new CqlCompilerOptions();
+        options.getOptions().clear();
+        options.setSignatureLevel(SignatureLevel.Overloads);
+        if (enableResultTypes) {
+            options.getOptions().add(CqlCompilerOptions.Options.EnableResultTypes);
+        }
+
+        return TestUtils.createTranslator(CQL_TEST_FILE, options);
+    }
+
+    private List<FunctionDef> stringifies(Library library) {
+        return library.getStatements().getDef()
+            .stream()
+            .filter(x -> "Stringify".equals(x.getName()))
+            .filter(FunctionDef.class::isInstance)
+            .map(FunctionDef.class::cast)
+            .collect(toList());
+    }
+
+    private void validateResultTypes(FunctionDef functionDef) {
+        assertEquals(2, functionDef.getOperand().size());
+
+        var operand = functionDef.getOperand().get(0);
+        assertThat(operand.getOperandTypeSpecifier(), instanceOf(ListTypeSpecifier.class));
+        var listSpecifier = (ListTypeSpecifier)operand.getOperandTypeSpecifier();
+        assertThat(listSpecifier.getElementType(), instanceOf(NamedTypeSpecifier.class));
+        var namedSpecifier = (NamedTypeSpecifier)listSpecifier.getElementType();
+        assertNotNull(namedSpecifier.getName());
+        assertNotNull(namedSpecifier.getResultType());
+
+        var second = functionDef.getOperand().get(1);
+        assertThat(second.getOperandTypeSpecifier(), instanceOf(ListTypeSpecifier.class));
+        listSpecifier = (ListTypeSpecifier)operand.getOperandTypeSpecifier();
+        assertThat(listSpecifier.getElementType(), instanceOf(NamedTypeSpecifier.class));
+        namedSpecifier = (NamedTypeSpecifier)listSpecifier.getElementType();
+        assertNotNull(namedSpecifier.getName());
+        assertNotNull(namedSpecifier.getResultType());
+    }
+
+    @Test
+    public void TestResultTypes() throws IOException {
+        Library library = getLibrary(true);
+
+        var stringifies = stringifies(library);
+        stringifies.forEach(this::validateResultTypes);
+    }
+
+    @Test
+    public void TestNoResultTypes() throws IOException {
+        Library library = getLibrary(false);
+
+        var stringifies = stringifies(library);
+        stringifies.forEach(this::validateResultTypes);
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestUtils.java
@@ -193,6 +193,10 @@ public class TestUtils {
         return createTranslator(null, testFileName, new CqlCompilerOptions(options));
     }
 
+    public static CqlTranslator createTranslator(String testFileName, CqlCompilerOptions options) throws IOException {
+        return createTranslator(null, testFileName, options);
+    }
+
     public static CqlTranslator getTranslator(String cqlTestFile, String nullableLibrarySourceProvider, LibraryBuilder.SignatureLevel signatureLevel) throws IOException {
         final File testFile = getFileOrThrow(cqlTestFile);
         final ModelManager modelManager = new ModelManager();

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/SignatureTests/GenericOverloadsTests.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/SignatureTests/GenericOverloadsTests.cql
@@ -1,0 +1,23 @@
+library GenericOverloadsTests
+
+using FHIR version '4.0.1'
+
+define "Encounter":
+   Encounter {
+      id: FHIR.id {value: '123'}
+   }
+
+define function Stringify(value List<FHIR.Encounter>, value2 List<FHIR.DomainResource>):
+   'Encounter / Domain'
+
+define function Stringify(value List<FHIR.DomainResource>, value2 List<FHIR.Encounter>):
+   'Domain / Encounter'
+
+define function Stringify(value List<FHIR.Encounter>, value2 List<FHIR.Encounter>):
+   'Encounter / Encounter'
+
+define function Stringify(value List<FHIR.DomainResource>, value2 List<FHIR.DomainResource>):
+   'Domain / Domain'
+
+define "Test":
+   Stringify({"Encounter"}, {("Encounter" as FHIR.DomainResource)})


### PR DESCRIPTION
* Adds tests to ensure that the compiler emits multiple levels of type specifiers when there are generic overloads.