### PR TITLE
Reporting coverage across subprojects

### DIFF
--- a/Src/java/engine-fhir/build.gradle
+++ b/Src/java/engine-fhir/build.gradle
@@ -27,12 +27,15 @@ generateSources {
 
 jacocoTestReport {
     dependsOn ':cql-to-elm:compileTestJava'
+    dependsOn ':engine:compileTestJava'
 
     sourceDirectories.setFrom(files(
         "${projectDir}/../cql-to-elm/src/main/java",
+        "${projectDir}/../engine/src/main/java",
     ))
 
     classDirectories.setFrom(files(
         "${projectDir}/../cql-to-elm/build/classes/java/main",
+        "${projectDir}/../engine/build/classes/java/main",
     ))
 }

--- a/Src/java/engine-fhir/build.gradle
+++ b/Src/java/engine-fhir/build.gradle
@@ -26,16 +26,19 @@ generateSources {
 }
 
 jacocoTestReport {
-    dependsOn ':cql-to-elm:compileTestJava'
-    dependsOn ':engine:compileTestJava'
+    dependsOn ':cql-to-elm:test'
+    dependsOn ':engine:test'
+    dependsOn ':engine-fhir:test'
 
     sourceDirectories.setFrom(files(
         "${projectDir}/../cql-to-elm/src/main/java",
         "${projectDir}/../engine/src/main/java",
+        "${projectDir}/../engine-fhir/src/main/java",
     ))
 
     classDirectories.setFrom(files(
         "${projectDir}/../cql-to-elm/build/classes/java/main",
         "${projectDir}/../engine/build/classes/java/main",
+        "${projectDir}/../engine-fhir/build/classes/java/main",
     ))
 }

--- a/Src/java/engine-fhir/build.gradle
+++ b/Src/java/engine-fhir/build.gradle
@@ -33,6 +33,6 @@ jacocoTestReport {
     ))
 
     classDirectories.setFrom(files(
-        "${projectDir}/../cql-to-elm/build/classes",
+        "${projectDir}/../cql-to-elm/build/classes/java/main",
     ))
 }

--- a/Src/java/engine-fhir/build.gradle
+++ b/Src/java/engine-fhir/build.gradle
@@ -24,3 +24,13 @@ generateSources {
         }
     }
 }
+
+jacocoTestReport {
+    sourceDirectories.setFrom(files(
+        "${projectDir}/../cql-to-elm/src/main/java",
+    ))
+
+    classDirectories.setFrom(files(
+        "${projectDir}/../cql-to-elm/build/classes",
+    ))
+}

--- a/Src/java/engine-fhir/build.gradle
+++ b/Src/java/engine-fhir/build.gradle
@@ -26,6 +26,8 @@ generateSources {
 }
 
 jacocoTestReport {
+    dependsOn ':cql-to-elm:compileTestJava'
+
     sourceDirectories.setFrom(files(
         "${projectDir}/../cql-to-elm/src/main/java",
     ))

--- a/Src/java/engine/build.gradle
+++ b/Src/java/engine/build.gradle
@@ -12,13 +12,16 @@ dependencies {
 }
 
 jacocoTestReport {
-    dependsOn ':cql-to-elm:compileTestJava'
+    dependsOn ':cql-to-elm:test'
+    dependsOn ':engine:test'
 
     sourceDirectories.setFrom(files(
             "${projectDir}/../cql-to-elm/src/main/java",
+            "${projectDir}/../engine/src/main/java",
     ))
 
     classDirectories.setFrom(files(
             "${projectDir}/../cql-to-elm/build/classes/java/main",
+            "${projectDir}/../engine/build/classes/java/main",
     ))
 }

--- a/Src/java/engine/build.gradle
+++ b/Src/java/engine/build.gradle
@@ -10,3 +10,15 @@ dependencies {
     testImplementation project(':elm-jackson')
     testImplementation 'org.mockito:mockito-core:5.4.0'
 }
+
+jacocoTestReport {
+    dependsOn ':cql-to-elm:compileTestJava'
+
+    sourceDirectories.setFrom(files(
+            "${projectDir}/../cql-to-elm/src/main/java",
+    ))
+
+    classDirectories.setFrom(files(
+            "${projectDir}/../cql-to-elm/build/classes/java/main",
+    ))
+}


### PR DESCRIPTION
Currently, the JaCoCo test reports which are run separately for the engine-fhir, engine, cql-to-elm subprojects only include the classes from the default source sets. This means that e.g. the coverage of cql-to-elm classes is not reported when running engine-fhir tests. Concrete example: `resolveMethod` in the cql-to-elm subproject has low coverage ([link](https://app.codecov.io/gh/cqframework/clinical_quality_language/commit/e00c39673d7d13def60debe112bc19ad7f48f297/blob/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemMethodResolver.java#L253)) even though there are many tests for FHIRPath methods inside engine-fhir ([link](https://github.com/cqframework/clinical_quality_language/blob/e00c39673d7d13def60debe112bc19ad7f48f297/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/r4/tests-fhir-r4.xml)).

Here I'm trying to get code coverage to be reported across subprojects and see if codecov can aggregate the reports which seems to be the case. See coverage for `resolveMethod` after changing `jacocoTestReport` config ([link](https://app.codecov.io/gh/cqframework/clinical_quality_language/commit/f76f939dac2b357009261bac8b8db0e36d298729/blob/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemMethodResolver.java#L253)) and overall change in coverage for the affected classes ([link](https://app.codecov.io/gh/cqframework/clinical_quality_language/pull/1374/indirect-changes)).