### PR TITLE
Fixes for localIds and Nary function resolution

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemMethodResolver.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemMethodResolver.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.cqframework.cql.cql2elm.model.QueryContext;
+import org.cqframework.cql.elm.IdObjectFactory;
 import org.cqframework.cql.gen.cqlParser;
 import org.hl7.cql.model.*;
 import org.hl7.elm.r1.*;
@@ -14,7 +15,7 @@ import org.hl7.elm.r1.*;
  * Created by Bryn on 12/27/2016.
  */
 public class SystemMethodResolver {
-    private final ObjectFactory of;
+    private final IdObjectFactory of;
     private final Cql2ElmVisitor visitor;
     private final LibraryBuilder builder;
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TypeBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/TypeBuilder.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.cqframework.cql.cql2elm.model.Model;
+import org.cqframework.cql.elm.IdObjectFactory;
 import org.hl7.cql.model.*;
-import org.hl7.elm.r1.ObjectFactory;
 import org.hl7.elm.r1.ParameterTypeSpecifier;
 import org.hl7.elm.r1.TupleElementDefinition;
 import org.hl7.elm.r1.TypeSpecifier;
@@ -13,7 +13,7 @@ import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 public class TypeBuilder {
 
-    private ObjectFactory of;
+    private IdObjectFactory of;
     private ModelResolver mr;
 
     public static class InternalModelResolver implements ModelResolver {
@@ -28,12 +28,12 @@ public class TypeBuilder {
         }
     }
 
-    public TypeBuilder(ObjectFactory of, ModelResolver mr) {
+    public TypeBuilder(IdObjectFactory of, ModelResolver mr) {
         this.of = of;
         this.mr = mr;
     }
 
-    public TypeBuilder(ObjectFactory of, ModelManager modelManager) {
+    public TypeBuilder(IdObjectFactory of, ModelManager modelManager) {
         this(of, new InternalModelResolver(modelManager));
     }
 

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorElmCommonVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorElmCommonVisitor.java
@@ -18,6 +18,7 @@ import org.cqframework.cql.cql2elm.*;
 import org.cqframework.cql.cql2elm.model.Chunk;
 import org.cqframework.cql.cql2elm.model.FunctionHeader;
 import org.cqframework.cql.cql2elm.model.Model;
+import org.cqframework.cql.elm.IdObjectFactory;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.cqframework.cql.elm.tracking.Trackable;
 import org.cqframework.cql.gen.cqlBaseVisitor;
@@ -32,7 +33,7 @@ import org.hl7.elm.r1.*;
  * Common functionality used by {@link CqlPreprocessor} and {@link Cql2ElmVisitor}
  */
 public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
-    protected final ObjectFactory of;
+    protected final IdObjectFactory of;
     protected final org.hl7.cql_annotations.r1.ObjectFactory af = new org.hl7.cql_annotations.r1.ObjectFactory();
     private boolean implicitContextCreated = false;
     private String currentContext = "Unfiltered";
@@ -42,7 +43,6 @@ public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
     protected LibraryInfo libraryInfo = new LibraryInfo();
     private boolean annotate = false;
     private boolean detailedErrors = false;
-    private int nextLocalId = 1;
     private boolean locate = false;
     private boolean resultTypes = false;
     private boolean dateRangeOptimization = false;
@@ -92,6 +92,16 @@ public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
             // ERROR:
             try {
                 o = super.visit(tree);
+                if (o instanceof Element) {
+                    Element element = (Element) o;
+                    if (element.getLocalId() == null) {
+                        throw new CqlInternalException(
+                                String.format(
+                                        "Internal translator error. 'localId' was not assigned for Element \"%s\"",
+                                        element.getClass().getName()),
+                                getTrackBack(tree));
+                    }
+                }
             } catch (CqlIncludeException e) {
                 CqlCompilerException translatorException =
                         new CqlCompilerException(e.getMessage(), getTrackBack(tree), e);
@@ -290,8 +300,10 @@ public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
         if (o instanceof Element) {
             Element element = (Element) o;
             if (element.getLocalId() == null) {
-                element.setLocalId(Integer.toString(getNextLocalId()));
+                throw new CqlInternalException(
+                        "Internal translator error. LocalId was not assigned", getTrackBack(tree));
             }
+
             chunk.setElement(element);
 
             if (!(tree instanceof cqlParser.LibraryContext)) {
@@ -777,10 +789,6 @@ public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
             return "";
         }
         return s.substring(index);
-    }
-
-    public int getNextLocalId() {
-        return nextLocalId++;
     }
 
     private void addExpression(Expression expression) {

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorElmCommonVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessorElmCommonVisitor.java
@@ -299,11 +299,6 @@ public class CqlPreprocessorElmCommonVisitor extends cqlBaseVisitor<Object> {
         Chunk chunk = chunks.pop();
         if (o instanceof Element) {
             Element element = (Element) o;
-            if (element.getLocalId() == null) {
-                throw new CqlInternalException(
-                        "Internal translator error. LocalId was not assigned", getTrackBack(tree));
-            }
-
             chunk.setElement(element);
 
             if (!(tree instanceof cqlParser.LibraryContext)) {

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/ArchitectureTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/ArchitectureTest.java
@@ -5,8 +5,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.constructors;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.cqframework.cql.cql2elm.model.LibraryRef;
+import org.cqframework.cql.elm.IdObjectFactory;
 import org.hl7.elm.r1.Element;
-import org.hl7.elm.r1.ObjectFactory;
 import org.junit.Test;
 
 public class ArchitectureTest {
@@ -27,7 +27,7 @@ public class ArchitectureTest {
                 .should()
                 .onlyBeCalled()
                 .byClassesThat()
-                .areAssignableTo(ObjectFactory.class)
+                .areAssignableTo(IdObjectFactory.class)
                 .because("ELM classes should never be instantiated directly, "
                         + "use an ObjectFactory that ensures that "
                         + "the classes are initialized and tracked correctly.")

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestLocalId.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestLocalId.java
@@ -1,0 +1,44 @@
+package org.cqframework.cql.cql2elm;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.cqframework.cql.cql2elm.CqlCompilerOptions.Options;
+import org.cqframework.cql.elm.utility.Visitors;
+import org.cqframework.cql.elm.visiting.FunctionalElmVisitor;
+import org.hl7.elm.r1.Element;
+import org.junit.Test;
+
+// This test compiles a few example libraries and ensures
+// local ids are assigned for all elements in the resulting ELM
+public class TestLocalId {
+
+    // This visitor checks that all nodes the graph have a localId
+    static FunctionalElmVisitor<Void, String> idChecker = Visitors.from((node, libraryName) -> {
+        if (node instanceof Element) {
+            var locator = node.getTrackbacks().isEmpty()
+                    ? "<unknown>"
+                    : node.getTrackbacks().get(0).toLocator();
+            assertNotNull(
+                    String.format(
+                            "node %s in library %s is missing localId at %s",
+                            node.getClass().getName(), libraryName, locator),
+                    ((Element) node).getLocalId());
+        }
+
+        return null;
+    });
+
+    @Test
+    public void testLocalIds() throws Exception {
+        runTest("OperatorTests/CqlListOperators.cql");
+        runTest("TranslationTests.cql");
+        runTest("LibraryTests/TestMeasure.cql");
+    }
+
+    private void runTest(String cqlFileName) throws Exception {
+        var lib = TestUtils.createTranslator(cqlFileName, Options.EnableLocators, Options.EnableAnnotations)
+                .toELM();
+
+        idChecker.visitLibrary(lib, cqlFileName);
+    }
+}

--- a/Src/java/elm-jaxb/src/main/java/org/cqframework/cql/elm/serializing/jaxb/ElmXmlMapper.java
+++ b/Src/java/elm-jaxb/src/main/java/org/cqframework/cql/elm/serializing/jaxb/ElmXmlMapper.java
@@ -2,6 +2,7 @@ package org.cqframework.cql.elm.serializing.jaxb;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import org.cqframework.cql.elm.IdObjectFactory;
 
 public class ElmXmlMapper {
 
@@ -10,8 +11,8 @@ public class ElmXmlMapper {
     public static JAXBContext getJaxbContext() {
         if (jaxbContext == null) {
             try {
-                jaxbContext = JAXBContext.newInstance(
-                        org.hl7.elm.r1.ObjectFactory.class, org.hl7.cql_annotations.r1.ObjectFactory.class);
+                jaxbContext =
+                        JAXBContext.newInstance(IdObjectFactory.class, org.hl7.cql_annotations.r1.ObjectFactory.class);
             } catch (JAXBException e) {
                 throw new RuntimeException("Error creating JAXBContext - " + e.getMessage());
             }


### PR DESCRIPTION
* Added more tests to verify that compiled ELM does contain localIds.
* Fixed cases where nodes created via reflection did not have Ids assigned.
* Fixed cases where `NaryFunction`s where resolved as `BinaryFunction`s
* Added assertions to the CQL compiler to validate all nodes have ids
* Refactored/Removed cases where localIds could be null.