### PR TITLE
Get FHIR core transitively, update jackson

### DIFF
--- a/Src/java/buildSrc/src/main/groovy/cql.fhir-conventions.gradle
+++ b/Src/java/buildSrc/src/main/groovy/cql.fhir-conventions.gradle
@@ -12,10 +12,6 @@ dependencies {
         exclude group: 'xpp3'
     }
 
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r5"
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.convertors"
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.utilities"
-
     implementation "ca.uhn.hapi.fhir:hapi-fhir-base"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-converter"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-hl7org-dstu2"

--- a/Src/java/buildSrc/src/main/groovy/cql.fhir-conventions.gradle
+++ b/Src/java/buildSrc/src/main/groovy/cql.fhir-conventions.gradle
@@ -4,7 +4,6 @@ plugins {
 
 ext {
     hapiVersion = project['hapi.version']
-    coreVersion = project['fhir-core.version']
 }
 
 dependencies {
@@ -13,9 +12,9 @@ dependencies {
         exclude group: 'xpp3'
     }
 
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r5:${coreVersion}"
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.convertors:${coreVersion}"
-    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.utilities:${coreVersion}"
+    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r5"
+    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.convertors"
+    implementation "ca.uhn.hapi.fhir:org.hl7.fhir.utilities"
 
     implementation "ca.uhn.hapi.fhir:hapi-fhir-base"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-converter"

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'cql.xjc-conventions'
 }
 
+ext {
+    jacksonVersion = project['jackson.version']
+}
+
 dependencies {
     api project(':cql')
     api project(':model')
@@ -14,7 +18,7 @@ dependencies {
     // in the cql-to-elm project. Ideally, we'd factor out all serialization depedencies into common
     // libraries such that we could swap out jackson for something else. In the meantime, these are
     // "implementation" dependencies so that they are not exported downstream.
-    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.15.2'
+    implementation "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:${jacksonVersion}"
     testImplementation project(':elm-jackson')
     testImplementation project(':model-jackson')
     testImplementation project(':quick')

--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -2,12 +2,13 @@ plugins {
     id 'cql.library-conventions'
 }
 
+ext {
+    jacksonVersion = properties['jackson.version']
+}
+
 dependencies {
     api project(':model')
     api project(':elm')
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1'
-    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1'
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
+    api "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:${jacksonVersion}"
 }

--- a/Src/java/elm-jackson/build.gradle
+++ b/Src/java/elm-jackson/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     api project(':model')
     api project(':elm')
     implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1'
+    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1'
 }

--- a/Src/java/elm-jaxb/build.gradle
+++ b/Src/java/elm-jaxb/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 dependencies {
     api project(':elm')
-    implementation 'org.apache.commons:commons-text:1.10.0'
 }

--- a/Src/java/gradle.properties
+++ b/Src/java/gradle.properties
@@ -5,6 +5,5 @@ group=info.cqframework
 version=3.8.0-SNAPSHOT
 specification.version=1.5.2
 hapi.version=7.0.0
-fhir-core.version=6.1.2.2
 antlr.version=4.13.1
 android.api.level=28

--- a/Src/java/gradle.properties
+++ b/Src/java/gradle.properties
@@ -5,5 +5,6 @@ group=info.cqframework
 version=3.8.0-SNAPSHOT
 specification.version=1.5.2
 hapi.version=7.0.0
+jackson.version=2.16.1
 antlr.version=4.13.1
 android.api.level=28

--- a/Src/java/model-jackson/build.gradle
+++ b/Src/java/model-jackson/build.gradle
@@ -4,8 +4,10 @@ plugins {
 
 dependencies {
     api project(':model')
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1'
+    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1'
 
     testImplementation project(":quick")
     testImplementation project(":qdm")

--- a/Src/java/model-jackson/build.gradle
+++ b/Src/java/model-jackson/build.gradle
@@ -2,12 +2,14 @@ plugins {
     id 'cql.library-conventions'
 }
 
+ext {
+    jacksonVersion = project['jackson.version']
+}
+
 dependencies {
     api project(':model')
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1'
-    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1'
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
+    api "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:${jacksonVersion}"
 
     testImplementation project(":quick")
     testImplementation project(":qdm")


### PR DESCRIPTION
* Remove explicit FHIR core version since the HAPI bom now includes it
* Align Jackson with the HAPI version
* Change Jackson deps from "implementation" to "api" so they are exported downstream