### PR TITLE
Implement identifier hiding detection for String literals

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -135,7 +135,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
 
         // The model was already calculated by CqlPreprocessorVisitor
         final UsingDef usingDef = libraryBuilder.resolveUsingRef(localIdentifier);
-        libraryBuilder.pushIdentifierForHiding(localIdentifier, false, usingDef);
+        libraryBuilder.pushIdentifierForHiding(localIdentifier, usingDef);
         return usingDef;
     }
 
@@ -198,7 +198,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
         }
 
         libraryBuilder.addInclude(library);
-        libraryBuilder.pushIdentifierForHiding(library.getLocalIdentifier(), false, library);
+        libraryBuilder.pushIdentifierForHiding(library.getLocalIdentifier(), library);
 
         return library;
     }
@@ -235,7 +235,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
         }
 
         libraryBuilder.addParameter(param);
-        libraryBuilder.pushIdentifierForHiding(param.getName(), false, param);
+        libraryBuilder.pushIdentifierForHiding(param.getName(), param);
 
         return param;
     }
@@ -278,7 +278,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
         }
 
         libraryBuilder.addCodeSystem(cs);
-        libraryBuilder.pushIdentifierForHiding(cs.getName(), false, cs);
+        libraryBuilder.pushIdentifierForHiding(cs.getName(), cs);
         return cs;
     }
 
@@ -350,7 +350,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
             vs.setResultType(new ListType(libraryBuilder.resolveTypeName("System", "Code")));
         }
         libraryBuilder.addValueSet(vs);
-        libraryBuilder.pushIdentifierForHiding(vs.getName(), false, vs);
+        libraryBuilder.pushIdentifierForHiding(vs.getName(), vs);
 
         return vs;
     }
@@ -372,7 +372,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
 
         cd.setResultType(libraryBuilder.resolveTypeName("Code"));
         libraryBuilder.addCode(cd);
-        libraryBuilder.pushIdentifierForHiding(cd.getName(), false, cd);
+        libraryBuilder.pushIdentifierForHiding(cd.getName(), cd);
 
         return cd;
     }
@@ -526,7 +526,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
         final ExpressionDef hollowExpressionDef = of.createExpressionDef()
                 .withName(identifier)
                 .withContext(getCurrentContext());
-        libraryBuilder.pushIdentifierForHiding(identifier, false, hollowExpressionDef);
+        libraryBuilder.pushIdentifierForHiding(identifier, hollowExpressionDef);
         if (def == null || isImplicitContextExpressionDef(def)) {
             if (def != null && isImplicitContextExpressionDef(def)) {
                 libraryBuilder.removeExpression(def);
@@ -575,7 +575,9 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
 
     @Override
     public Literal visitStringLiteral(cqlParser.StringLiteralContext ctx) {
-        return libraryBuilder.createLiteral(parseString(ctx.STRING()));
+        final Literal stringLiteral = libraryBuilder.createLiteral(parseString(ctx.STRING()));
+        libraryBuilder.pushIdentifierForHiding(stringLiteral.getValue(), stringLiteral);
+        return stringLiteral;
     }
 
     @Override
@@ -3076,7 +3078,7 @@ DATETIME
             queryContext.addPrimaryQuerySources(sources);
 
             for (AliasedQuerySource source : sources) {
-                libraryBuilder.pushIdentifierForHiding(source.getAlias(), false, source);
+                libraryBuilder.pushIdentifierForHiding(source.getAlias(), source);
             }
 
             // If we are evaluating a population-level query whose source ranges over any patient-context expressions,
@@ -3095,7 +3097,7 @@ DATETIME
 
                 if (dfcx != null) {
                     for (LetClause letClause : dfcx) {
-                        libraryBuilder.pushIdentifierForHiding(letClause.getIdentifier(), false, letClause);
+                        libraryBuilder.pushIdentifierForHiding(letClause.getIdentifier(), letClause);
                     }
                 }
 
@@ -4051,10 +4053,10 @@ DATETIME
         if (op == null) {
             throw new IllegalArgumentException(String.format("Internal error: Could not resolve operator map entry for function header %s", fh.getMangledName()));
         }
-        libraryBuilder.pushIdentifierForHiding(fun.getName(), true, fun);
+        libraryBuilder.pushIdentifierForHiding(fun.getName(), fun);
         final List<OperandDef> operand = op.getFunctionDef().getOperand();
         for (OperandDef operandDef : operand) {
-            libraryBuilder.pushIdentifierForHiding(operandDef.getName(), false, operandDef);
+            libraryBuilder.pushIdentifierForHiding(operandDef.getName(), operandDef);
         }
 
         if (ctx.functionBody() != null) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/HidingIdentifierContext.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/HidingIdentifierContext.java
@@ -1,0 +1,52 @@
+package org.cqframework.cql.cql2elm;
+
+import org.cqframework.cql.elm.tracking.Trackable;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Simple POJO using for identifier hider that maintains the identifier and Trackable type of the construct being evaluated.
+ */
+public class HidingIdentifierContext {
+    private final String identifier;
+    private final Class<? extends Trackable> elementSubclass;
+
+    public HidingIdentifierContext(String theIdentifier, Class<? extends Trackable> theElementSubclass) {
+        identifier = theIdentifier;
+        elementSubclass = theElementSubclass;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public Class<? extends Trackable> getTrackableSubclass() {
+        return elementSubclass;
+    }
+
+    @Override
+    public boolean equals(Object theO) {
+        if (this == theO) {
+            return true;
+        }
+        if (theO == null || getClass() != theO.getClass()) {
+            return false;
+        }
+        HidingIdentifierContext that = (HidingIdentifierContext) theO;
+        return Objects.equals(identifier, that.identifier) && Objects.equals(elementSubclass, that.elementSubclass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, elementSubclass);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", HidingIdentifierContext.class.getSimpleName() + "[", "]")
+                .add("identifier='" + identifier + "'")
+                .add("elementSubclass=" + elementSubclass)
+                .toString();
+    }
+}

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r401/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r401/BaseTest.java
@@ -14,7 +14,9 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.cqframework.cql.cql2elm.TestUtils.visitFile;
 import static org.cqframework.cql.cql2elm.TestUtils.visitFileLibrary;
@@ -836,26 +838,46 @@ public class BaseTest {
     @Test
     public void testOverload() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("fhir/r401/TestOverload.cql", 0);
-        assertThat(translator.getWarnings().size(), greaterThan(0));
-        assertThat(translator.getWarnings().get(0).getMessage(), startsWith("The function TestOverload.Stringify has multiple"));
+        assertThat(translator.getWarnings().size(), is(2));
+
+        final List<String> warningMessages = translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList());
+        assertThat(warningMessages.toString(), translator.getWarnings().size(), is(2));
+
+        final String first = "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? \n";
+        final String second = "The function TestOverload.Stringify has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.";
+
+        assertThat(warningMessages.toString(), warningMessages, containsInAnyOrder(first, second));
     }
 
     @Test
     public void testOverloadOutput() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("fhir/r401/TestOverload.cql", 0, LibraryBuilder.SignatureLevel.Overloads);
-        assertThat(translator.getWarnings().size(), is(0));
+        assertThat(translator.getWarnings().size(), is(1));
+
+        final List<String> warningMessages = translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList());
+        assertThat(warningMessages.toString(), warningMessages, contains("You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? \n"));
     }
 
     @Test
     public void testOverloadForward() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("fhir/r401/TestOverloadForward.cql", 0);
-        assertThat(translator.getWarnings().size(), greaterThan(0));
-        assertThat(translator.getWarnings().get(0).getMessage(), startsWith("The function TestOverloadForward.Stringify has multiple"));
+        assertThat(translator.getWarnings().size(), is(2));
+
+        final List<String> warningMessages = translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList());
+        assertThat(warningMessages.toString(), translator.getWarnings().size(), is(2));
+
+        final String first = "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? \n";
+        final String second = "The function TestOverloadForward.Stringify has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.";
+
+        assertThat(warningMessages.toString(), warningMessages, containsInAnyOrder(first, second));
     }
 
     @Test
     public void testOverloadForwardOutput() throws IOException {
         CqlTranslator translator = TestUtils.runSemanticTest("fhir/r401/TestOverloadForward.cql", 0, LibraryBuilder.SignatureLevel.Overloads);
-        assertThat(translator.getWarnings().size(), is(0));
+        assertThat(translator.getWarnings().size(), is(1));
+
+        final List<String> warningMessages = translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList());
+        assertThat(warningMessages.toString(), warningMessages, contains("You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? \n"));
     }
 }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/HidingTests/TestHidingStringLiteral.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/HidingTests/TestHidingStringLiteral.cql
@@ -1,0 +1,10 @@
+library TestHidingStringLiteral
+
+define "IWantToBeHidden": 1
+define "IWantToHide": 'IWantToBeHidden'
+
+define function iWantToHide(value String) :
+    'IWantToHide'
+
+define function iWantToHide(value Integer) :
+    'IWantToHide'


### PR DESCRIPTION
- Support hiding detection for String literal identifiers
- Do not push string literals to the identifier hiding deque
- Minor refactoring of the identifier hiding solution

Closes https://github.com/cqframework/clinical_quality_language/issues/607