### PR TITLE
Make logging of skipped tests less verbose in the build

### DIFF
--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsDstu3Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsDstu3Test.java
@@ -39,7 +39,8 @@ public class CQLOperationsDstu3Test extends TestFhirPath {
             for (Group group : loadTestsFile(file).getGroup()) {
                 for (org.hl7.fhirpath.tests.Test test : group.getTest()) {
                     if (!"2.1.0".equals(test.getVersion())) { // unsupported version
-                        testsToRun.add(new Object[] {file, group, test});
+                        var name = getTestName(file, group, test);
+                        testsToRun.add(new Object[] {name, test});
                     }
                 }
             }
@@ -146,17 +147,16 @@ public class CQLOperationsDstu3Test extends TestFhirPath {
             "stu3/tests-fhir-r3/testWhere(Patient.name.where(given = 'Jim').count() = 1)",
             "stu3/tests-fhir-r3/testWhere(Patient.name.where(given = 'X').count() = 0)");
 
-    public String getTestName(String file, Group group, org.hl7.fhirpath.tests.Test test) {
+    public static String getTestName(String file, Group group, org.hl7.fhirpath.tests.Test test) {
         return file.replaceAll(".xml", "")
                 + "/" + group.getName()
                 + (test.getName() != null ? "/" + test.getName() : "")
                 + "(" + test.getExpression().getValue() + ")";
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @MethodSource("dataMethod")
-    void test(String file, Group group, org.hl7.fhirpath.tests.Test test) throws UcumException {
-        var name = getTestName(file, group, test);
+    void test(String name, org.hl7.fhirpath.tests.Test test) throws UcumException {
         Assumptions.assumeFalse(SKIP.contains(name), "Skipping " + name);
         runTest(test, "stu3/input/", fhirContext, provider, fhirModelResolver);
     }

--- a/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
+++ b/Src/java/engine-fhir/src/test/java/org/hl7/fhirpath/CQLOperationsR4Test.java
@@ -57,7 +57,8 @@ public class CQLOperationsR4Test extends TestFhirPath {
             for (Group group : loadTestsFile(file).getGroup()) {
                 for (org.hl7.fhirpath.tests.Test test : group.getTest()) {
                     if (!"2.1.0".equals(test.getVersion())) { // unsupported version
-                        testsToRun.add(new Object[] {file, group, test});
+                        var name = getTestName(file, group, test);
+                        testsToRun.add(new Object[] {name, test});
                     }
                 }
             }
@@ -273,7 +274,7 @@ public class CQLOperationsR4Test extends TestFhirPath {
             "r4/tests-fhir-r4/testWhere/testWhere3",
             "r4/tests-fhir-r4/testWhere/testWhere4");
 
-    public String getTestName(String file, Group group, org.hl7.fhirpath.tests.Test test) {
+    public static String getTestName(String file, Group group, org.hl7.fhirpath.tests.Test test) {
         return file.replaceAll(".xml", "") + "/" + group.getName()
                 + "/"
                 + (test.getName() != null
@@ -281,10 +282,9 @@ public class CQLOperationsR4Test extends TestFhirPath {
                         : test.getExpression().getValue());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @MethodSource("dataMethod")
-    void test(String file, Group group, org.hl7.fhirpath.tests.Test test) throws UcumException {
-        var name = getTestName(file, group, test);
+    void test(String name, org.hl7.fhirpath.tests.Test test) throws UcumException {
         Assumptions.assumeFalse(SKIP.contains(name), "Skipping " + name);
         runTest(test, "r4/input/", fhirContext, provider, fhirModelResolver);
     }


### PR DESCRIPTION
Overriding the the display name of parameterized tests to make the logging of skipped tests less verbose.

See the output of "Run Gradle Build" in the CI which runs `./gradlew build`.

Before:

```
$ ./gradlew build

...

> Task :engine-fhir:test

CQLOperationsDstu3Test > test(String, Group, Test) > [18] stu3/tests-fhir-r3.xml, org.hl7.fhirpath.tests.Group@2b9ac3ab[notes=<null>(default), test={org.hl7.fhirpath.tests.Test@53c6e031[expression=org.hl7.fhirpath.tests.Expression@aa4447[value=Patient.name.given.where(substring($this.length()-3) = 'out'), invalid=<null>(default)], output=<null>(default), notes=<null>(default), name=testDollarThis1, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), check…, org.hl7.fhirpath.tests.Test@53c6e031[expression=org.hl7.fhirpath.tests.Expression@aa4447[value=Patient.name.given.where(substring($this.length()-3) = 'out'), invalid=<null>(default)], output=<null>(default), notes=<null>(default), name=testDollarThis1, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), checkOrderedFunctions=<null>(default)] SKIPPED

CQLOperationsDstu3Test > test(String, Group, Test) > [19] stu3/tests-fhir-r3.xml, org.hl7.fhirpath.tests.Group@2b9ac3ab[notes=<null>(default), test={org.hl7.fhirpath.tests.Test@53c6e031[expression=org.hl7.fhirpath.tests.Expression@aa4447[value=Patient.name.given.where(substring($this.length()-3) = 'out'), invalid=<null>(default)], output=<null>(default), notes=<null>(default), name=testDollarThis1, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), check…, org.hl7.fhirpath.tests.Test@74c01ddf[expression=org.hl7.fhirpath.tests.Expression@93a1f77[value=Patient.name.given.where(substring($this.length()-3) = 'ter'), invalid=<null>(default)], output={org.hl7.fhirpath.tests.Output@6d19a109[value=Peter, type=STRING]}, notes=<null>(default), name=testDollarThis2, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), checkOrderedFunction… SKIPPED

CQLOperationsDstu3Test > test(String, Group, Test) > [22] stu3/tests-fhir-r3.xml, org.hl7.fhirpath.tests.Group@2b9ac3ab[notes=<null>(default), test={org.hl7.fhirpath.tests.Test@53c6e031[expression=org.hl7.fhirpath.tests.Expression@aa4447[value=Patient.name.given.where(substring($this.length()-3) = 'out'), invalid=<null>(default)], output=<null>(default), notes=<null>(default), name=testDollarThis1, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), check…, org.hl7.fhirpath.tests.Test@10ae65ea[expression=org.hl7.fhirpath.tests.Expression@ded52f4[value=Patient.children().skip(1), invalid=TRUE], output=<null>(default), notes=<null>(default), name=testDollarOrderNotAllowed, version=<null>(default), description=<null>(default), reference=<null>(default), inputfile=patient-example.xml, predicate=<null>(default), mode=<null>(default), ordered=<null>(default), checkOrderedFunctions=<null>(default)] SKIPPED

...
```

After:

```
$ ./gradlew build

...

> Task :engine-fhir:test

CQLOperationsDstu3Test > test(String, Test) > stu3/tests-fhir-r3/Dollar/testDollarThis1(Patient.name.given.where(substring($this.length()-3) = 'out')) SKIPPED

CQLOperationsDstu3Test > test(String, Test) > stu3/tests-fhir-r3/Dollar/testDollarThis2(Patient.name.given.where(substring($this.length()-3) = 'ter')) SKIPPED

CQLOperationsDstu3Test > test(String, Test) > stu3/tests-fhir-r3/Dollar/testDollarOrderNotAllowed(Patient.children().skip(1)) SKIPPED

...
```