### PR TITLE
Add test for default timezone offset of DateTime

### DIFF
--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlDateTimeOperatorsTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlDateTimeOperatorsTest.java
@@ -119,6 +119,7 @@ class CqlDateTimeOperatorsTest extends CqlTestBase {
 
             // Issue1420 calculates the difference in hours between `DateTime(y, m, d, h, m, s, ms)` and
             // `DateTime(y, m, d, h, m, s, ms, 0)`, so it returns the timezone offset of the first DateTime.
+            // The first DateTime should have the timezone offset of the evaluation request as per the spec.
             // CQL also has `timezoneoffset from DateTime(...)` but here we are testing a more complex scenario.
             var value = engine.expression(library, "Issue1420", evaluationZonedDateTime)
                     .value();

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlDateTimeOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlDateTimeOperatorsTest.cql
@@ -21,3 +21,6 @@ define TimeOfDayTest: TimeOfDay()
 
 //Today
 define Issue34B: Today()
+
+// Default timezoneOffset
+define Issue1420: hours between DateTime(2024, 10, 3, 15, 54, 0, 0) and DateTime(2024, 10, 3, 15, 54, 0, 0, 0)


### PR DESCRIPTION
Closes https://github.com/cqframework/clinical_quality_language/issues/1420.

This PR adds tests for calling `DateTime(y, m, d, h, m, s, ms)` without specifying the timezone offset. As per the spec, it should default to the timezone offset of the evaluation request.

Note that when `engine.expression(...)` or `engine.evaluate(...)` is called without passing in the evaluation date time explicitly, it is set to `ZonedDateTime.now()`.