### PR TITLE
Remove usages of interfaces deprecated in latest FHIR core

### DIFF
--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmLibrarySourceProvider.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmLibrarySourceProvider.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.fhir.r5.context.ILoggingService;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 
@@ -16,8 +15,7 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
  */
 public class NpmLibrarySourceProvider implements LibrarySourceProvider {
 
-    public NpmLibrarySourceProvider(
-            List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
+    public NpmLibrarySourceProvider(List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
         this.packages = packages;
         this.reader = reader;
         this.logger = logger;

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmLibrarySourceProvider.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmLibrarySourceProvider.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.util.List;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.fhir.r5.context.ILoggingService;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -16,7 +17,7 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
 public class NpmLibrarySourceProvider implements LibrarySourceProvider {
 
     public NpmLibrarySourceProvider(
-            List<NpmPackage> packages, ILibraryReader reader, IWorkerContext.ILoggingService logger) {
+            List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
         this.packages = packages;
         this.reader = reader;
         this.logger = logger;
@@ -24,7 +25,7 @@ public class NpmLibrarySourceProvider implements LibrarySourceProvider {
 
     private List<NpmPackage> packages;
     private ILibraryReader reader;
-    private IWorkerContext.ILoggingService logger;
+    private ILoggingService logger;
 
     @Override
     public InputStream getLibrarySource(VersionedIdentifier identifier) {
@@ -59,7 +60,7 @@ public class NpmLibrarySourceProvider implements LibrarySourceProvider {
                 }
             } catch (IOException e) {
                 logger.logDebugMessage(
-                        IWorkerContext.ILoggingService.LogCategory.PROGRESS,
+                        ILoggingService.LogCategory.PROGRESS,
                         String.format(
                                 "Exceptions occurred attempting to load npm library source for %s",
                                 identifier.toString()));

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.cql.model.ModelInfoProvider;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
+import org.hl7.fhir.r5.context.ILoggingService;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -18,7 +19,7 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
 public class NpmModelInfoProvider implements ModelInfoProvider {
 
     public NpmModelInfoProvider(
-            List<NpmPackage> packages, ILibraryReader reader, IWorkerContext.ILoggingService logger) {
+            List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
         this.packages = packages;
         this.reader = reader;
         this.logger = logger;
@@ -26,7 +27,7 @@ public class NpmModelInfoProvider implements ModelInfoProvider {
 
     private List<NpmPackage> packages;
     private ILibraryReader reader;
-    private IWorkerContext.ILoggingService logger;
+    private ILoggingService logger;
 
     public ModelInfo load(ModelIdentifier modelIdentifier) {
         // VersionedIdentifier.id: Name of the model
@@ -60,7 +61,7 @@ public class NpmModelInfoProvider implements ModelInfoProvider {
                 }
             } catch (IOException e) {
                 logger.logDebugMessage(
-                        IWorkerContext.ILoggingService.LogCategory.PROGRESS,
+                        ILoggingService.LogCategory.PROGRESS,
                         String.format(
                                 "Exceptions occurred attempting to load npm library for model %s",
                                 modelIdentifier.toString()));

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
@@ -9,7 +9,6 @@ import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.cql.model.ModelInfoProvider;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 import org.hl7.fhir.r5.context.ILoggingService;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.Library;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 
@@ -18,8 +17,7 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
  */
 public class NpmModelInfoProvider implements ModelInfoProvider {
 
-    public NpmModelInfoProvider(
-            List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
+    public NpmModelInfoProvider(List<NpmPackage> packages, ILibraryReader reader, ILoggingService logger) {
         this.packages = packages;
         this.reader = reader;
         this.logger = logger;

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmPackageManager.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmPackageManager.java
@@ -4,9 +4,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.hl7.fhir.r5.context.ILoggingService;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmPackageManager.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmPackageManager.java
@@ -4,6 +4,8 @@ import ca.uhn.fhir.model.primitive.IdDt;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.hl7.fhir.r5.context.ILoggingService;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.VersionUtilities;
@@ -12,7 +14,7 @@ import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NpmPackageManager implements IWorkerContext.ILoggingService {
+public class NpmPackageManager implements ILoggingService {
     private static final Logger logger = LoggerFactory.getLogger(NpmPackageManager.class);
     private final ImplementationGuide sourceIg;
     private final FilesystemPackageCacheManager fspcm;

--- a/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
+++ b/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
@@ -12,6 +12,7 @@ import org.hl7.elm_modelinfo.r1.ModelInfo;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
 import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r5.context.ILoggingService;
 import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
+public class NpmPackageManagerTests implements ILoggingService {
 
     private final Logger logger = LoggerFactory.getLogger(NpmPackageManagerTests.class);
     private final VersionConvertor_40_50 convertor = new VersionConvertor_40_50(new BaseAdvisor_40_50());
@@ -134,7 +135,7 @@ public class NpmPackageManagerTests implements IWorkerContext.ILoggingService {
     }
 
     @Override
-    public void logDebugMessage(IWorkerContext.ILoggingService.LogCategory category, String msg) {
+    public void logDebugMessage(ILoggingService.LogCategory category, String msg) {
         logMessage(msg);
     }
 

--- a/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
+++ b/Src/java/cqf-fhir-npm/src/test/java/org/cqframework/fhir/npm/NpmPackageManagerTests.java
@@ -13,7 +13,6 @@ import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
 import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r5.context.ILoggingService;
-import org.hl7.fhir.r5.context.IWorkerContext;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 import org.junit.jupiter.api.Disabled;


### PR DESCRIPTION
* FHIR Core moved the definition of the ILoggingService up a level and deprecated the old interface.