### PR TITLE
#648: added tests for validating type inference through conditional

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -6,9 +6,7 @@ import org.hl7.cql.model.NamedType;
 import org.hl7.elm.r1.*;
 import org.testng.annotations.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,7 +15,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.testng.Assert.assertThrows;
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/Issue648.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/Issue648.cql
@@ -1,0 +1,19 @@
+library Issue648
+
+/*
+https://github.com/cqframework/clinical_quality_language/issues/648
+Type inference through conditionals (case-when, if-else, etc)
+ */
+
+define "Cases": 
+  case
+    when true then 'true'
+    when false then false
+    when true then 5
+    else null
+  end
+
+define "If":
+    if true then 'true'
+    else if false then false
+    else null


### PR DESCRIPTION
Added the separate test cases for case and if type conditionals. The returned result types are verified as ChoiceType for following snippets.

``` 
define "Cases": 
  case
    when true then 'true'
    when false then false
    else null
  end
```

```
  define "If":
    if true then 'true'
    else if false then false
    else null
```

Github issue: https://github.com/cqframework/clinical_quality_language/issues/648