### PR TITLE
Remove redundant overrides in `Cql2ElmVisitor` and `CqlPreprocessor`

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -4564,9 +4564,4 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
 
         return tb;
     }
-
-    @Override
-    protected Object defaultResult() {
-        return null;
-    }
 }

--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/preprocessor/CqlPreprocessor.java
@@ -326,9 +326,4 @@ public class CqlPreprocessor extends CqlPreprocessorElmCommonVisitor {
         identifiers.add(identifier);
         return identifiers;
     }
-
-    @Override
-    protected Object defaultResult() {
-        return null;
-    }
 }


### PR DESCRIPTION
`defaultResult` is already defined in the `CqlPreprocessorElmCommonVisitor` as
```
    @Override
    protected Object defaultResult() {
        return null;
    }
```
No need to override again in `Cql2ElmVisitor` and `CqlPreprocessor` (both extend `CqlPreprocessorElmCommonVisitor`) with the same logic.