### PR TITLE
Remove newlines from hiding messages

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -3241,12 +3241,12 @@ public class LibraryBuilder {
 
         if (trackable instanceof Literal) {
             return String.format(
-                    "You used a string literal: [%s] here that matches an identifier in scope: [%s]. Did you mean to use the identifier instead? %n",
+                    "You used a string literal: [%s] here that matches an identifier in scope: [%s]. Did you mean to use the identifier instead?",
                     identifierParam, matchedIdentifier);
         }
 
         return String.format(
-                "%s identifier [%s] is hiding another identifier of the same name. %n", elementString, identifierParam);
+                "%s identifier [%s] is hiding another identifier of the same name.", elementString, identifierParam);
     }
 
     private class Scope {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/HidingTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/HidingTests.java
@@ -30,7 +30,7 @@ public class HidingTests {
                 warnings.stream().map(Throwable::getMessage).collect(Collectors.toSet());
         assertThat(
                 warningMessages,
-                contains(String.format("A let identifier [var] is hiding another identifier of the same name. %n")));
+                contains(String.format("A let identifier [var] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -50,9 +50,9 @@ public class HidingTests {
         assertThat(distinct.size(), is(2));
 
         final String first = String.format(
-                "You used a string literal: [X] here that matches an identifier in scope: [X]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [X] here that matches an identifier in scope: [X]. Did you mean to use the identifier instead?");
         final String second = String.format(
-                "You used a string literal: [Y] here that matches an identifier in scope: [Y]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [Y] here that matches an identifier in scope: [Y]. Did you mean to use the identifier instead?");
 
         assertThat(distinct.toString(), distinct, containsInAnyOrder(first, second));
     }
@@ -75,11 +75,11 @@ public class HidingTests {
         assertThat(distinct.size(), is(3));
 
         final String first = String.format(
-                "You used a string literal: [X] here that matches an identifier in scope: [X]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [X] here that matches an identifier in scope: [X]. Did you mean to use the identifier instead?");
         final String second = String.format(
-                "You used a string literal: [Y] here that matches an identifier in scope: [Y]. Did you mean to use the identifier instead? %n");
-        final String third = String.format(
-                "An alias identifier [IWantToBeHidden] is hiding another identifier of the same name. %n");
+                "You used a string literal: [Y] here that matches an identifier in scope: [Y]. Did you mean to use the identifier instead?");
+        final String third =
+                String.format("An alias identifier [IWantToBeHidden] is hiding another identifier of the same name.");
 
         assertThat(distinct.toString(), distinct, containsInAnyOrder(first, second, third));
     }
@@ -103,7 +103,7 @@ public class HidingTests {
         assertThat(
                 warnings.stream().map(Throwable::getMessage).collect(Collectors.toList()),
                 containsInAnyOrder(String.format(
-                        "An alias identifier [SoMuchNesting] is hiding another identifier of the same name. %n")));
+                        "An alias identifier [SoMuchNesting] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -124,9 +124,9 @@ public class HidingTests {
         assertThat(distinct.size(), is(2));
 
         final String first =
-                String.format("An alias identifier [SoMuchNesting] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [SoMuchNesting] is hiding another identifier of the same name.");
         final String second =
-                String.format("A let identifier [SoMuchNesting] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [SoMuchNesting] is hiding another identifier of the same name.");
 
         assertThat(distinct, containsInAnyOrder(first, second));
     }
@@ -142,7 +142,7 @@ public class HidingTests {
         assertThat(
                 warnings.stream().map(Throwable::getMessage).collect(Collectors.toList()),
                 containsInAnyOrder(
-                        String.format("A let identifier [Alias] is hiding another identifier of the same name. %n")));
+                        String.format("A let identifier [Alias] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class HidingTests {
         assertThat(
                 translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList()),
                 contains(String.format(
-                        "An alias identifier [testOperand] is hiding another identifier of the same name. %n")));
+                        "An alias identifier [testOperand] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class HidingTests {
         assertThat(
                 warningMessages,
                 contains(String.format(
-                        "An alias identifier [IWantToBeHidden] is hiding another identifier of the same name. %n")));
+                        "An alias identifier [IWantToBeHidden] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class HidingTests {
         assertThat(
                 warningMessages,
                 contains(String.format(
-                        "An alias identifier [Measurement Period] is hiding another identifier of the same name. %n")));
+                        "An alias identifier [Measurement Period] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -203,7 +203,7 @@ public class HidingTests {
         assertThat(
                 warningMessages,
                 contains(String.format(
-                        "An alias identifier [FHIRHelpers] is hiding another identifier of the same name. %n")));
+                        "An alias identifier [FHIRHelpers] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -219,7 +219,7 @@ public class HidingTests {
         assertThat(distinctWarningMessages.toString(), distinctWarningMessages.size(), is(1));
         assertThat(
                 distinctWarningMessages,
-                contains(String.format("An alias identifier [5] is hiding another identifier of the same name. %n")));
+                contains(String.format("An alias identifier [5] is hiding another identifier of the same name.")));
     }
 
     @Test
@@ -235,9 +235,9 @@ public class HidingTests {
         assertThat(distinctWarningMessages.toString(), distinctWarningMessages.size(), is(2));
 
         final String stringLiteralIWantToBeHidden = String.format(
-                "You used a string literal: [IWantToBeHidden] here that matches an identifier in scope: [IWantToBeHidden]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [IWantToBeHidden] here that matches an identifier in scope: [IWantToBeHidden]. Did you mean to use the identifier instead?");
         final String stringLiteralIWantToHide = String.format(
-                "You used a string literal: [IWantToHide] here that matches an identifier in scope: [IWantToHide]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [IWantToHide] here that matches an identifier in scope: [IWantToHide]. Did you mean to use the identifier instead?");
         assertThat(distinctWarningMessages, containsInAnyOrder(stringLiteralIWantToBeHidden, stringLiteralIWantToHide));
     }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -353,27 +353,27 @@ public class TranslationTests {
         assertThat(warningMessages.toString(), distinct.size(), is(11));
 
         final String hidingDefinition =
-                String.format("An alias identifier [Definition] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [Definition] is hiding another identifier of the same name.");
         final String hidingVarLet =
-                String.format("A let identifier [var] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [var] is hiding another identifier of the same name.");
         final String hidingContextValueSet =
-                String.format("An alias identifier [ValueSet] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [ValueSet] is hiding another identifier of the same name.");
         final String hidingLetValueSet =
-                String.format("A let identifier [ValueSet] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [ValueSet] is hiding another identifier of the same name.");
         final String hidingContextCode =
-                String.format("An alias identifier [Code] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [Code] is hiding another identifier of the same name.");
         final String hidingLetCode =
-                String.format("A let identifier [Code] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [Code] is hiding another identifier of the same name.");
         final String hidingContextCodeSystem =
-                String.format("An alias identifier [CodeSystem] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [CodeSystem] is hiding another identifier of the same name.");
         final String hidingLetCodeSystem =
-                String.format("A let identifier [CodeSystem] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [CodeSystem] is hiding another identifier of the same name.");
         final String hidingContextFhir =
-                String.format("An alias identifier [FHIR] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [FHIR] is hiding another identifier of the same name.");
         final String hidingLetFhir =
-                String.format("A let identifier [FHIR] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [FHIR] is hiding another identifier of the same name.");
         final String hidingAliasLet =
-                String.format("A let identifier [Alias] is hiding another identifier of the same name. %n");
+                String.format("A let identifier [Alias] is hiding another identifier of the same name.");
 
         assertThat(
                 distinct,

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r401/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r401/BaseTest.java
@@ -852,7 +852,7 @@ public class BaseTest {
         assertThat(warningMessages.toString(), translator.getWarnings().size(), is(2));
 
         final String first = String.format(
-                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead?");
         final String second =
                 "The function TestOverload.Stringify has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.";
 
@@ -872,7 +872,7 @@ public class BaseTest {
                 warningMessages,
                 contains(
                         String.format(
-                                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? %n")));
+                                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead?")));
     }
 
     @Test
@@ -885,7 +885,7 @@ public class BaseTest {
         assertThat(warningMessages.toString(), translator.getWarnings().size(), is(2));
 
         final String first = String.format(
-                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? %n");
+                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead?");
         final String second =
                 "The function TestOverloadForward.Stringify has multiple overloads and due to the SignatureLevel setting (None), the overload signature is not being included in the output. This may result in ambiguous function resolution at runtime, consider setting the SignatureLevel to Overloads or All to ensure that the output includes sufficient information to support correct overload selection at runtime.";
 
@@ -905,6 +905,6 @@ public class BaseTest {
                 warningMessages,
                 contains(
                         String.format(
-                                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead? %n")));
+                                "You used a string literal: [Encounter] here that matches an identifier in scope: [Encounter]. Did you mean to use the identifier instead?")));
     }
 }

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
@@ -25,7 +25,7 @@ public class BaseTest {
         assertThat(translator.getWarnings().toString(), translator.getWarnings().size(), is(1));
 
         final String first =
-                String.format("An alias identifier [Diabetes] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [Diabetes] is hiding another identifier of the same name.");
 
         assertThat(
                 translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList()),

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v500/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v500/BaseTest.java
@@ -34,7 +34,7 @@ public class BaseTest {
         assertThat(translator.getWarnings().toString(), translator.getWarnings().size(), is(1));
 
         final String first =
-                String.format("An alias identifier [Diabetes] is hiding another identifier of the same name. %n");
+                String.format("An alias identifier [Diabetes] is hiding another identifier of the same name.");
 
         assertThat(
                 translator.getWarnings().stream().map(Throwable::getMessage).collect(Collectors.toList()),


### PR DESCRIPTION
* Removes newlines from error messages, allowing the error messages to be arbitrarily formatted by downstream tooling, like an IDE