### PR TITLE
Issue1469: Return false when performing 'in' on valueset with null code

### DIFF
--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/AnyInValueSetEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/AnyInValueSetEvaluator.java
@@ -6,6 +6,10 @@ import org.opencds.cqf.cql.engine.execution.State;
 public class AnyInValueSetEvaluator {
 
     public static Object internalEvaluate(Object codes, ValueSetRef valueSetRef, Object valueset, State state) {
+        if (codes == null) {
+            return false;
+        }
+
         Object vs = null;
         if (valueSetRef != null) {
             vs = ValueSetRefEvaluator.toValueSet(state, valueSetRef);
@@ -13,7 +17,9 @@ public class AnyInValueSetEvaluator {
             vs = valueset;
         }
 
-        if (codes == null || vs == null) return null;
+        if (vs == null) {
+            return null;
+        }
 
         if (codes instanceof Iterable) {
             Object result;

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InValueSetEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InValueSetEvaluator.java
@@ -22,8 +22,10 @@ If the code argument is null, the result is null.
 
 public class InValueSetEvaluator {
     public static Object inValueSet(Object code, Object valueset, State state) {
-
-        if (code == null || valueset == null) {
+        if (code == null) {
+            return false;
+        }
+        if (valueset == null) {
             return null;
         }
 

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/elm/executing/AnyInValueSetEvaluatorTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/elm/executing/AnyInValueSetEvaluatorTest.java
@@ -1,0 +1,25 @@
+package org.opencds.cqf.cql.engine.elm.executing;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.hl7.elm.r1.ValueSetRef;
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.execution.Environment;
+import org.opencds.cqf.cql.engine.execution.State;
+import org.opencds.cqf.cql.engine.runtime.ValueSet;
+
+public class AnyInValueSetEvaluatorTest {
+
+    @Test
+    void issue1469FalseOnNullCode() {
+        var env = new Environment(null);
+        var state = new State(env);
+        var valueSet = new ValueSet();
+        var valueSetRef = new ValueSetRef();
+
+        Object actual = AnyInValueSetEvaluator.internalEvaluate(null, valueSetRef, valueSet, state);
+        assertInstanceOf(Boolean.class, actual);
+        assertFalse((Boolean) actual);
+    }
+}

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/elm/executing/InValueSetEvaluatorTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/elm/executing/InValueSetEvaluatorTest.java
@@ -1,0 +1,23 @@
+package org.opencds.cqf.cql.engine.elm.executing;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+import org.opencds.cqf.cql.engine.execution.Environment;
+import org.opencds.cqf.cql.engine.execution.State;
+import org.opencds.cqf.cql.engine.runtime.ValueSet;
+
+public class InValueSetEvaluatorTest {
+
+    @Test
+    void issue1469FalseOnNullCode() {
+        var env = new Environment(null);
+        var state = new State(env);
+        var valueSet = new ValueSet();
+
+        Object actual = InValueSetEvaluator.inValueSet(null, valueSet, state);
+        assertInstanceOf(Boolean.class, actual);
+        assertFalse((Boolean) actual);
+    }
+}


### PR DESCRIPTION
- Updates InValueSetEvaluator and AnyInValuSetEvaluator to the current spec behavior round null code's, as described in https://github.com/cqframework/clinical_quality_language/issues/1469

This is my first time trying to put up a pr for the project, so if there are additional steps i should be taking, i'm more than willing to learn!