### PR TITLE
Call isInstantiable recursively to make sure that type parameters (if present) are bound

### DIFF
--- a/Src/java/model/src/main/java/org/hl7/cql/model/ChoiceType.java
+++ b/Src/java/model/src/main/java/org/hl7/cql/model/ChoiceType.java
@@ -148,6 +148,16 @@ public class ChoiceType extends DataType {
 
     @Override
     public boolean isInstantiable(DataType callType, InstantiationContext context) {
+        // Call isInstantiable recursively to make sure that type parameters (if present) are bound
+        if (callType.equals(DataType.ANY)) {
+            for (var type : types) {
+                if (!type.isInstantiable(callType, context)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         return isSuperTypeOf(callType);
     }
 

--- a/Src/java/model/src/main/java/org/hl7/cql/model/TupleType.java
+++ b/Src/java/model/src/main/java/org/hl7/cql/model/TupleType.java
@@ -164,7 +164,13 @@ public class TupleType extends DataType {
 
     @Override
     public boolean isInstantiable(DataType callType, InstantiationContext context) {
+        // Call isInstantiable recursively to make sure that type parameters (if present) are bound
         if (callType.equals(DataType.ANY)) {
+            for (var element : elements) {
+                if (!element.getType().isInstantiable(callType, context)) {
+                    return false;
+                }
+            }
             return true;
         }
 


### PR DESCRIPTION
This is not critical at the moment but will be needed if some generic operators are defined with choice or tuple types with type parameters inside.