### PR TITLE
engine-fhir tests improvements

### DIFF
--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
@@ -66,7 +66,6 @@ public class CQLOperationsR4Test extends TestFhirPath {
     }
 
     public static Set<String> SKIP = Sets.newHashSet(
-            "cql/CqlAggregateTest/AggregateTests/FactorialOfFive",
             "cql/CqlAggregateTest/AggregateTests/RolledOutIntervals",
             "cql/CqlArithmeticFunctionsTest/Divide/Divide1Q1Q",
             "cql/CqlArithmeticFunctionsTest/Ln/Ln1000D",

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
@@ -7,15 +7,23 @@
 			<output>120</output>
 		</test>
     <test name="RolledOutIntervals">
-      <expression>MedicationRequestIntervals M
+      <expression>({
+    Interval[@2012-01-01, @2012-02-28],
+    Interval[@2012-02-01, @2012-03-31],
+    Interval[@2012-03-01, @2012-04-30]
+}) M
     aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
       M X
         let S: Max({ end of Last(R) + 1 day, start of X }),
           E: S + duration in days of X
         return Interval[S, E]
     })</expression>
-      <output>TODO</output>
-      <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
+      <output>{
+    Interval[@2012-01-01, @2012-02-28],
+    Interval[@2012-02-29, @2012-04-28],
+    Interval[@2012-04-29, @2012-06-28]
+}</output>
+      <!-- Execution Error: Invalid precision: 1. -->
     </test>
   </group>
 </tests>


### PR DESCRIPTION
Two small changes:

* Enabling the FactorialOfFive test:
Succeeds in checking `({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num = 120` with no changes needed.

* Fixing the expression logic for the RolledOutIntervals test and adding the expected output, but keeping the test skipped:
For future reference, if you enable the test, you get an execution error `Invalid precision: 1`. This is because `duration in days of X` is interpreted as an integer which, when converted to a quantity, has unit `'1'` and not `'day'`.