### PR TITLE
Issue 1225 - USCore 3.1.1 CQL Execution for "Patient.address.line"

### DIFF
--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/Issue1225.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/Issue1225.cql
@@ -1,0 +1,13 @@
+library Issue1225
+
+using USCore version '3.1.1'
+
+include FHIRHelpers version '4.0.1'
+
+context Patient
+
+define "Address":
+  Patient.address.line
+
+define "Address Line 1":
+  Patient.address.line[0]


### PR DESCRIPTION
The fix https://github.com/cqframework/clinical_quality_language/pull/1247 was applied. Tested the fix for Issue https://github.com/cqframework/clinical_quality_language/issues/1225

Patient:

```
{
  "resourceType": "Patient",
  "id": "USCorePatient-2",
  "meta": {
    "profile": [
      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
    ]
  },
  "identifier": [
    {
      "use": "usual",
      "type": {
        "coding": [
          {
            "code": "MR",
            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
            "display": "Medical Record Number"
          }
        ]
      },
      "system": "urn:oid:1.2.36.146.595.217.0.1",
      "value": "12345",
      "period": {
        "start": "2001-05-06"
      },
      "assigner": {
        "display": "Acme Healthcare"
      }
    }
  ],
  "active": true,
  "name": [
    {
      "use": "official",
      "family": "Chalmers",
      "given": [
        "James"
      ]
    }
  ],
  "gender": "male",
  "birthDate": "1974-12-25",
  "deceasedBoolean": false,
  "maritalStatus": {
    "coding": [
      {
        "code": "M",
        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"
      }
    ]
  },
  "address": [
    {
      "use": "home",
      "type": "both",
      "text": "534 Erewhon St PeasantVille, Utah 84414",
      "line": [
        "534 Erewhon St"
      ],
      "city": "PleasantVille",
      "district": "Rainbow",
      "state": "UT",
      "postalCode": "84414",
      "period": {
        "start": "1974-12-25"
      }
    }
  ]
}
```