### PR TITLE
Implement ToChars in the engine

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/SystemFunctionResolver.java
@@ -338,7 +338,8 @@ public class SystemFunctionResolver {
                 case "ToTime":
                 case "ToQuantity":
                 case "ToRatio":
-                case "ToConcept": {
+                case "ToConcept":
+                case "ToChars": {
                     return resolveUnary(fun);
                 }
 

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlTypeOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlTypeOperatorsTest.xml
@@ -57,6 +57,23 @@
 			<output>false</output>
 		</test>
 	</group>
+	<group name="ToChars">
+		<test name="StringToChars">
+			<expression>ToChars('abc123')</expression>
+			<output>{ 'a', 'b', 'c', '1', '2', '3' }</output>
+		</test>
+		<test name="EmptyStringToChars">
+			<expression>ToChars('')</expression>
+			<output>{}</output>
+		</test>
+		<test name="NullToChars">
+			<expression>ToChars(null)</expression>
+			<output>null</output>
+		</test>
+		<test name="ToCharsMalformed">
+			<expression invalid="true">ToChars(123)</expression>
+		</test>
+	</group>
 	<group name="ToConcept">
 		<test name="CodeToConcept1">
 			<expression>ToConcept(Code { code: '8480-6' })</expression>

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/ToCharsEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/ToCharsEvaluator.java
@@ -1,0 +1,35 @@
+package org.opencds.cqf.cql.engine.elm.executing;
+
+import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ToChars(argument String) List<String>
+
+The ToChars operator takes a string and returns a list with one string for each character in the input, in the order in which they appear in the string.
+
+If the argument is null, the result is null.
+*/
+
+public class ToCharsEvaluator {
+
+    public static List<String> toChars(Object operand) {
+        if (operand == null) {
+            return null;
+        }
+
+        if (operand instanceof String) {
+            List<String> result = new ArrayList<>();
+            for (char c : ((String) operand).toCharArray()) {
+                result.add(String.valueOf(c));
+            }
+            return result;
+        }
+
+        throw new InvalidOperatorArgument(
+                "ToChars(String)",
+                String.format("ToInteger(%s)", operand.getClass().getName()));
+    }
+}

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.java
@@ -421,6 +421,12 @@ public class EvaluationVisitor extends BaseElmLibraryVisitor<Object, State> {
     }
 
     @Override
+    public Object visitToChars(ToChars elm, State state) {
+        Object operand = visitExpression(elm.getOperand(), state);
+        return ToCharsEvaluator.toChars(operand);
+    }
+
+    @Override
     public Object visitToDate(ToDate elm, State state) {
         Object operand = visitExpression(elm.getOperand(), state);
         return ToDateEvaluator.toDate(operand);


### PR DESCRIPTION
This PR implements the ToChars operator as defined by https://cql.hl7.org/04-logicalspecification.html#tochars:

> The ToChars operator takes a string and returns a list with one string for each character in the input, in the order in which they appear in the string.
> 
> If the argument is null, the result is null.


Squeezed in as much coverage as possible with 4 additional tests.