### PR TITLE
Change default signature level from None to Overloads

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlCompilerOptions.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/CqlCompilerOptions.java
@@ -29,7 +29,7 @@ public class CqlCompilerOptions {
     private boolean enableCqlOnly = false;
     private String compatibilityLevel = "1.5";
     private CqlCompilerException.ErrorSeverity errorLevel = CqlCompilerException.ErrorSeverity.Info;
-    private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
+    private LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.Overloads;
     private boolean analyzeDataRequirements = false;
     private boolean collapseDataRequirements = false;
 

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/options.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/options.json
@@ -1,1 +1,1 @@
-{"options":["EnableAnnotations","EnableLocators","DisableListDemotion","DisableListPromotion"],"formats":[ "XML"],"validateUnits":true,"verifyOnly":false,"errorLevel":"Info","signatureLevel":"None"}
+{"options":["EnableAnnotations","EnableLocators","DisableListDemotion","DisableListPromotion"],"formats":[ "XML"],"validateUnits":true,"verifyOnly":false,"errorLevel":"Info","signatureLevel":"Overloads"}

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFHIRHelpers.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFHIRHelpers.java
@@ -36,7 +36,8 @@ class TestFHIRHelpers extends FhirExecutionTestBase {
         var badOptionsEngine = new CqlEngine(new Environment(libraryManager));
         badOptionsEngine.getEnvironment().registerDataProvider("http://hl7.org/fhir", r4Provider);
 
-        assertThrows(CqlException.class, () -> badOptionsEngine.evaluate(library.getIdentifier()));
+        var identifier = library.getIdentifier();
+        assertThrows(CqlException.class, () -> badOptionsEngine.evaluate(identifier));
     }
 
     @Test


### PR DESCRIPTION
* The `None` default for Signature level can cause the CQL compiler to generate ELM that's ambiguous at runtime. This PR changes the default to the minimum level to ensure the generated ELM is unambiguous for overloads.