### PR TITLE
Fix list equality logic

### DIFF
--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
@@ -108,7 +108,6 @@ public class CQLOperationsR4Test extends TestFhirPath {
             "cql/CqlListOperatorsTest/Equivalent/Equivalent123AndABC",
             "cql/CqlListOperatorsTest/Equivalent/Equivalent123AndString123",
             "cql/CqlListOperatorsTest/Equivalent/EquivalentABCAnd123",
-            "cql/CqlListOperatorsTest/Flatten/FlattenListNullAndNull",
             "cql/CqlListOperatorsTest/NotEqual/NotEqual123AndABC",
             "cql/CqlListOperatorsTest/NotEqual/NotEqual123AndString123",
             "cql/CqlListOperatorsTest/NotEqual/NotEqualABCAnd123",

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
@@ -129,7 +129,7 @@
 	<group name="Equal">
 		<test name="EqualNullNull">
 			<expression>{null} = {null}</expression>
-			<output>null</output>
+			<output>true</output>
 		</test>
 		<test name="EqualEmptyListNull">
 			<expression>{} as List&lt;String&gt; = null</expression>

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
@@ -175,9 +175,13 @@
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:59.999 } = { @T10:59:59.999, @T20:59:59.999, @T20:59:59.999 }</expression>
 			<output>false</output>
 		</test>
-		<test name="EqualWithSubLists">
+		<test name="EqualWithSubListsTrue">
 			<expression>{ { 'a', 'b' }, 'c' } = { { 'a', 'b' }, 'c' }</expression>
 			<output>true</output>
+		</test>
+		<test name="EqualWithSubListsFalse">
+			<expression>{ { 'a', 'b' }, 'c' } = { { 'a', 'b' }, 'd' }</expression>
+			<output>false</output>
 		</test>
 	</group>
 	<group name="Except">

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
@@ -171,6 +171,10 @@
 			<expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:59.999 } = { @T10:59:59.999, @T20:59:59.999, @T20:59:59.999 }</expression>
 			<output>false</output>
 		</test>
+		<test name="EqualWithSubLists">
+			<expression>{ { 'a', 'b' }, 'c' } = { { 'a', 'b' }, 'c' }</expression>
+			<output>true</output>
+		</test>
 	</group>
 	<group name="Except">
 		<test name="ExceptEmptyListAndEmptyList">

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
@@ -131,6 +131,10 @@
 			<expression>{null} = {null}</expression>
 			<output>true</output>
 		</test>
+		<test name="EqualLiteralNull">
+			<expression>{ 1, null } = { 1, null }</expression>
+			<output>true</output>
+		</test>
 		<test name="EqualEmptyListNull">
 			<expression>{} as List&lt;String&gt; = null</expression>
 			<output>null</output>

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/EqualEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/EqualEvaluator.java
@@ -46,6 +46,10 @@ public class EqualEvaluator {
             return ((Interval) right).equal(left);
         }
 
+        if (left instanceof Iterable && right instanceof Iterable) {
+            return CqlList.equal((Iterable<?>) left, (Iterable<?>) right, state);
+        }
+
         if (!left.getClass().equals(right.getClass())) {
             return false;
         } else if (left instanceof Boolean
@@ -55,8 +59,6 @@ public class EqualEvaluator {
             return left.equals(right);
         } else if (left instanceof BigDecimal && right instanceof BigDecimal) {
             return ((BigDecimal) left).compareTo((BigDecimal) right) == 0;
-        } else if (left instanceof Iterable && right instanceof Iterable) {
-            return CqlList.equal((Iterable<?>) left, (Iterable<?>) right, state);
         } else if (left instanceof CqlType && right instanceof CqlType) {
             return ((CqlType) left).equal(right);
         }

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
@@ -109,6 +109,9 @@ public class CqlList {
                 if (leftObject instanceof Iterable && rightObject instanceof Iterable) {
                     return equal((Iterable<?>) leftObject, (Iterable<?>) rightObject, state);
                 }
+                if (leftObject == null && rightObject == null) {
+                    return true;
+                }
                 Boolean elementEquals = EqualEvaluator.equal(leftObject, rightObject, state);
                 if (elementEquals == null || !elementEquals) {
                     return elementEquals;

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
@@ -110,7 +110,7 @@ public class CqlList {
                     return equal((Iterable<?>) leftObject, (Iterable<?>) rightObject, state);
                 }
                 if (leftObject == null && rightObject == null) {
-                    return true;
+                    continue;
                 }
                 Boolean elementEquals = EqualEvaluator.equal(leftObject, rightObject, state);
                 if (elementEquals == null || !elementEquals) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/CqlList.java
@@ -106,9 +106,6 @@ public class CqlList {
             Object leftObject = leftIterator.next();
             if (rightIterator.hasNext()) {
                 Object rightObject = rightIterator.next();
-                if (leftObject instanceof Iterable && rightObject instanceof Iterable) {
-                    return equal((Iterable<?>) leftObject, (Iterable<?>) rightObject, state);
-                }
                 if (leftObject == null && rightObject == null) {
                     continue;
                 }

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/ListOperatorsTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/ListOperatorsTest.java
@@ -164,7 +164,7 @@ class ListOperatorsTest extends CqlTestBase {
         assertThat(((List<?>) value).size(), is(2));
 
         value = results.forExpression("EqualNullNull").value();
-        assertThat(value, is(nullValue()));
+        assertThat(value, is(true));
 
         value = results.forExpression("EqualEmptyListNull").value();
         assertThat(value, is(nullValue()));

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlPerformanceTest.cql
@@ -4546,7 +4546,7 @@ define test_Equal_EqualTupleList: TestMessage(Equal_EqualTupleList, 'Equal_Equal
 define test_Equal_UnequalTupleList: TestMessage(not Equal_UnequalTupleList, 'Equal_UnequalTupleList', toString(false), toString(Equal_UnequalTupleList))
 define test_Equal_FirstListHasNull: TestMessage(Equal_FirstListHasNull is null, 'Equal_FirstListHasNull', 'null', toString(Equal_FirstListHasNull))
 define test_Equal_SecondListHasNull: TestMessage(Equal_SecondListHasNull is null, 'Equal_SecondListHasNull', 'null', toString(Equal_SecondListHasNull))
-define test_Equal_BothListsHaveNull: TestMessage(Equal_BothListsHaveNull is null, 'Equal_BothListsHaveNull', 'null', toString(Equal_BothListsHaveNull))
+define test_Equal_BothListsHaveNull: TestMessage(Equal_BothListsHaveNull, 'Equal_BothListsHaveNull', toString(true), toString(Equal_BothListsHaveNull))
 
 // NotEqual
 define NotEqual_EqualIntList: {1, 2, 3} != {1, 2, 3}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTestSuite.cql
@@ -4546,7 +4546,7 @@ define test_Equal_EqualTupleList: TestMessage(Equal_EqualTupleList, 'Equal_Equal
 define test_Equal_UnequalTupleList: TestMessage(not Equal_UnequalTupleList, 'Equal_UnequalTupleList', toString(false), toString(Equal_UnequalTupleList))
 define test_Equal_FirstListHasNull: TestMessage(Equal_FirstListHasNull is null, 'Equal_FirstListHasNull', 'null', toString(Equal_FirstListHasNull))
 define test_Equal_SecondListHasNull: TestMessage(Equal_SecondListHasNull is null, 'Equal_SecondListHasNull', 'null', toString(Equal_SecondListHasNull))
-define test_Equal_BothListsHaveNull: TestMessage(Equal_BothListsHaveNull is null, 'Equal_BothListsHaveNull', 'null', toString(Equal_BothListsHaveNull))
+define test_Equal_BothListsHaveNull: TestMessage(Equal_BothListsHaveNull, 'Equal_BothListsHaveNull', toString(true), toString(Equal_BothListsHaveNull))
 
 // NotEqual
 define NotEqual_EqualIntList: {1, 2, 3} != {1, 2, 3}


### PR DESCRIPTION
This PR adds some fixes to the list equality logic.

1. Remove the early return statement inside `CqlList.equal` leading to e.g. this being true: `{{'a','b'}, 'c'} = {{'a','b'},'d'}`. Added the `EqualWithSubListsTrue` and `EqualWithSubListsFalse` tests for this case.

2. Fix null handling ("For list types, this means that equality returns true if and only if the lists contain elements of the same type, have the same number of elements, and for each element in the lists, in order, the elements are equal using equality semantics, with the exception that null elements are considered equal." - [link](https://cql.hl7.org/04-logicalspecification.html#equal)). Added the `EqualLiteralNull` test to better cover this case.

3. The `EqualNullNull` test (XML-based) is adjusted to match the spec. The same change is proposed in https://github.com/cqframework/cql-tests/pull/38.

4. The `test_Equal_BothListsHaveNull` test (library-based) is also fixed to match the spec.

5. Because our XML-based tests use CQL's equality semantics to compare the expected to actual value of test expressions, it's now possible to un-skip the `FlattenListNullAndNull` test which previously wasn't passing because `{ null, null } = { null, null }` didn't evaluate to `true`.