### PR TITLE
Set ValueSetRef.preserve to true for included value sets

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryBuilder.java
@@ -2926,6 +2926,9 @@ public class LibraryBuilder {
                 ValueSetRef result =
                         of.createValueSetRef().withLibraryName(libraryName).withName(memberIdentifier);
                 result.setResultType(element.getResultType());
+                if (isCompatibleWith("1.5")) {
+                    result.setPreserve(true);
+                }
                 return result;
             }
 

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/SemanticTests.java
@@ -2,9 +2,7 @@ package org.cqframework.cql.cql2elm;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -757,6 +755,26 @@ public class SemanticTests {
     @Test
     void issue863() throws IOException {
         TestUtils.runSemanticTest("Issue863.cql", 0);
+    }
+
+    @Test
+    void issue1407() throws IOException {
+        assertNull(issue1407GetIsPreserve("1.4"));
+        assertTrue(issue1407GetIsPreserve("1.5"));
+    }
+
+    private Boolean issue1407GetIsPreserve(String compatibilityLevel) throws IOException {
+        CqlTranslator translator = runSemanticTest(
+                "LibraryTests/Issue1407.cql", 0, new CqlCompilerOptions().withCompatibilityLevel(compatibilityLevel));
+        var library = translator.toELM();
+        var testExpression = library.getStatements().getDef().stream()
+                .filter(def -> def.getName().equals("TestStatement"))
+                .findFirst()
+                .orElseThrow()
+                .getExpression();
+
+        assertThat(testExpression, instanceOf(ValueSetRef.class));
+        return ((ValueSetRef) testExpression).isPreserve();
     }
 
     private CqlTranslator runSemanticTest(String testFileName) throws IOException {

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/Issue1407.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/Issue1407.cql
@@ -1,0 +1,11 @@
+library Issue1407
+
+using FHIR version '4.0.1'
+
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+include Issue1407ValueSets
+
+context Patient
+
+define TestStatement: Issue1407ValueSets.TestValueSet

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/Issue1407ValueSets.cql
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/LibraryTests/Issue1407ValueSets.cql
@@ -1,0 +1,5 @@
+library Issue1407ValueSets
+
+using FHIR version '4.0.1'
+
+valueset TestValueSet: 'garb'

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.java
@@ -2,17 +2,11 @@ package org.opencds.cqf.cql.engine.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.opencds.cqf.cql.engine.execution.CqlConceptTest.assertEqual;
 
-import java.util.Collections;
-import java.util.List;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.junit.jupiter.api.Test;
-import org.opencds.cqf.cql.engine.runtime.Code;
-import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
-import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
-import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.opencds.cqf.cql.engine.runtime.ValueSet;
 
 class IncludedValueSetRefTest {
 
@@ -21,33 +15,15 @@ class IncludedValueSetRefTest {
         LibraryManager libraryManager = new LibraryManager(new ModelManager());
         libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
 
-        Code expected = new Code().withCode("M").withSystem("http://test.com/system");
-        TerminologyProvider terminologyProvider = new TerminologyProvider() {
-            public boolean in(Code code, ValueSetInfo valueSet) {
-                return true;
-            }
-
-            public Iterable<Code> expand(ValueSetInfo valueSet) {
-                return Collections.singletonList(expected);
-            }
-
-            public Code lookup(Code code, CodeSystemInfo codeSystem) {
-                return null;
-            }
-        };
-
-        Environment environment = new Environment(libraryManager, null, terminologyProvider);
+        Environment environment = new Environment(libraryManager);
 
         CqlEngine engine = new CqlEngine(environment);
 
         var results = engine.evaluate(CqlTestBase.toElmIdentifier("IncludedValueSetRefTest"));
 
-        @SuppressWarnings("unchecked")
-        List<Code> actual =
-                (List<Code>) results.forExpression("IncludedValueSet").value();
-        assertNotNull(actual);
-        assertEquals(1, actual.size());
+        var actual = (ValueSet) results.forExpression("IncludedValueSet").value();
 
-        assertEqual(expected, actual.get(0));
+        assertNotNull(actual);
+        assertEquals("http://test/common", actual.getId());
     }
 }


### PR DESCRIPTION
Closes #1407.

Starting with version 1.5, `ValueSetRef`s need to have `preserve` set to true during translation so that ValueSetRefEvaluator does not expand them during execution. Currently, this is only applied to the `ValueSetRef`s that point to value sets from the same library and not when the value set comes from an included library (i.e. not when `ValueSetRef`s are constructed from imported `ValueSetDef`s). The fix is to set `ValueSetRef.preserve` to true in both cases.