### PR TITLE
Add tests for ProperIn

### DIFF
--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlListOperatorsTest.xml
@@ -720,12 +720,52 @@
 		</test>
 	</group>
 	<group name="ProperIn">
+		<test name="ProperIn1">
+			<expression>'a' properly included in null as List&lt;String&gt;</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn2">
+			<expression>'a' properly included in {}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn3">
+			<expression>'a' properly included in { 'a' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn4">
+			<expression>null as String properly included in { null }</expression>
+			<output>false</output>
+		</test>
 		<test name="ProperInNullRightFalse">
-			<expression>null properly included in {'s', 'u', 'n'}</expression>
+			<expression>null as String properly included in {'s', 'u', 'n'}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn5">
+			<expression>null as String properly included in { null, null }</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperInNullRightTrue">
-			<expression>null properly included in {'s', 'u', 'n', null}</expression>
+			<expression>null as String properly included in {'s', 'u', 'n', null}</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperIn6">
+			<expression>'a' properly included in { 'a', 'b' }</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperIn7">
+			<expression>'a' properly included in { 'a', 'a' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn8">
+			<expression>'c' properly included in { 'a', 'b' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn9">
+			<expression>'a' properly included in { 'a', null }</expression>
+			<output>null</output>
+		</test>
+		<test name="ProperIn10">
+			<expression>'a' properly included in { 'a', 'b', null }</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperInTimeTrue">

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/ProperInEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/ProperInEvaluator.java
@@ -6,13 +6,18 @@ package org.opencds.cqf.cql.engine.elm.executing;
         T, Interval : The type of T must be the same as the point type of the interval.
 
     For the T, List overload, this operator returns if the given element is in the given list,
-        and it is not the only element in the list, using equivalence semantics.
-        If the list-valued argument is null, it should be treated as an empty list.
+        and it is not the only element in the list, using equality semantics, with the exception
+        that null elements are considered equal.
+        If the first argument is null, the result is true if the list contains any null elements
+        and at least one other element, and false otherwise.
+        If the second argument is null, the result is false.
 
     For the T, Interval overload, this operator returns true if the given point is greater than
         the starting point, and less than the ending point of the interval, as determined by the Start and End operators.
-        If precision is specified and the point type is a date/time type, comparisons used in the operation are performed
-            at the specified precision.
+        If precision is specified and the point type is a Date, DateTime, or Time type, comparisons used in the operation
+        are performed at the specified precision.
+        If the first argument is null, the result is null.
+        If the second argument is null the result is false.
 */
 
 import org.opencds.cqf.cql.engine.execution.State;

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
@@ -215,8 +215,8 @@ define ProperContainsTimeTrue: { @T15:59:59, @T20:59:59.999, @T20:59:49.999 } pr
 define ProperContainsTimeNull: { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59
 
 //ProperIn
-define ProperInNullRightFalse: null properly included in {'s', 'u', 'n'}
-define ProperInNullRightTrue: null properly included in {'s', 'u', 'n', null}
+define ProperInNullRightFalse: null as String properly included in {'s', 'u', 'n'}
+define ProperInNullRightTrue: null as String properly included in {'s', 'u', 'n', null}
 define ProperInTimeTrue: @T15:59:59 properly included in { @T15:59:59, @T20:59:59.999, @T20:59:49.999 }
 define ProperInTimeNull: @T15:59:59 properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
 


### PR DESCRIPTION
This PR adds tests for the ProperIn evaluator following the changes to ProperContains to align it with the spec. Internally, ProperIn uses the ProperContains logic entirely because the operators are the same except for the order of the arguments.