### PR TITLE
Enable tests for Distinct

### DIFF
--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
@@ -103,8 +103,6 @@ public class CQLOperationsR4Test extends TestFhirPath {
             "cql/CqlIntervalOperatorsTest/Expand/ExpandPer1",
             "cql/CqlIntervalOperatorsTest/Expand/ExpandPer2Days",
             "cql/CqlIntervalOperatorsTest/Expand/ExpandPerMinute",
-            "cql/CqlListOperatorsTest/Distinct/DistinctANullANull",
-            "cql/CqlListOperatorsTest/Distinct/DistinctNullNullNull",
             "cql/CqlListOperatorsTest/Equivalent/Equivalent123AndABC",
             "cql/CqlListOperatorsTest/Equivalent/Equivalent123AndString123",
             "cql/CqlListOperatorsTest/Equivalent/EquivalentABCAnd123",


### PR DESCRIPTION
Un-skipping two existing tests for the Distinct operator.

These tests pass after the fixes to the list equality implementation (https://github.com/cqframework/clinical_quality_language/pull/1387).