### PR TITLE
Bug half time zone

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -976,7 +976,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
                         }
 
                         result.setTimezoneOffset(libraryBuilder.createLiteral(
-                                (double) (hourOffset + (minuteOffset / 60)) * offsetPolarity));
+                                (double) (hourOffset + ((double) minuteOffset / 60)) * offsetPolarity));
                     } else {
                         if (matcher.group(26) != null) {
                             int hourOffset = Integer.parseInt(matcher.group(26));

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LiteralTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LiteralTests.java
@@ -67,6 +67,11 @@ public class LiteralTests {
 
         def = defs.get("UTCDateLiteral");
         assertThat(def, hasTypeAndResult(DateTime.class, "System.DateTime"));
+
+        def = defs.get("TimeZoneHalfHourLiteral");
+        assertThat(def, hasTypeAndResult(DateTime.class, "System.DateTime"));
+        dateTime = (DateTime) def.getExpression();
+        assertThat(dateTime.getTimezoneOffset(), literalFor(1.5));
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/DateTimeLiteralTest.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/DateTimeLiteralTest.cql
@@ -28,6 +28,9 @@ define UTCDateTimeLiteral: @2014-02-12T10:30:15.0000Z
 define TimeZoneDateTimeLiteral: @2014-02-12T10:30:15.0000-07:00
 define TimeZonePositiveDateTimeLiteral: @2014-02-12T10:30:15.0000+07:00
 
+// Test for https://github.com/cqframework/clinical_quality_language/issues/1298
+define TimeZoneHalfHourLiteral: @2014-01-01T12:05:05.955+01:30
+
 define YearExpression: 1 year
 define YearsExpression: 10 years
 define MonthExpression: 1 month

--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
@@ -142,8 +142,6 @@ public class CQLOperationsR4Test extends TestFhirPath implements ITest {
             "cql/CqlTypeOperatorsTest/As/CastAsQuantity",
             "cql/CqlTypeOperatorsTest/Convert/StringToDateTimeMalformed",
             "cql/CqlTypeOperatorsTest/Convert/StringToIntegerError",
-            "cql/CqlTypeOperatorsTest/ToDateTime/ToDateTime4",
-            "cql/CqlTypeOperatorsTest/ToDateTime/ToDateTime5",
             "cql/CqlTypeOperatorsTest/ToDateTime/ToDateTimeMalformed",
             "cql/CqlTypeOperatorsTest/ToTime/ToTime2",
             "cql/CqlTypeOperatorsTest/ToTime/ToTime3",


### PR DESCRIPTION
* Fix integer division incorrectly creating truncating fractional timezone literals
* Renable FhirPath tests
* Resolves #1298 