### PR TITLE
Fix JUnit Tests

### DIFF
--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/ArchitectureTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/ArchitectureTest.java
@@ -7,7 +7,7 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.cqframework.cql.cql2elm.model.LibraryRef;
 import org.cqframework.cql.elm.IdObjectFactory;
 import org.hl7.elm.r1.Element;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class ArchitectureTest {
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/GenericOverloadsTests.java
@@ -3,8 +3,8 @@ package org.cqframework.cql.cql2elm;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryManagerTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LibraryManagerTests.java
@@ -3,7 +3,7 @@ package org.cqframework.cql.cql2elm;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertNotNull;
 
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.testng.annotations.AfterClass;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LiteralTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/LiteralTests.java
@@ -4,7 +4,7 @@ import static org.cqframework.cql.cql2elm.matchers.HasTypeAndResult.hasTypeAndRe
 import static org.cqframework.cql.cql2elm.matchers.LiteralFor.literalFor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -2,9 +2,9 @@ package org.cqframework.cql.cql2elm;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -667,11 +667,11 @@ public class SemanticTests {
         assertTrue(
                 errors.stream()
                         .map(Throwable::getMessage)
-                        .collect(Collectors.toSet())
-                        .toString(),
+                        .anyMatch("Could not find type for model: null and name: ThisTypeDoesNotExist"::equals),
                 errors.stream()
                         .map(Throwable::getMessage)
-                        .anyMatch("Could not find type for model: null and name: ThisTypeDoesNotExist"::equals));
+                        .collect(Collectors.toSet())
+                        .toString());
     }
 
     @Test
@@ -684,11 +684,11 @@ public class SemanticTests {
         assertTrue(
                 errors.stream()
                         .map(Throwable::getMessage)
-                        .collect(Collectors.toSet())
-                        .toString(),
+                        .anyMatch("Could not find type for model: FHIR and name: Code"::equals),
                 errors.stream()
                         .map(Throwable::getMessage)
-                        .anyMatch("Could not find type for model: FHIR and name: Code"::equals));
+                        .collect(Collectors.toSet())
+                        .toString());
     }
 
     @Test
@@ -723,7 +723,7 @@ public class SemanticTests {
         for (DataType dt : choiceType.getTypes()) {
             actualChoiceTypes.add(((NamedType) dt).getName());
         }
-        assertTrue("Expected types are String, Boolean, and Integer: ", actualChoiceTypes.equals(expectedChoiceTypes));
+        assertTrue(actualChoiceTypes.equals(expectedChoiceTypes), "Expected types are String, Boolean, and Integer: ");
     }
 
     @Test
@@ -751,7 +751,7 @@ public class SemanticTests {
         for (DataType dt : choiceType.getTypes()) {
             actualChoiceTypes.add(((NamedType) dt).getName());
         }
-        assertTrue("Expected return types are String and Boolean: ", actualChoiceTypes.equals(expectedChoiceTypes));
+        assertTrue(actualChoiceTypes.equals(expectedChoiceTypes), "Expected return types are String and Boolean: ");
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/StringLibrarySourceProviderTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/StringLibrarySourceProviderTest.java
@@ -1,13 +1,13 @@
 package org.cqframework.cql.cql2elm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.io.IOException;
 import java.util.List;
 import org.hl7.elm.r1.VersionedIdentifier;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class StringLibrarySourceProviderTest {
 
@@ -19,7 +19,7 @@ public class StringLibrarySourceProviderTest {
     private static final String NOT_QUOTED_VERSION_2 = "library Test version '2.0.0'\n define \"Value\": 2 + 2";
     private static final String GARBAGE = "NotALibrary";
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void ambiguous_id_throws_error() throws IOException {
         var list = List.of(QUOTED, NOT_QUOTED);
 
@@ -28,7 +28,7 @@ public class StringLibrarySourceProviderTest {
         provider.getLibrarySource(new VersionedIdentifier().withId("Test"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void ambiguous_id_without_version_throws_error() throws IOException {
         var list = List.of(QUOTED_VERSION_1, NOT_QUOTED_VERSION_1);
 
@@ -36,7 +36,7 @@ public class StringLibrarySourceProviderTest {
         provider.getLibrarySource(new VersionedIdentifier().withId("Test"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void ambiguous_id_with_version_throws_error() throws IOException {
         var list = List.of(QUOTED_VERSION_1, NOT_QUOTED_VERSION_1);
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestLocalId.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TestLocalId.java
@@ -1,8 +1,8 @@
 package org.cqframework.cql.cql2elm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -14,7 +14,7 @@ import org.cqframework.cql.elm.visiting.FunctionalElmVisitor;
 import org.cqframework.cql.gen.cqlLexer;
 import org.cqframework.cql.gen.cqlParser;
 import org.hl7.elm.r1.Element;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 // This test compiles a few example libraries and ensures
 // local ids are assigned for all elements in the resulting ELM

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/TranslationTests.java
@@ -5,7 +5,7 @@ import static org.cqframework.cql.cql2elm.CqlCompilerOptions.Options.EnableDetai
 import static org.cqframework.cql.cql2elm.CqlCompilerOptions.Options.EnableResultTypes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.testng.Assert.*;
 
 import jakarta.xml.bind.JAXBException;
 import java.io.File;
@@ -191,86 +191,74 @@ public class TranslationTests {
     @Test
     public void tenDividedByTwo() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("TenDividedByTwo.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void divideMultiple() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("DivideMultiple.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void divideVariables() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("DivideVariables.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void arithmetic_Mixed() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Arithmetic_Mixed.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void arithmetic_Parenthetical() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Arithmetic_Parenthetical.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void roundUp() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("RoundUp.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void roundDown() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("RoundDown.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void log_BaseTen() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Log_BaseTen.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void median_odd() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Median_odd.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void median_dup_vals_odd() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Median_dup_vals_odd.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void geometricMean_Zero() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("GeometricMean_Zero.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     @Ignore("Could not resolve call to operator Equal with signature (tuple{Foo:System.Any},tuple{Bar:System.Any}")
     public void tupleDifferentKeys() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("TupleDifferentKeys.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
@@ -278,23 +266,20 @@ public class TranslationTests {
             "Could not resolve call to operator Equal with signature (tuple{a:System.String,b:System.Any},tuple{a:System.String,c:System.Any})")
     public void uncertTuplesWithDiffNullFields() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("UncertTuplesWithDiffNullFields.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     @Ignore("Could not resolve call to operator Collapse with signature (System.Any,System.Quantity)")
     public void nullIvlCollapse_NullCollapse() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("NullIvlCollapse_NullCollapse.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test
     public void median_q_diff_units() throws IOException {
         final CqlTranslator translator = TestUtils.createTranslator("Median_q_diff_units.cql");
-        assertEquals(
-                "Errors: " + translator.getErrors(), 0, translator.getErrors().size());
+        assertEquals(translator.getErrors().size(), 0, "Errors: " + translator.getErrors());
     }
 
     @Test

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r4/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/fhir/r4/BaseTest.java
@@ -5,7 +5,7 @@ import static org.cqframework.cql.cql2elm.TestUtils.visitFileLibrary;
 import static org.cqframework.cql.cql2elm.matchers.QuickDataType.quickDataType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/qicore/v411/BaseTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/validation/LocalIdTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/validation/LocalIdTests.java
@@ -1,6 +1,6 @@
 package org.cqframework.cql.cql2elm.validation;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/IdObjectFactoryTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/IdObjectFactoryTest.java
@@ -3,7 +3,7 @@ package org.cqframework.cql.elm;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import org.hl7.elm.r1.Element;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class IdObjectFactoryTest {
 

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/utility/VisitorsTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/utility/VisitorsTest.java
@@ -1,12 +1,12 @@
 package org.cqframework.cql.elm.utility;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import org.hl7.elm.r1.ExpressionDef;
 import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.Library.Statements;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class VisitorsTest {
 

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/BaseElmVisitorTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/BaseElmVisitorTest.java
@@ -1,13 +1,13 @@
 package org.cqframework.cql.elm.visiting;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.cqframework.cql.elm.tracking.Trackable;
 import org.hl7.elm.r1.ByDirection;
 import org.hl7.elm.r1.Sort;
 import org.hl7.elm.r1.SortByItem;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 @SuppressWarnings("checkstyle:abstractclassname")
 public class BaseElmVisitorTest {

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/DesignTests.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/DesignTests.java
@@ -14,7 +14,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.hl7.elm.r1.Element;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class DesignTests {
 

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/FunctionalElmVisitorTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/FunctionalElmVisitorTest.java
@@ -1,13 +1,13 @@
 package org.cqframework.cql.elm.visiting;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import org.hl7.elm.r1.Element;
 import org.hl7.elm.r1.ExpressionDef;
 import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.Library.Statements;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class FunctionalElmVisitorTest {
 

--- a/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/RandomElmGraphTest.java
+++ b/Src/java/elm/src/test/java/org/cqframework/cql/elm/visiting/RandomElmGraphTest.java
@@ -1,6 +1,6 @@
 package org.cqframework.cql.elm.visiting;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
@@ -16,33 +16,20 @@ import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.ObjenesisObjectFactory;
 import org.jeasy.random.api.ExclusionPolicy;
 import org.jeasy.random.api.RandomizerContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
-@RunWith(Parameterized.class)
 public class RandomElmGraphTest {
 
-    @Parameters
-    public static Iterable<Object[]> seeds() {
+    @DataProvider(name = "seed")
+    public static Object[] seeds() {
         // I randomly picked these seeds until
         // I got 3 in a row that passed without errors.
         // Not perfect, but it's a start.
-        return java.util.Arrays.asList(new Object[][] {{96874}, {15895}, {121873}, {174617}});
+        return new Object[] {96874, 15895, 121873, 174617};
     }
 
-    public RandomElmGraphTest(int seed) {
-        this.seed = seed;
-    }
-
-    private int seed;
-
-    @Test
-    public void allNodesVisited() {
-        allNodesVisited(seed);
-    }
-
+    @Test(dataProvider = "seed")
     public void allNodesVisited(int seed) {
         // This test generates a random ELM graph and verifies that all nodes are
         // visited exactly once.
@@ -118,7 +105,7 @@ public class RandomElmGraphTest {
         }
 
         // No missed nodes, working as intended
-        assertEquals(0, elementsGenerated.size());
+        assertEquals(elementsGenerated.size(), 0);
 
         // Check that we didn't double-visit any nodes
         if (!elementsDuplicated.isEmpty()) {
@@ -128,11 +115,11 @@ public class RandomElmGraphTest {
         }
 
         // No duplicate visits, working as intended
-        assertEquals(0, elementsDuplicated.size());
+        assertEquals(elementsDuplicated.size(), 0);
 
         // if these are equal, then aggregateResult
         // ran once for every node in the graph (working as intended)
-        assertEquals(elementsGeneratedCount, visitorCount.intValue());
+        assertEquals(visitorCount.intValue(), elementsGeneratedCount);
     }
 
     class NoTypeSpecifierRecursionPolicy implements ExclusionPolicy {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/Dstu3FhirTest.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/Dstu3FhirTest.java
@@ -22,7 +22,7 @@ public class Dstu3FhirTest {
     private static IParser FHIR_PARSER = FHIR_CONTEXT.newJsonParser().setPrettyPrint(true);
     private static int HTTP_PORT = 0;
 
-    // emulate wiremock's junit.WireMockRule with testng features
+    // emulate wiremock's testng.WireMockRule with testng features
     WireMockServer wireMockServer;
     WireMock wireMock;
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
@@ -30,7 +30,7 @@ public abstract class R4FhirTest {
     private static IParser FHIR_PARSER = FHIR_CONTEXT.newJsonParser().setPrettyPrint(true);
     private static int HTTP_PORT = 0;
 
-    // emulate wiremock's junit.WireMockRule with testng features
+    // emulate wiremock's testng.WireMockRule with testng features
     WireMockServer wireMockServer;
     WireMock wireMock;
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/Issue1225.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/Issue1225.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.cql.engine.fhir.data;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Collections;
 import org.hl7.fhir.r4.model.Address;

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/Issue1226.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/Issue1226.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.cql.engine.fhir.data;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Collections;
 import org.hl7.fhir.r4.model.MedicationRequest;

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestCodeRef.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestCodeRef.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.cql.engine.fhir.data;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.cql.engine.execution;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import org.opencds.cqf.cql.engine.debug.DebugMap;
 import org.testng.annotations.Test;

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TestUnion.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TestUnion.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.cql.engine.execution;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/model/CachingModelResolverDecoratorTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/model/CachingModelResolverDecoratorTest.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.engine.model;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Date;
 import org.mockito.Mock;

--- a/Src/java/model/src/test/java/org/hl7/cql/model/ChoiceTypeTests.java
+++ b/Src/java/model/src/test/java/org/hl7/cql/model/ChoiceTypeTests.java
@@ -1,6 +1,6 @@
 package org.hl7.cql.model;
 
-import static org.junit.Assert.*;
+import static org.testng.Assert.*;
 
 import java.util.Arrays;
 import org.testng.annotations.Test;


### PR DESCRIPTION
As some point in the future we'd like to migrate all tests to JUnit. In the meantime, most of the tests are written using TestNG. The CI Server was not executing JUnit-based tests, causing a few regressions.

* Migrated all Junit tests to TestNG
* Fixed parameter ordering of relevant assertions