### PR TITLE
ELMFunctionalVisitor

### DIFF
--- a/Src/java/elm/src/main/java/org/cqframework/cql/elm/visiting/ElmFunctionalVisitor.java
+++ b/Src/java/elm/src/main/java/org/cqframework/cql/elm/visiting/ElmFunctionalVisitor.java
@@ -1,0 +1,37 @@
+package org.cqframework.cql.elm.visiting;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import org.cqframework.cql.elm.tracking.Trackable;
+
+/**
+ * The is a base class for visitors that apply functions to all the visited ELM elements.
+ * Useful for quick visitor implementations, such as counting all nodes, or finding a specific element
+ * type.
+ */
+public class ElmFunctionalVisitor<T, C> extends ElmBaseLibraryVisitor<T, C> {
+
+    private final BiFunction<Trackable, C, T> defaultResult;
+    private final BiFunction<T, T, T> aggregateResult;
+
+    /**
+     * Constructor that takes a default visit function and an aggregate result function.
+     * @param defaultResult the function for processing a visited element
+     * @param aggregateResult the function for aggregating results
+     */
+    public ElmFunctionalVisitor(BiFunction<Trackable, C, T> defaultResult, BiFunction<T, T, T> aggregateResult) {
+        this.defaultResult = Objects.requireNonNull(defaultResult);
+        this.aggregateResult = Objects.requireNonNull(aggregateResult);
+    }
+
+    @Override
+    public T defaultResult(Trackable elm, C context) {
+        return this.defaultResult.apply(elm, context);
+    }
+
+    @Override
+    public T aggregateResult(T aggregate, T nextResult) {
+        return this.aggregateResult.apply(aggregate, nextResult);
+    }
+}

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/ElmFunctionalVisitorTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/ElmFunctionalVisitorTest.java
@@ -1,0 +1,56 @@
+package org.cqframework.cql.elm.visiting;
+
+import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import org.hl7.elm.r1.Element;
+import org.hl7.elm.r1.ExpressionDef;
+import org.hl7.elm.r1.Library;
+import org.hl7.elm.r1.Library.Statements;
+import org.junit.Test;
+
+public class ElmFunctionalVisitorTest {
+
+    @Test
+    public void countTest() {
+        // set up visitor that counts all visited elements
+        var trackableCounter = new ElmFunctionalVisitor<Integer, Void>(
+            (elm, context) -> 1,
+            Integer::sum
+        );
+
+        var library = new Library();
+        library.setStatements(new Statements());
+        library.getStatements().getDef().add(new ExpressionDef());
+        library.getStatements().getDef().add(new ExpressionDef());
+        library.getStatements().getDef().add(new ExpressionDef());
+
+        var result = trackableCounter.visitLibrary(library, null);
+        assertEquals(4 + 3, result.intValue());  // ELM elements + implicit access modifiers
+
+
+        // set up visitor that counts all visited ELM elements
+        var elmCounter = new ElmFunctionalVisitor<Integer, Void>(
+            (elm, context) -> elm instanceof Element ? 1 : 0,
+            Integer::sum
+        );
+
+        result = elmCounter.visitLibrary(library, null);
+        assertEquals(4, result.intValue());
+
+        var maxFiveCounter = new ElmFunctionalVisitor<Integer, Void>(
+            (elm, context) -> 1,
+            (aggregate, nextResult) -> aggregate >= 5 ? aggregate : aggregate + nextResult
+        );
+
+        result = maxFiveCounter.visitLibrary(library, null);
+        assertEquals(5, result.intValue());
+    }
+
+    @Test
+    public void nullVisitorTest() {
+        assertThrows(NullPointerException.class, () -> new ElmFunctionalVisitor<Integer, Void>(null, null));
+        assertThrows(NullPointerException.class, () -> new ElmFunctionalVisitor<Integer, Void>(null, Integer::sum));
+        assertThrows(NullPointerException.class, () -> new ElmFunctionalVisitor<Integer, Void>((x, y) -> 1, null));
+    }
+}


### PR DESCRIPTION
* Adds a new `ElmFunctionalVisitor` class and tests for same.
* This class is intended to be used in cases where a simple function definition can determine the visitor behavior. Potential use cases include
  * Unit tests
  * Simple ELM edits
  * Implementing compiler warnings