### PR TITLE
Prep for retiring Jackson-flavored ELM

### DIFF
--- a/Src/java/buildSrc/src/main/groovy/cql.java-conventions.gradle
+++ b/Src/java/buildSrc/src/main/groovy/cql.java-conventions.gradle
@@ -25,12 +25,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation 'org.slf4j:slf4j-api:2.0.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'uk.co.datumedge:hamcrest-json:0.2'
 	testImplementation(platform('org.junit:junit-bom:5.10.2'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.13'
 
     // These are JAXB dependencies excluded because the libraries need to work
     // on Android. But for test purposes we use them pretty much everywhere.

--- a/Src/java/buildSrc/src/main/groovy/cql.xjc-conventions.gradle
+++ b/Src/java/buildSrc/src/main/groovy/cql.xjc-conventions.gradle
@@ -17,7 +17,7 @@ dependencies {
     xjc 'org.glassfish.jaxb:jaxb-xjc:3.0.2'
     xjc 'org.glassfish.jaxb:jaxb-runtime:4.0.3'
     xjc 'org.eclipse.persistence:org.eclipse.persistence.moxy:4.0.2'
-    xjc 'org.slf4j:slf4j-simple:1.7.36'
+    xjc 'org.slf4j:slf4j-simple:2.0.13'
     api 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.1'
     api 'codes.rafael.jaxb2_commons:jaxb2-basics-runtime:3.0.0'
 }

--- a/Src/java/cql-to-elm-cli/build.gradle
+++ b/Src/java/cql-to-elm-cli/build.gradle
@@ -14,11 +14,9 @@ dependencies {
     implementation project(':model-jaxb')
     implementation project(':elm-jaxb')
     implementation 'net.sf.jopt-simple:jopt-simple:4.7'
-    implementation 'org.slf4j:slf4j-simple:1.7.36'
+    implementation 'org.slf4j:slf4j-simple:2.0.13'
     implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.5'
     implementation 'org.eclipse.persistence:org.eclipse.persistence.moxy:4.0.2'
     testImplementation project(':model-jaxb')
-    testImplementation project(':model-jackson')
     testImplementation project(':elm-jaxb')
-    testImplementation project(':elm-jackson')
 }

--- a/Src/java/cql-to-elm/build.gradle
+++ b/Src/java/cql-to-elm/build.gradle
@@ -19,10 +19,11 @@ dependencies {
     // libraries such that we could swap out jackson for something else. In the meantime, these are
     // "implementation" dependencies so that they are not exported downstream.
     implementation "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:${jacksonVersion}"
-    testImplementation project(':elm-jackson')
-    testImplementation project(':model-jackson')
+    testImplementation project(':elm-jaxb')
+    testImplementation project(':model-jaxb')
     testImplementation project(':quick')
     testImplementation project(':qdm')
+    testImplementation 'org.xmlunit:xmlunit-assertj:2.10.0'
     testImplementation 'com.github.reinert:jjschema:1.16'
     testImplementation 'com.tngtech.archunit:archunit:1.2.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'

--- a/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
+++ b/Src/java/cql-to-elm/src/test/java/org/cqframework/cql/cql2elm/CMS146XmlTest.java
@@ -1,8 +1,5 @@
 package org.cqframework.cql.cql2elm;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -13,6 +10,7 @@ import org.cqframework.cql.cql2elm.CqlCompilerException.ErrorSeverity;
 import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.xmlunit.assertj.XmlAssert;
 
 class CMS146XmlTest {
 
@@ -37,7 +35,8 @@ class CMS146XmlTest {
                 new LibraryManager(
                         modelManager, new CqlCompilerOptions(ErrorSeverity.Warning, expectedSignatureLevel)));
         final String actualXml = translator.toXml().trim();
-        assertThat(actualXml, equalTo(expectedXml));
+
+        XmlAssert.assertThat(actualXml).and(expectedXml).ignoreWhitespace().areIdentical();
     }
 
     private static String getXml(String name) throws IOException {

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.json
@@ -1,898 +1,10 @@
 {
   "library" : {
-    "type" : "Library",
-    "identifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "CMS146",
-      "version" : "2"
-    },
-    "schemaIdentifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "urn:hl7-org:elm",
-      "version" : "r1"
-    },
-    "usings" : {
-      "type" : "Library$Usings",
-      "def" : [ {
-        "type" : "UsingDef",
-        "localIdentifier" : "System",
-        "uri" : "urn:hl7-org:elm-types:r1"
-      }, {
-        "type" : "UsingDef",
-        "localIdentifier" : "QUICK",
-        "uri" : "http://hl7.org/fhir"
-      } ]
-    },
-    "parameters" : {
-      "type" : "Library$Parameters",
-      "def" : [ {
-        "type" : "ParameterDef",
-        "default" : {
-          "type" : "Interval",
-          "low" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2013"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ]
-          },
-          "high" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2014"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ]
-          },
-          "lowClosed" : true,
-          "highClosed" : false
-        },
-        "name" : "MeasurementPeriod",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "valueSets" : {
-      "type" : "Library$ValueSets",
-      "def" : [ {
-        "type" : "ValueSetDef",
-        "name" : "Acute Pharyngitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Acute Tonsillitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Ambulatory/ED Visit",
-        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Antibiotic Medications",
-        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Group A Streptococcus Test",
-        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "contexts" : {
-      "type" : "Library$Contexts",
-      "def" : [ {
-        "type" : "ContextDef",
-        "name" : "Patient"
-      } ]
-    },
-    "statements" : {
-      "type" : "Library$Statements",
-      "def" : [ {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "SingletonFrom",
-          "operand" : {
-            "type" : "Retrieve",
-            "dataType" : "{http://hl7.org/fhir}Patient",
-            "templateId" : "patient-qicore-qicore-patient"
-          }
-        },
-        "name" : "Patient",
-        "context" : "Patient"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "signature" : [ {
-            "type" : "NamedTypeSpecifier",
-            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-          }, {
-            "type" : "NamedTypeSpecifier",
-            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-          } ],
-          "operand" : [ {
-            "type" : "GreaterOrEqual",
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ],
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              } ],
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "signature" : [ {
-                  "type" : "IntervalTypeSpecifier",
-                  "pointType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }
-                } ],
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2"
-            } ]
-          }, {
-            "type" : "Less",
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ],
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              } ],
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "signature" : [ {
-                  "type" : "IntervalTypeSpecifier",
-                  "pointType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }
-                } ],
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "18"
-            } ]
-          } ]
-        },
-        "name" : "InDemographic",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Union",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Condition"
-            }
-          }, {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Condition"
-            }
-          } ],
-          "operand" : [ {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Pharyngitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          }, {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Tonsillitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          } ]
-        },
-        "name" : "Pharyngitis",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Retrieve",
-          "codes" : {
-            "type" : "ValueSetRef",
-            "name" : "Antibiotic Medications",
-            "preserve" : true
-          },
-          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
-          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
-          "codeProperty" : "medication.code",
-          "codeComparator" : "in"
-        },
-        "name" : "Antibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "Retrieve",
-              "codes" : {
-                "type" : "ValueSetRef",
-                "name" : "Ambulatory/ED Visit",
-                "preserve" : true
-              },
-              "dataType" : "{http://hl7.org/fhir}Encounter",
-              "templateId" : "encounter-qicore-qicore-encounter",
-              "codeProperty" : "type",
-              "codeComparator" : "in"
-            },
-            "alias" : "E"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "signature" : [ {
-                "type" : "IntervalTypeSpecifier",
-                "pointType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }
-              }, {
-                "type" : "IntervalTypeSpecifier",
-                "pointType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }
-              } ],
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "P"
-          }, {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Antibiotics"
-            },
-            "suchThat" : {
-              "type" : "And",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-              } ],
-              "operand" : [ {
-                "type" : "In",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }, {
-                  "type" : "IntervalTypeSpecifier",
-                  "pointType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }
-                } ],
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "dateWritten",
-                  "scope" : "A"
-                }, {
-                  "type" : "Interval",
-                  "low" : {
-                    "type" : "Start",
-                    "signature" : [ {
-                      "type" : "IntervalTypeSpecifier",
-                      "pointType" : {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                      }
-                    } ],
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  },
-                  "high" : {
-                    "type" : "Add",
-                    "signature" : [ {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                    }, {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}Quantity"
-                    } ],
-                    "operand" : [ {
-                      "type" : "Start",
-                      "signature" : [ {
-                        "type" : "IntervalTypeSpecifier",
-                        "pointType" : {
-                          "type" : "NamedTypeSpecifier",
-                          "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                        }
-                      } ],
-                      "operand" : {
-                        "type" : "Property",
-                        "path" : "period",
-                        "scope" : "E"
-                      }
-                    }, {
-                      "type" : "Quantity",
-                      "value" : 3,
-                      "unit" : "days"
-                    } ]
-                  },
-                  "lowClosed" : false,
-                  "highClosed" : true
-                } ]
-              }, {
-                "type" : "Not",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-                } ],
-                "operand" : {
-                  "type" : "IsNull",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}Any"
-                  } ],
-                  "operand" : {
-                    "type" : "Start",
-                    "signature" : [ {
-                      "type" : "IntervalTypeSpecifier",
-                      "pointType" : {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                      }
-                    } ],
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  }
-                }
-              } ]
-            },
-            "alias" : "A"
-          } ],
-          "where" : {
-            "type" : "IncludedIn",
-            "signature" : [ {
-              "type" : "IntervalTypeSpecifier",
-              "pointType" : {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }
-            }, {
-              "type" : "IntervalTypeSpecifier",
-              "pointType" : {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }
-            } ],
-            "operand" : [ {
-              "type" : "Property",
-              "path" : "period",
-              "scope" : "E"
-            }, {
-              "type" : "ParameterRef",
-              "name" : "MeasurementPeriod"
-            } ]
-          }
-        },
-        "name" : "TargetEncounters",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "alias" : "P"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "TargetEncounters"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "signature" : [ {
-                "type" : "IntervalTypeSpecifier",
-                "pointType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }
-              }, {
-                "type" : "IntervalTypeSpecifier",
-                "pointType" : {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }
-              } ],
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "E"
-          } ]
-        },
-        "name" : "TargetDiagnoses",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}MedicationPrescription"
-            }
-          } ],
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "Antibiotics"
-              },
-              "alias" : "A"
-            } ],
-            "relationship" : [ {
-              "type" : "With",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "TargetDiagnoses"
-              },
-              "suchThat" : {
-                "type" : "And",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-                }, {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-                } ],
-                "operand" : [ {
-                  "type" : "In",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }, {
-                    "type" : "IntervalTypeSpecifier",
-                    "pointType" : {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                    }
-                  } ],
-                  "operand" : [ {
-                    "type" : "Property",
-                    "path" : "dateWritten",
-                    "scope" : "A"
-                  }, {
-                    "type" : "Interval",
-                    "low" : {
-                      "type" : "Subtract",
-                      "signature" : [ {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                      }, {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}Quantity"
-                      } ],
-                      "operand" : [ {
-                        "type" : "Property",
-                        "path" : "onsetDateTime",
-                        "scope" : "D"
-                      }, {
-                        "type" : "Quantity",
-                        "value" : 30,
-                        "unit" : "days"
-                      } ]
-                    },
-                    "high" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    },
-                    "lowClosed" : true,
-                    "highClosed" : false
-                  } ]
-                }, {
-                  "type" : "Not",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-                  } ],
-                  "operand" : {
-                    "type" : "IsNull",
-                    "signature" : [ {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}Any"
-                    } ],
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    }
-                  }
-                } ]
-              },
-              "alias" : "D"
-            } ]
-          }
-        },
-        "name" : "HasPriorAntibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Encounter"
-            }
-          } ],
-          "operand" : {
-            "type" : "ExpressionRef",
-            "name" : "TargetEncounters"
-          }
-        },
-        "name" : "HasTargetEncounter",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "signature" : [ {
-            "type" : "NamedTypeSpecifier",
-            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-          }, {
-            "type" : "NamedTypeSpecifier",
-            "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-          } ],
-          "operand" : [ {
-            "type" : "ExpressionRef",
-            "name" : "InDemographic"
-          }, {
-            "type" : "ExpressionRef",
-            "name" : "HasTargetEncounter"
-          } ]
-        },
-        "name" : "InInitialPopulation",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Literal",
-          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
-          "value" : "true"
-        },
-        "name" : "InDenominator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "ExpressionRef",
-          "name" : "HasPriorAntibiotics"
-        },
-        "name" : "InDenominatorExclusions",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Observation"
-            }
-          } ],
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "Retrieve",
-                "codes" : {
-                  "type" : "ValueSetRef",
-                  "name" : "Group A Streptococcus Test",
-                  "preserve" : true
-                },
-                "dataType" : "{http://hl7.org/fhir}Observation",
-                "templateId" : "observation-qicore-qicore-observation",
-                "codeProperty" : "code",
-                "codeComparator" : "in"
-              },
-              "alias" : "R"
-            } ],
-            "where" : {
-              "type" : "And",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-              } ],
-              "operand" : [ {
-                "type" : "In",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }, {
-                  "type" : "IntervalTypeSpecifier",
-                  "pointType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }
-                } ],
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "issued",
-                  "scope" : "R"
-                }, {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                } ]
-              }, {
-                "type" : "Not",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}Boolean"
-                } ],
-                "operand" : {
-                  "type" : "IsNull",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}Any"
-                  } ],
-                  "operand" : {
-                    "type" : "Property",
-                    "path" : "valueQuantity",
-                    "scope" : "R"
-                  }
-                }
-              } ]
-            }
-          }
-        },
-        "name" : "InNumerator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      } ]
-    },
     "annotation" : [ {
-      "type" : "CqlToElmInfo",
       "translatorOptions" : "",
-      "signatureLevel" : "All"
+      "signatureLevel" : "All",
+      "type" : "CqlToElmInfo"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -901,9 +13,9 @@
       "endChar" : 54,
       "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -912,7 +24,1118 @@
       "endChar" : 54,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    } ]
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
+    } ],
+    "identifier" : {
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir",
+        "annotation" : [ ]
+      } ]
+    },
+    "parameters" : {
+      "def" : [ {
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "default" : {
+          "lowClosed" : true,
+          "highClosed" : false,
+          "type" : "Interval",
+          "annotation" : [ ],
+          "low" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          }
+        }
+      } ]
+    },
+    "valueSets" : {
+      "def" : [ {
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ {
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "type" : "NamedTypeSpecifier",
+            "annotation" : [ ]
+          }, {
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "type" : "NamedTypeSpecifier",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "type" : "IntervalTypeSpecifier",
+                  "annotation" : [ ],
+                  "pointType" : {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }
+                } ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Less",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "type" : "IntervalTypeSpecifier",
+                  "annotation" : [ ],
+                  "pointType" : {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }
+                } ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Union",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Condition",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          }, {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Condition",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : [ {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Pharyngitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }, {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Tonsillitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in",
+          "type" : "Retrieve",
+          "annotation" : [ ],
+          "codes" : {
+            "name" : "Antibiotic Medications",
+            "preserve" : true,
+            "type" : "ValueSetRef",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "E",
+            "annotation" : [ ],
+            "expression" : {
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in",
+              "type" : "Retrieve",
+              "annotation" : [ ],
+              "codes" : {
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true,
+                "type" : "ValueSetRef",
+                "annotation" : [ ]
+              },
+              "include" : [ ],
+              "codeFilter" : [ ],
+              "dateFilter" : [ ],
+              "otherFilter" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "P",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ {
+                "type" : "IntervalTypeSpecifier",
+                "annotation" : [ ],
+                "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "IntervalTypeSpecifier",
+                "annotation" : [ ],
+                "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }
+              } ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          }, {
+            "alias" : "A",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Antibiotics",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "annotation" : [ ],
+                  "pointType" : {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }
+                } ],
+                "operand" : [ {
+                  "path" : "dateWritten",
+                  "scope" : "A",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "lowClosed" : false,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "annotation" : [ ],
+                  "low" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "type" : "IntervalTypeSpecifier",
+                      "annotation" : [ ],
+                      "pointType" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      }
+                    } ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    }, {
+                      "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    } ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "annotation" : [ ],
+                      "signature" : [ {
+                        "type" : "IntervalTypeSpecifier",
+                        "annotation" : [ ],
+                        "pointType" : {
+                          "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                          "type" : "NamedTypeSpecifier",
+                          "annotation" : [ ]
+                        }
+                      } ],
+                      "operand" : {
+                        "path" : "period",
+                        "scope" : "E",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }
+                    }, {
+                      "value" : 3,
+                      "unit" : "days",
+                      "type" : "Quantity",
+                      "annotation" : [ ]
+                    } ]
+                  }
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                } ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}Any",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  } ],
+                  "operand" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "type" : "IntervalTypeSpecifier",
+                      "annotation" : [ ],
+                      "pointType" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      }
+                    } ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                }
+              } ]
+            }
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "IntervalTypeSpecifier",
+              "annotation" : [ ],
+              "pointType" : {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }
+            }, {
+              "type" : "IntervalTypeSpecifier",
+              "annotation" : [ ],
+              "pointType" : {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }
+            } ],
+            "operand" : [ {
+              "path" : "period",
+              "scope" : "E",
+              "type" : "Property",
+              "annotation" : [ ]
+            }, {
+              "name" : "MeasurementPeriod",
+              "type" : "ParameterRef",
+              "annotation" : [ ]
+            } ]
+          }
+        }
+      }, {
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "P",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "E",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "TargetEncounters",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ {
+                "type" : "IntervalTypeSpecifier",
+                "annotation" : [ ],
+                "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "IntervalTypeSpecifier",
+                "annotation" : [ ],
+                "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }
+              } ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          } ]
+        }
+      }, {
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}MedicationPrescription",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "A",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "Antibiotics",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ {
+              "alias" : "D",
+              "type" : "With",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "TargetDiagnoses",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              },
+              "suchThat" : {
+                "type" : "And",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }, {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                } ],
+                "operand" : [ {
+                  "type" : "In",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }, {
+                    "type" : "IntervalTypeSpecifier",
+                    "annotation" : [ ],
+                    "pointType" : {
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    }
+                  } ],
+                  "operand" : [ {
+                    "path" : "dateWritten",
+                    "scope" : "A",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }, {
+                    "lowClosed" : true,
+                    "highClosed" : false,
+                    "type" : "Interval",
+                    "annotation" : [ ],
+                    "low" : {
+                      "type" : "Subtract",
+                      "annotation" : [ ],
+                      "signature" : [ {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      }, {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      } ],
+                      "operand" : [ {
+                        "path" : "onsetDateTime",
+                        "scope" : "D",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }, {
+                        "value" : 30,
+                        "unit" : "days",
+                        "type" : "Quantity",
+                        "annotation" : [ ]
+                      } ]
+                    },
+                    "high" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  } ],
+                  "operand" : {
+                    "type" : "IsNull",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "name" : "{urn:hl7-org:elm-types:r1}Any",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    } ],
+                    "operand" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                } ]
+              }
+            } ]
+          }
+        }
+      }, {
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Encounter",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : {
+            "name" : "TargetEncounters",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }
+        }
+      }, {
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ {
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "type" : "NamedTypeSpecifier",
+            "annotation" : [ ]
+          }, {
+            "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "type" : "NamedTypeSpecifier",
+            "annotation" : [ ]
+          } ],
+          "operand" : [ {
+            "name" : "InDemographic",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }, {
+            "name" : "HasTargetEncounter",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true",
+          "type" : "Literal",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "name" : "HasPriorAntibiotics",
+          "type" : "ExpressionRef",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Observation",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "R",
+              "annotation" : [ ],
+              "expression" : {
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in",
+                "type" : "Retrieve",
+                "annotation" : [ ],
+                "codes" : {
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true,
+                  "type" : "ValueSetRef",
+                  "annotation" : [ ]
+                },
+                "include" : [ ],
+                "codeFilter" : [ ],
+                "dateFilter" : [ ],
+                "otherFilter" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "annotation" : [ ],
+                  "pointType" : {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }
+                } ],
+                "operand" : [ {
+                  "path" : "issued",
+                  "scope" : "R",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                } ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}Any",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  } ],
+                  "operand" : {
+                    "path" : "valueQuantity",
+                    "scope" : "R",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }
+                }
+              } ]
+            }
+          }
+        }
+      } ]
+    }
   }
 }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_All.xml
@@ -1,460 +1,330 @@
-<?xml version='1.1' encoding='UTF-8'?>
-<Library type="Library">
-  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
-  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
-  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
-    <wstxns3:def>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
-    </wstxns3:def>
-  </wstxns3:usings>
-  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
-    <wstxns4:def>
-      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
-        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
-          <wstxns4:low wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:signature>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-            </wstxns4:signature>
-          </wstxns4:low>
-          <wstxns4:high wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:signature>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              <wstxns4:signature wstxns4:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-            </wstxns4:signature>
-          </wstxns4:high>
-        </wstxns4:default>
-      </wstxns4:def>
-    </wstxns4:def>
-  </wstxns4:parameters>
-  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
-    <wstxns5:def>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
-    </wstxns5:def>
-  </wstxns5:valueSets>
-  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
-    <wstxns6:def>
-      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
-    </wstxns6:def>
-  </wstxns6:contexts>
-  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
-    <wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
-        <wstxns7:expression wstxns7:type="SingletonFrom">
-          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-          </wstxns7:signature>
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="GreaterOrEqual">
-              <wstxns7:signature>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              </wstxns7:signature>
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        </wstxns7:signature>
-                      </wstxns7:signature>
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Less">
-              <wstxns7:signature>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              </wstxns7:signature>
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        </wstxns7:signature>
-                      </wstxns7:signature>
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Union">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Condition"/>
-            </wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Condition"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
-          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
-              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
-                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
-              </wstxns7:expression>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:signature>
-                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                </wstxns7:signature>
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="A">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              <wstxns7:suchThat wstxns7:type="And">
-                <wstxns7:signature>
-                  <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                  <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                </wstxns7:signature>
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="In">
-                    <wstxns7:signature>
-                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                      <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                        <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                      </wstxns7:signature>
-                    </wstxns7:signature>
-                    <wstxns7:operand>
-                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
-                        <wstxns7:low wstxns7:type="Start">
-                          <wstxns7:signature>
-                            <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                              <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                            </wstxns7:signature>
-                          </wstxns7:signature>
-                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                        </wstxns7:low>
-                        <wstxns7:high wstxns7:type="Add">
-                          <wstxns7:signature>
-                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
-                          </wstxns7:signature>
-                          <wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Start">
-                              <wstxns7:signature>
-                                <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                                  <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                                </wstxns7:signature>
-                              </wstxns7:signature>
-                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                            </wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
-                          </wstxns7:operand>
-                        </wstxns7:high>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Not">
-                    <wstxns7:signature>
-                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                    </wstxns7:signature>
-                    <wstxns7:operand wstxns7:type="IsNull">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                      </wstxns7:signature>
-                      <wstxns7:operand wstxns7:type="Start">
-                        <wstxns7:signature>
-                          <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                            <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                          </wstxns7:signature>
-                        </wstxns7:signature>
-                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-          <wstxns7:where wstxns7:type="IncludedIn">
-            <wstxns7:signature>
-              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-              </wstxns7:signature>
-              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-              </wstxns7:signature>
-            </wstxns7:signature>
-            <wstxns7:operand>
-              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-            </wstxns7:operand>
-          </wstxns7:where>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="E">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:signature>
-                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                    <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                </wstxns7:signature>
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}MedicationPrescription"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:relationship>
-              <wstxns7:relationship wstxns7:type="With" alias="D">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
-                <wstxns7:suchThat wstxns7:type="And">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="In">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        </wstxns7:signature>
-                      </wstxns7:signature>
-                      <wstxns7:operand>
-                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
-                          <wstxns7:low wstxns7:type="Subtract">
-                            <wstxns7:signature>
-                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
-                            </wstxns7:signature>
-                            <wstxns7:operand>
-                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
-                            </wstxns7:operand>
-                          </wstxns7:low>
-                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                        </wstxns7:operand>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Not">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                      </wstxns7:signature>
-                      <wstxns7:operand wstxns7:type="IsNull">
-                        <wstxns7:signature>
-                          <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                        </wstxns7:signature>
-                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:suchThat>
-              </wstxns7:relationship>
-            </wstxns7:relationship>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Encounter"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-          </wstxns7:signature>
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Observation"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
-                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
-                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
-                </wstxns7:expression>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:where wstxns7:type="And">
-              <wstxns7:signature>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-              </wstxns7:signature>
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="In">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                      <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    </wstxns7:signature>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
-                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Not">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Boolean"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand wstxns7:type="IsNull">
-                    <wstxns7:signature>
-                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                    </wstxns7:signature>
-                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:operand>
-            </wstxns7:where>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-    </wstxns7:def>
-  </wstxns7:statements>
-  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
-    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="All"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
-  </wstxns8:annotation>
-</Library>
+<?xml version="1.0" encoding="UTF-8"?>
+<library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
+  <annotation translatorOptions="" signatureLevel="All" xsi:type="a:CqlToElmInfo"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <identifier id="CMS146" version="2"/>
+  <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
+  <usings>
+    <def localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+    <def localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+  </usings>
+  <parameters>
+    <def name="MeasurementPeriod" accessLevel="Public">
+      <default lowClosed="true" highClosed="false" xsi:type="Interval">
+        <low xsi:type="DateTime">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <year valueType="t:Integer" value="2013" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </low>
+        <high xsi:type="DateTime">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <year valueType="t:Integer" value="2014" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </high>
+      </default>
+    </def>
+  </parameters>
+  <valueSets>
+    <def name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+    <def name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+    <def name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+    <def name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+    <def name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+  </valueSets>
+  <contexts>
+    <def name="Patient"/>
+  </contexts>
+  <statements>
+    <def name="Patient" context="Patient">
+      <expression xsi:type="SingletonFrom">
+        <operand dataType="fhir:Patient" templateId="patient-qicore-qicore-patient" xsi:type="Retrieve"/>
+      </expression>
+    </def>
+    <def name="InDemographic" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+        <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+        <operand xsi:type="GreaterOrEqual">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <signature xsi:type="IntervalTypeSpecifier">
+                <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              </signature>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="2" xsi:type="Literal"/>
+        </operand>
+        <operand xsi:type="Less">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <signature xsi:type="IntervalTypeSpecifier">
+                <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              </signature>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="18" xsi:type="Literal"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Pharyngitis" context="Patient" accessLevel="Public">
+      <expression xsi:type="Union">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Condition" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Condition" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Pharyngitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Tonsillitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Antibiotics" context="Patient" accessLevel="Public">
+      <expression dataType="fhir:MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in" xsi:type="Retrieve">
+        <codes name="Antibiotic Medications" preserve="true" xsi:type="ValueSetRef"/>
+      </expression>
+    </def>
+    <def name="TargetEncounters" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="E">
+          <expression dataType="fhir:Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in" xsi:type="Retrieve">
+            <codes name="Ambulatory/ED Visit" preserve="true" xsi:type="ValueSetRef"/>
+          </expression>
+        </source>
+        <relationship alias="P" xsi:type="With">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <signature xsi:type="IntervalTypeSpecifier">
+              <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            </signature>
+            <signature xsi:type="IntervalTypeSpecifier">
+              <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            </signature>
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+        <relationship alias="A" xsi:type="With">
+          <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="And">
+            <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+            <operand xsi:type="In">
+              <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              <signature xsi:type="IntervalTypeSpecifier">
+                <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              </signature>
+              <operand path="dateWritten" scope="A" xsi:type="Property"/>
+              <operand lowClosed="false" highClosed="true" xsi:type="Interval">
+                <low xsi:type="Start">
+                  <signature xsi:type="IntervalTypeSpecifier">
+                    <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                  </signature>
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </low>
+                <high xsi:type="Add">
+                  <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                  <signature name="t:Quantity" xsi:type="NamedTypeSpecifier"/>
+                  <operand xsi:type="Start">
+                    <signature xsi:type="IntervalTypeSpecifier">
+                      <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                    </signature>
+                    <operand path="period" scope="E" xsi:type="Property"/>
+                  </operand>
+                  <operand value="3" unit="days" xsi:type="Quantity"/>
+                </high>
+              </operand>
+            </operand>
+            <operand xsi:type="Not">
+              <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+              <operand xsi:type="IsNull">
+                <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                <operand xsi:type="Start">
+                  <signature xsi:type="IntervalTypeSpecifier">
+                    <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                  </signature>
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </operand>
+          </suchThat>
+        </relationship>
+        <where xsi:type="IncludedIn">
+          <signature xsi:type="IntervalTypeSpecifier">
+            <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+          </signature>
+          <signature xsi:type="IntervalTypeSpecifier">
+            <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+          </signature>
+          <operand path="period" scope="E" xsi:type="Property"/>
+          <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+        </where>
+      </expression>
+    </def>
+    <def name="TargetDiagnoses" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="P">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+        </source>
+        <relationship alias="E" xsi:type="With">
+          <expression name="TargetEncounters" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <signature xsi:type="IntervalTypeSpecifier">
+              <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            </signature>
+            <signature xsi:type="IntervalTypeSpecifier">
+              <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            </signature>
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+      </expression>
+    </def>
+    <def name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:MedicationPrescription" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand xsi:type="Query">
+          <source alias="A">
+            <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          </source>
+          <relationship alias="D" xsi:type="With">
+            <expression name="TargetDiagnoses" xsi:type="ExpressionRef"/>
+            <suchThat xsi:type="And">
+              <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+              <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+              <operand xsi:type="In">
+                <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                <signature xsi:type="IntervalTypeSpecifier">
+                  <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                </signature>
+                <operand path="dateWritten" scope="A" xsi:type="Property"/>
+                <operand lowClosed="true" highClosed="false" xsi:type="Interval">
+                  <low xsi:type="Subtract">
+                    <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                    <signature name="t:Quantity" xsi:type="NamedTypeSpecifier"/>
+                    <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                    <operand value="30" unit="days" xsi:type="Quantity"/>
+                  </low>
+                  <high path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+              <operand xsi:type="Not">
+                <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+                <operand xsi:type="IsNull">
+                  <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                  <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </suchThat>
+          </relationship>
+        </operand>
+      </expression>
+    </def>
+    <def name="HasTargetEncounter" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Encounter" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand name="TargetEncounters" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InInitialPopulation" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+        <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+        <operand name="InDemographic" xsi:type="ExpressionRef"/>
+        <operand name="HasTargetEncounter" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InDenominator" context="Patient" accessLevel="Public">
+      <expression valueType="t:Boolean" value="true" xsi:type="Literal"/>
+    </def>
+    <def name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+      <expression name="HasPriorAntibiotics" xsi:type="ExpressionRef"/>
+    </def>
+    <def name="InNumerator" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Observation" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand xsi:type="Query">
+          <source alias="R">
+            <expression dataType="fhir:Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+              <codes name="Group A Streptococcus Test" preserve="true" xsi:type="ValueSetRef"/>
+            </expression>
+          </source>
+          <where xsi:type="And">
+            <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+            <operand xsi:type="In">
+              <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              <signature xsi:type="IntervalTypeSpecifier">
+                <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              </signature>
+              <operand path="issued" scope="R" xsi:type="Property"/>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+            <operand xsi:type="Not">
+              <signature name="t:Boolean" xsi:type="NamedTypeSpecifier"/>
+              <operand xsi:type="IsNull">
+                <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                <operand path="valueQuantity" scope="R" xsi:type="Property"/>
+              </operand>
+            </operand>
+          </where>
+        </operand>
+      </expression>
+    </def>
+  </statements>
+</library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.json
@@ -1,627 +1,10 @@
 {
   "library" : {
-    "type" : "Library",
-    "identifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "CMS146",
-      "version" : "2"
-    },
-    "schemaIdentifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "urn:hl7-org:elm",
-      "version" : "r1"
-    },
-    "usings" : {
-      "type" : "Library$Usings",
-      "def" : [ {
-        "type" : "UsingDef",
-        "localIdentifier" : "System",
-        "uri" : "urn:hl7-org:elm-types:r1"
-      }, {
-        "type" : "UsingDef",
-        "localIdentifier" : "QUICK",
-        "uri" : "http://hl7.org/fhir"
-      } ]
-    },
-    "parameters" : {
-      "type" : "Library$Parameters",
-      "def" : [ {
-        "type" : "ParameterDef",
-        "default" : {
-          "type" : "Interval",
-          "low" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2013"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "high" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2014"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "lowClosed" : true,
-          "highClosed" : false
-        },
-        "name" : "MeasurementPeriod",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "valueSets" : {
-      "type" : "Library$ValueSets",
-      "def" : [ {
-        "type" : "ValueSetDef",
-        "name" : "Acute Pharyngitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Acute Tonsillitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Ambulatory/ED Visit",
-        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Antibiotic Medications",
-        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Group A Streptococcus Test",
-        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "contexts" : {
-      "type" : "Library$Contexts",
-      "def" : [ {
-        "type" : "ContextDef",
-        "name" : "Patient"
-      } ]
-    },
-    "statements" : {
-      "type" : "Library$Statements",
-      "def" : [ {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "SingletonFrom",
-          "operand" : {
-            "type" : "Retrieve",
-            "dataType" : "{http://hl7.org/fhir}Patient",
-            "templateId" : "patient-qicore-qicore-patient"
-          }
-        },
-        "name" : "Patient",
-        "context" : "Patient"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "GreaterOrEqual",
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2"
-            } ]
-          }, {
-            "type" : "Less",
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "18"
-            } ]
-          } ]
-        },
-        "name" : "InDemographic",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Union",
-          "operand" : [ {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Pharyngitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          }, {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Tonsillitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          } ]
-        },
-        "name" : "Pharyngitis",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Retrieve",
-          "codes" : {
-            "type" : "ValueSetRef",
-            "name" : "Antibiotic Medications",
-            "preserve" : true
-          },
-          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
-          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
-          "codeProperty" : "medication.code",
-          "codeComparator" : "in"
-        },
-        "name" : "Antibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "Retrieve",
-              "codes" : {
-                "type" : "ValueSetRef",
-                "name" : "Ambulatory/ED Visit",
-                "preserve" : true
-              },
-              "dataType" : "{http://hl7.org/fhir}Encounter",
-              "templateId" : "encounter-qicore-qicore-encounter",
-              "codeProperty" : "type",
-              "codeComparator" : "in"
-            },
-            "alias" : "E"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "P"
-          }, {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Antibiotics"
-            },
-            "suchThat" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "dateWritten",
-                  "scope" : "A"
-                }, {
-                  "type" : "Interval",
-                  "low" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  },
-                  "high" : {
-                    "type" : "Add",
-                    "operand" : [ {
-                      "type" : "Start",
-                      "operand" : {
-                        "type" : "Property",
-                        "path" : "period",
-                        "scope" : "E"
-                      }
-                    }, {
-                      "type" : "Quantity",
-                      "value" : 3,
-                      "unit" : "days"
-                    } ]
-                  },
-                  "lowClosed" : false,
-                  "highClosed" : true
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}Any"
-                  } ],
-                  "operand" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  }
-                }
-              } ]
-            },
-            "alias" : "A"
-          } ],
-          "where" : {
-            "type" : "IncludedIn",
-            "operand" : [ {
-              "type" : "Property",
-              "path" : "period",
-              "scope" : "E"
-            }, {
-              "type" : "ParameterRef",
-              "name" : "MeasurementPeriod"
-            } ]
-          }
-        },
-        "name" : "TargetEncounters",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "alias" : "P"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "TargetEncounters"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "E"
-          } ]
-        },
-        "name" : "TargetDiagnoses",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "Antibiotics"
-              },
-              "alias" : "A"
-            } ],
-            "relationship" : [ {
-              "type" : "With",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "TargetDiagnoses"
-              },
-              "suchThat" : {
-                "type" : "And",
-                "operand" : [ {
-                  "type" : "In",
-                  "operand" : [ {
-                    "type" : "Property",
-                    "path" : "dateWritten",
-                    "scope" : "A"
-                  }, {
-                    "type" : "Interval",
-                    "low" : {
-                      "type" : "Subtract",
-                      "operand" : [ {
-                        "type" : "Property",
-                        "path" : "onsetDateTime",
-                        "scope" : "D"
-                      }, {
-                        "type" : "Quantity",
-                        "value" : 30,
-                        "unit" : "days"
-                      } ]
-                    },
-                    "high" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    },
-                    "lowClosed" : true,
-                    "highClosed" : false
-                  } ]
-                }, {
-                  "type" : "Not",
-                  "operand" : {
-                    "type" : "IsNull",
-                    "signature" : [ {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}Any"
-                    } ],
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    }
-                  }
-                } ]
-              },
-              "alias" : "D"
-            } ]
-          }
-        },
-        "name" : "HasPriorAntibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "ExpressionRef",
-            "name" : "TargetEncounters"
-          }
-        },
-        "name" : "HasTargetEncounter",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "ExpressionRef",
-            "name" : "InDemographic"
-          }, {
-            "type" : "ExpressionRef",
-            "name" : "HasTargetEncounter"
-          } ]
-        },
-        "name" : "InInitialPopulation",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Literal",
-          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
-          "value" : "true"
-        },
-        "name" : "InDenominator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "ExpressionRef",
-          "name" : "HasPriorAntibiotics"
-        },
-        "name" : "InDenominatorExclusions",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "Retrieve",
-                "codes" : {
-                  "type" : "ValueSetRef",
-                  "name" : "Group A Streptococcus Test",
-                  "preserve" : true
-                },
-                "dataType" : "{http://hl7.org/fhir}Observation",
-                "templateId" : "observation-qicore-qicore-observation",
-                "codeProperty" : "code",
-                "codeComparator" : "in"
-              },
-              "alias" : "R"
-            } ],
-            "where" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "issued",
-                  "scope" : "R"
-                }, {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}Any"
-                  } ],
-                  "operand" : {
-                    "type" : "Property",
-                    "path" : "valueQuantity",
-                    "scope" : "R"
-                  }
-                }
-              } ]
-            }
-          }
-        },
-        "name" : "InNumerator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      } ]
-    },
     "annotation" : [ {
-      "type" : "CqlToElmInfo",
       "translatorOptions" : "",
-      "signatureLevel" : "Differing"
+      "signatureLevel" : "Differing",
+      "type" : "CqlToElmInfo"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -630,9 +13,9 @@
       "endChar" : 54,
       "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -641,7 +24,798 @@
       "endChar" : 54,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    } ]
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
+    } ],
+    "identifier" : {
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir",
+        "annotation" : [ ]
+      } ]
+    },
+    "parameters" : {
+      "def" : [ {
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "default" : {
+          "lowClosed" : true,
+          "highClosed" : false,
+          "type" : "Interval",
+          "annotation" : [ ],
+          "low" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          }
+        }
+      } ]
+    },
+    "valueSets" : {
+      "def" : [ {
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Less",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Union",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Pharyngitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }, {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Tonsillitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in",
+          "type" : "Retrieve",
+          "annotation" : [ ],
+          "codes" : {
+            "name" : "Antibiotic Medications",
+            "preserve" : true,
+            "type" : "ValueSetRef",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "E",
+            "annotation" : [ ],
+            "expression" : {
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in",
+              "type" : "Retrieve",
+              "annotation" : [ ],
+              "codes" : {
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true,
+                "type" : "ValueSetRef",
+                "annotation" : [ ]
+              },
+              "include" : [ ],
+              "codeFilter" : [ ],
+              "dateFilter" : [ ],
+              "otherFilter" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "P",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          }, {
+            "alias" : "A",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Antibiotics",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "path" : "dateWritten",
+                  "scope" : "A",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "lowClosed" : false,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "annotation" : [ ],
+                  "low" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "annotation" : [ ],
+                      "signature" : [ ],
+                      "operand" : {
+                        "path" : "period",
+                        "scope" : "E",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }
+                    }, {
+                      "value" : 3,
+                      "unit" : "days",
+                      "type" : "Quantity",
+                      "annotation" : [ ]
+                    } ]
+                  }
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}Any",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  } ],
+                  "operand" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                }
+              } ]
+            }
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "path" : "period",
+              "scope" : "E",
+              "type" : "Property",
+              "annotation" : [ ]
+            }, {
+              "name" : "MeasurementPeriod",
+              "type" : "ParameterRef",
+              "annotation" : [ ]
+            } ]
+          }
+        }
+      }, {
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "P",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "E",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "TargetEncounters",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          } ]
+        }
+      }, {
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "A",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "Antibiotics",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ {
+              "alias" : "D",
+              "type" : "With",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "TargetDiagnoses",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              },
+              "suchThat" : {
+                "type" : "And",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "type" : "In",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : [ {
+                    "path" : "dateWritten",
+                    "scope" : "A",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }, {
+                    "lowClosed" : true,
+                    "highClosed" : false,
+                    "type" : "Interval",
+                    "annotation" : [ ],
+                    "low" : {
+                      "type" : "Subtract",
+                      "annotation" : [ ],
+                      "signature" : [ ],
+                      "operand" : [ {
+                        "path" : "onsetDateTime",
+                        "scope" : "D",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }, {
+                        "value" : 30,
+                        "unit" : "days",
+                        "type" : "Quantity",
+                        "annotation" : [ ]
+                      } ]
+                    },
+                    "high" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "type" : "IsNull",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "name" : "{urn:hl7-org:elm-types:r1}Any",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    } ],
+                    "operand" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                } ]
+              }
+            } ]
+          }
+        }
+      }, {
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "name" : "TargetEncounters",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }
+        }
+      }, {
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "name" : "InDemographic",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }, {
+            "name" : "HasTargetEncounter",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true",
+          "type" : "Literal",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "name" : "HasPriorAntibiotics",
+          "type" : "ExpressionRef",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "R",
+              "annotation" : [ ],
+              "expression" : {
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in",
+                "type" : "Retrieve",
+                "annotation" : [ ],
+                "codes" : {
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true,
+                  "type" : "ValueSetRef",
+                  "annotation" : [ ]
+                },
+                "include" : [ ],
+                "codeFilter" : [ ],
+                "dateFilter" : [ ],
+                "otherFilter" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "path" : "issued",
+                  "scope" : "R",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}Any",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  } ],
+                  "operand" : {
+                    "path" : "valueQuantity",
+                    "scope" : "R",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }
+                }
+              } ]
+            }
+          }
+        }
+      } ]
+    }
   }
 }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Differing.xml
@@ -1,299 +1,231 @@
-<?xml version='1.1' encoding='UTF-8'?>
-<Library type="Library">
-  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
-  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
-  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
-    <wstxns3:def>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
-    </wstxns3:def>
-  </wstxns3:usings>
-  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
-    <wstxns4:def>
-      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
-        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
-          <wstxns4:low wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:low>
-          <wstxns4:high wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:high>
-        </wstxns4:default>
-      </wstxns4:def>
-    </wstxns4:def>
-  </wstxns4:parameters>
-  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
-    <wstxns5:def>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
-    </wstxns5:def>
-  </wstxns5:valueSets>
-  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
-    <wstxns6:def>
-      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
-    </wstxns6:def>
-  </wstxns6:contexts>
-  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
-    <wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
-        <wstxns7:expression wstxns7:type="SingletonFrom">
-          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="GreaterOrEqual">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Less">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Union">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
-          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
-              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
-                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
-              </wstxns7:expression>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="A">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              <wstxns7:suchThat wstxns7:type="And">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="In">
-                    <wstxns7:operand>
-                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
-                        <wstxns7:low wstxns7:type="Start">
-                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                        </wstxns7:low>
-                        <wstxns7:high wstxns7:type="Add">
-                          <wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Start">
-                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                            </wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
-                          </wstxns7:operand>
-                        </wstxns7:high>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Not">
-                    <wstxns7:operand wstxns7:type="IsNull">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                      </wstxns7:signature>
-                      <wstxns7:operand wstxns7:type="Start">
-                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-          <wstxns7:where wstxns7:type="IncludedIn">
-            <wstxns7:operand>
-              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-            </wstxns7:operand>
-          </wstxns7:where>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="E">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:relationship>
-              <wstxns7:relationship wstxns7:type="With" alias="D">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
-                <wstxns7:suchThat wstxns7:type="And">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="In">
-                      <wstxns7:operand>
-                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
-                          <wstxns7:low wstxns7:type="Subtract">
-                            <wstxns7:operand>
-                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
-                            </wstxns7:operand>
-                          </wstxns7:low>
-                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                        </wstxns7:operand>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Not">
-                      <wstxns7:operand wstxns7:type="IsNull">
-                        <wstxns7:signature>
-                          <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                        </wstxns7:signature>
-                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:suchThat>
-              </wstxns7:relationship>
-            </wstxns7:relationship>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
-                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
-                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
-                </wstxns7:expression>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:where wstxns7:type="And">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="In">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
-                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Not">
-                  <wstxns7:operand wstxns7:type="IsNull">
-                    <wstxns7:signature>
-                      <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Any"/>
-                    </wstxns7:signature>
-                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:operand>
-            </wstxns7:where>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-    </wstxns7:def>
-  </wstxns7:statements>
-  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
-    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="Differing"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
-  </wstxns8:annotation>
-</Library>
+<?xml version="1.0" encoding="UTF-8"?>
+<library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
+  <annotation translatorOptions="" signatureLevel="Differing" xsi:type="a:CqlToElmInfo"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <identifier id="CMS146" version="2"/>
+  <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
+  <usings>
+    <def localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+    <def localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+  </usings>
+  <parameters>
+    <def name="MeasurementPeriod" accessLevel="Public">
+      <default lowClosed="true" highClosed="false" xsi:type="Interval">
+        <low xsi:type="DateTime">
+          <year valueType="t:Integer" value="2013" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </low>
+        <high xsi:type="DateTime">
+          <year valueType="t:Integer" value="2014" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </high>
+      </default>
+    </def>
+  </parameters>
+  <valueSets>
+    <def name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+    <def name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+    <def name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+    <def name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+    <def name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+  </valueSets>
+  <contexts>
+    <def name="Patient"/>
+  </contexts>
+  <statements>
+    <def name="Patient" context="Patient">
+      <expression xsi:type="SingletonFrom">
+        <operand dataType="fhir:Patient" templateId="patient-qicore-qicore-patient" xsi:type="Retrieve"/>
+      </expression>
+    </def>
+    <def name="InDemographic" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand xsi:type="GreaterOrEqual">
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="2" xsi:type="Literal"/>
+        </operand>
+        <operand xsi:type="Less">
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="18" xsi:type="Literal"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Pharyngitis" context="Patient" accessLevel="Public">
+      <expression xsi:type="Union">
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Pharyngitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Tonsillitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Antibiotics" context="Patient" accessLevel="Public">
+      <expression dataType="fhir:MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in" xsi:type="Retrieve">
+        <codes name="Antibiotic Medications" preserve="true" xsi:type="ValueSetRef"/>
+      </expression>
+    </def>
+    <def name="TargetEncounters" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="E">
+          <expression dataType="fhir:Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in" xsi:type="Retrieve">
+            <codes name="Ambulatory/ED Visit" preserve="true" xsi:type="ValueSetRef"/>
+          </expression>
+        </source>
+        <relationship alias="P" xsi:type="With">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+        <relationship alias="A" xsi:type="With">
+          <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="And">
+            <operand xsi:type="In">
+              <operand path="dateWritten" scope="A" xsi:type="Property"/>
+              <operand lowClosed="false" highClosed="true" xsi:type="Interval">
+                <low xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </low>
+                <high xsi:type="Add">
+                  <operand xsi:type="Start">
+                    <operand path="period" scope="E" xsi:type="Property"/>
+                  </operand>
+                  <operand value="3" unit="days" xsi:type="Quantity"/>
+                </high>
+              </operand>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                <operand xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </operand>
+          </suchThat>
+        </relationship>
+        <where xsi:type="IncludedIn">
+          <operand path="period" scope="E" xsi:type="Property"/>
+          <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+        </where>
+      </expression>
+    </def>
+    <def name="TargetDiagnoses" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="P">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+        </source>
+        <relationship alias="E" xsi:type="With">
+          <expression name="TargetEncounters" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+      </expression>
+    </def>
+    <def name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand xsi:type="Query">
+          <source alias="A">
+            <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          </source>
+          <relationship alias="D" xsi:type="With">
+            <expression name="TargetDiagnoses" xsi:type="ExpressionRef"/>
+            <suchThat xsi:type="And">
+              <operand xsi:type="In">
+                <operand path="dateWritten" scope="A" xsi:type="Property"/>
+                <operand lowClosed="true" highClosed="false" xsi:type="Interval">
+                  <low xsi:type="Subtract">
+                    <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                    <operand value="30" unit="days" xsi:type="Quantity"/>
+                  </low>
+                  <high path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+              <operand xsi:type="Not">
+                <operand xsi:type="IsNull">
+                  <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                  <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </suchThat>
+          </relationship>
+        </operand>
+      </expression>
+    </def>
+    <def name="HasTargetEncounter" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand name="TargetEncounters" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InInitialPopulation" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand name="InDemographic" xsi:type="ExpressionRef"/>
+        <operand name="HasTargetEncounter" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InDenominator" context="Patient" accessLevel="Public">
+      <expression valueType="t:Boolean" value="true" xsi:type="Literal"/>
+    </def>
+    <def name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+      <expression name="HasPriorAntibiotics" xsi:type="ExpressionRef"/>
+    </def>
+    <def name="InNumerator" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand xsi:type="Query">
+          <source alias="R">
+            <expression dataType="fhir:Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+              <codes name="Group A Streptococcus Test" preserve="true" xsi:type="ValueSetRef"/>
+            </expression>
+          </source>
+          <where xsi:type="And">
+            <operand xsi:type="In">
+              <operand path="issued" scope="R" xsi:type="Property"/>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <signature name="t:Any" xsi:type="NamedTypeSpecifier"/>
+                <operand path="valueQuantity" scope="R" xsi:type="Property"/>
+              </operand>
+            </operand>
+          </where>
+        </operand>
+      </expression>
+    </def>
+  </statements>
+</library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.json
@@ -1,615 +1,10 @@
 {
   "library" : {
-    "type" : "Library",
-    "identifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "CMS146",
-      "version" : "2"
-    },
-    "schemaIdentifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "urn:hl7-org:elm",
-      "version" : "r1"
-    },
-    "usings" : {
-      "type" : "Library$Usings",
-      "def" : [ {
-        "type" : "UsingDef",
-        "localIdentifier" : "System",
-        "uri" : "urn:hl7-org:elm-types:r1"
-      }, {
-        "type" : "UsingDef",
-        "localIdentifier" : "QUICK",
-        "uri" : "http://hl7.org/fhir"
-      } ]
-    },
-    "parameters" : {
-      "type" : "Library$Parameters",
-      "def" : [ {
-        "type" : "ParameterDef",
-        "default" : {
-          "type" : "Interval",
-          "low" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2013"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "high" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2014"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "lowClosed" : true,
-          "highClosed" : false
-        },
-        "name" : "MeasurementPeriod",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "valueSets" : {
-      "type" : "Library$ValueSets",
-      "def" : [ {
-        "type" : "ValueSetDef",
-        "name" : "Acute Pharyngitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Acute Tonsillitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Ambulatory/ED Visit",
-        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Antibiotic Medications",
-        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Group A Streptococcus Test",
-        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "contexts" : {
-      "type" : "Library$Contexts",
-      "def" : [ {
-        "type" : "ContextDef",
-        "name" : "Patient"
-      } ]
-    },
-    "statements" : {
-      "type" : "Library$Statements",
-      "def" : [ {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "SingletonFrom",
-          "operand" : {
-            "type" : "Retrieve",
-            "dataType" : "{http://hl7.org/fhir}Patient",
-            "templateId" : "patient-qicore-qicore-patient"
-          }
-        },
-        "name" : "Patient",
-        "context" : "Patient"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "GreaterOrEqual",
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2"
-            } ]
-          }, {
-            "type" : "Less",
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "18"
-            } ]
-          } ]
-        },
-        "name" : "InDemographic",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Union",
-          "operand" : [ {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Pharyngitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          }, {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Tonsillitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          } ]
-        },
-        "name" : "Pharyngitis",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Retrieve",
-          "codes" : {
-            "type" : "ValueSetRef",
-            "name" : "Antibiotic Medications",
-            "preserve" : true
-          },
-          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
-          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
-          "codeProperty" : "medication.code",
-          "codeComparator" : "in"
-        },
-        "name" : "Antibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "Retrieve",
-              "codes" : {
-                "type" : "ValueSetRef",
-                "name" : "Ambulatory/ED Visit",
-                "preserve" : true
-              },
-              "dataType" : "{http://hl7.org/fhir}Encounter",
-              "templateId" : "encounter-qicore-qicore-encounter",
-              "codeProperty" : "type",
-              "codeComparator" : "in"
-            },
-            "alias" : "E"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "P"
-          }, {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Antibiotics"
-            },
-            "suchThat" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "dateWritten",
-                  "scope" : "A"
-                }, {
-                  "type" : "Interval",
-                  "low" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  },
-                  "high" : {
-                    "type" : "Add",
-                    "operand" : [ {
-                      "type" : "Start",
-                      "operand" : {
-                        "type" : "Property",
-                        "path" : "period",
-                        "scope" : "E"
-                      }
-                    }, {
-                      "type" : "Quantity",
-                      "value" : 3,
-                      "unit" : "days"
-                    } ]
-                  },
-                  "lowClosed" : false,
-                  "highClosed" : true
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "operand" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  }
-                }
-              } ]
-            },
-            "alias" : "A"
-          } ],
-          "where" : {
-            "type" : "IncludedIn",
-            "operand" : [ {
-              "type" : "Property",
-              "path" : "period",
-              "scope" : "E"
-            }, {
-              "type" : "ParameterRef",
-              "name" : "MeasurementPeriod"
-            } ]
-          }
-        },
-        "name" : "TargetEncounters",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "alias" : "P"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "TargetEncounters"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "E"
-          } ]
-        },
-        "name" : "TargetDiagnoses",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "Antibiotics"
-              },
-              "alias" : "A"
-            } ],
-            "relationship" : [ {
-              "type" : "With",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "TargetDiagnoses"
-              },
-              "suchThat" : {
-                "type" : "And",
-                "operand" : [ {
-                  "type" : "In",
-                  "operand" : [ {
-                    "type" : "Property",
-                    "path" : "dateWritten",
-                    "scope" : "A"
-                  }, {
-                    "type" : "Interval",
-                    "low" : {
-                      "type" : "Subtract",
-                      "operand" : [ {
-                        "type" : "Property",
-                        "path" : "onsetDateTime",
-                        "scope" : "D"
-                      }, {
-                        "type" : "Quantity",
-                        "value" : 30,
-                        "unit" : "days"
-                      } ]
-                    },
-                    "high" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    },
-                    "lowClosed" : true,
-                    "highClosed" : false
-                  } ]
-                }, {
-                  "type" : "Not",
-                  "operand" : {
-                    "type" : "IsNull",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    }
-                  }
-                } ]
-              },
-              "alias" : "D"
-            } ]
-          }
-        },
-        "name" : "HasPriorAntibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "ExpressionRef",
-            "name" : "TargetEncounters"
-          }
-        },
-        "name" : "HasTargetEncounter",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "ExpressionRef",
-            "name" : "InDemographic"
-          }, {
-            "type" : "ExpressionRef",
-            "name" : "HasTargetEncounter"
-          } ]
-        },
-        "name" : "InInitialPopulation",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Literal",
-          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
-          "value" : "true"
-        },
-        "name" : "InDenominator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "ExpressionRef",
-          "name" : "HasPriorAntibiotics"
-        },
-        "name" : "InDenominatorExclusions",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "Retrieve",
-                "codes" : {
-                  "type" : "ValueSetRef",
-                  "name" : "Group A Streptococcus Test",
-                  "preserve" : true
-                },
-                "dataType" : "{http://hl7.org/fhir}Observation",
-                "templateId" : "observation-qicore-qicore-observation",
-                "codeProperty" : "code",
-                "codeComparator" : "in"
-              },
-              "alias" : "R"
-            } ],
-            "where" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "issued",
-                  "scope" : "R"
-                }, {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "operand" : {
-                    "type" : "Property",
-                    "path" : "valueQuantity",
-                    "scope" : "R"
-                  }
-                }
-              } ]
-            }
-          }
-        },
-        "name" : "InNumerator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      } ]
-    },
     "annotation" : [ {
-      "type" : "CqlToElmInfo",
       "translatorOptions" : "",
-      "signatureLevel" : "None"
+      "signatureLevel" : "None",
+      "type" : "CqlToElmInfo"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -618,9 +13,9 @@
       "endChar" : 54,
       "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -629,7 +24,786 @@
       "endChar" : 54,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    } ]
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
+    } ],
+    "identifier" : {
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir",
+        "annotation" : [ ]
+      } ]
+    },
+    "parameters" : {
+      "def" : [ {
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "default" : {
+          "lowClosed" : true,
+          "highClosed" : false,
+          "type" : "Interval",
+          "annotation" : [ ],
+          "low" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          }
+        }
+      } ]
+    },
+    "valueSets" : {
+      "def" : [ {
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Less",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Union",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Pharyngitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }, {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Tonsillitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in",
+          "type" : "Retrieve",
+          "annotation" : [ ],
+          "codes" : {
+            "name" : "Antibiotic Medications",
+            "preserve" : true,
+            "type" : "ValueSetRef",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "E",
+            "annotation" : [ ],
+            "expression" : {
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in",
+              "type" : "Retrieve",
+              "annotation" : [ ],
+              "codes" : {
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true,
+                "type" : "ValueSetRef",
+                "annotation" : [ ]
+              },
+              "include" : [ ],
+              "codeFilter" : [ ],
+              "dateFilter" : [ ],
+              "otherFilter" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "P",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          }, {
+            "alias" : "A",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Antibiotics",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "path" : "dateWritten",
+                  "scope" : "A",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "lowClosed" : false,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "annotation" : [ ],
+                  "low" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "annotation" : [ ],
+                      "signature" : [ ],
+                      "operand" : {
+                        "path" : "period",
+                        "scope" : "E",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }
+                    }, {
+                      "value" : 3,
+                      "unit" : "days",
+                      "type" : "Quantity",
+                      "annotation" : [ ]
+                    } ]
+                  }
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                }
+              } ]
+            }
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "operand" : [ {
+              "path" : "period",
+              "scope" : "E",
+              "type" : "Property",
+              "annotation" : [ ]
+            }, {
+              "name" : "MeasurementPeriod",
+              "type" : "ParameterRef",
+              "annotation" : [ ]
+            } ]
+          }
+        }
+      }, {
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "P",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "E",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "TargetEncounters",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          } ]
+        }
+      }, {
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "A",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "Antibiotics",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ {
+              "alias" : "D",
+              "type" : "With",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "TargetDiagnoses",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              },
+              "suchThat" : {
+                "type" : "And",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "type" : "In",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : [ {
+                    "path" : "dateWritten",
+                    "scope" : "A",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }, {
+                    "lowClosed" : true,
+                    "highClosed" : false,
+                    "type" : "Interval",
+                    "annotation" : [ ],
+                    "low" : {
+                      "type" : "Subtract",
+                      "annotation" : [ ],
+                      "signature" : [ ],
+                      "operand" : [ {
+                        "path" : "onsetDateTime",
+                        "scope" : "D",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }, {
+                        "value" : 30,
+                        "unit" : "days",
+                        "type" : "Quantity",
+                        "annotation" : [ ]
+                      } ]
+                    },
+                    "high" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "type" : "IsNull",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                } ]
+              }
+            } ]
+          }
+        }
+      }, {
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "name" : "TargetEncounters",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }
+        }
+      }, {
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "name" : "InDemographic",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }, {
+            "name" : "HasTargetEncounter",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true",
+          "type" : "Literal",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "name" : "HasPriorAntibiotics",
+          "type" : "ExpressionRef",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "R",
+              "annotation" : [ ],
+              "expression" : {
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in",
+                "type" : "Retrieve",
+                "annotation" : [ ],
+                "codes" : {
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true,
+                  "type" : "ValueSetRef",
+                  "annotation" : [ ]
+                },
+                "include" : [ ],
+                "codeFilter" : [ ],
+                "dateFilter" : [ ],
+                "otherFilter" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "path" : "issued",
+                  "scope" : "R",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "path" : "valueQuantity",
+                    "scope" : "R",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }
+                }
+              } ]
+            }
+          }
+        }
+      } ]
+    }
   }
 }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_None.xml
@@ -1,290 +1,228 @@
-<?xml version='1.1' encoding='UTF-8'?>
-<Library type="Library">
-  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
-  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
-  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
-    <wstxns3:def>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
-    </wstxns3:def>
-  </wstxns3:usings>
-  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
-    <wstxns4:def>
-      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
-        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
-          <wstxns4:low wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:low>
-          <wstxns4:high wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:high>
-        </wstxns4:default>
-      </wstxns4:def>
-    </wstxns4:def>
-  </wstxns4:parameters>
-  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
-    <wstxns5:def>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
-    </wstxns5:def>
-  </wstxns5:valueSets>
-  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
-    <wstxns6:def>
-      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
-    </wstxns6:def>
-  </wstxns6:contexts>
-  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
-    <wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
-        <wstxns7:expression wstxns7:type="SingletonFrom">
-          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="GreaterOrEqual">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Less">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Union">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
-          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
-              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
-                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
-              </wstxns7:expression>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="A">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              <wstxns7:suchThat wstxns7:type="And">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="In">
-                    <wstxns7:operand>
-                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
-                        <wstxns7:low wstxns7:type="Start">
-                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                        </wstxns7:low>
-                        <wstxns7:high wstxns7:type="Add">
-                          <wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Start">
-                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                            </wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
-                          </wstxns7:operand>
-                        </wstxns7:high>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Not">
-                    <wstxns7:operand wstxns7:type="IsNull">
-                      <wstxns7:operand wstxns7:type="Start">
-                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-          <wstxns7:where wstxns7:type="IncludedIn">
-            <wstxns7:operand>
-              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-            </wstxns7:operand>
-          </wstxns7:where>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="E">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:relationship>
-              <wstxns7:relationship wstxns7:type="With" alias="D">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
-                <wstxns7:suchThat wstxns7:type="And">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="In">
-                      <wstxns7:operand>
-                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
-                          <wstxns7:low wstxns7:type="Subtract">
-                            <wstxns7:operand>
-                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
-                            </wstxns7:operand>
-                          </wstxns7:low>
-                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                        </wstxns7:operand>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Not">
-                      <wstxns7:operand wstxns7:type="IsNull">
-                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:suchThat>
-              </wstxns7:relationship>
-            </wstxns7:relationship>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
-                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
-                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
-                </wstxns7:expression>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:where wstxns7:type="And">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="In">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
-                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Not">
-                  <wstxns7:operand wstxns7:type="IsNull">
-                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:operand>
-            </wstxns7:where>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-    </wstxns7:def>
-  </wstxns7:statements>
-  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
-    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="None"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
-  </wstxns8:annotation>
-</Library>
+<?xml version="1.0" encoding="UTF-8"?>
+<library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
+  <annotation translatorOptions="" signatureLevel="None" xsi:type="a:CqlToElmInfo"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <identifier id="CMS146" version="2"/>
+  <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
+  <usings>
+    <def localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+    <def localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+  </usings>
+  <parameters>
+    <def name="MeasurementPeriod" accessLevel="Public">
+      <default lowClosed="true" highClosed="false" xsi:type="Interval">
+        <low xsi:type="DateTime">
+          <year valueType="t:Integer" value="2013" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </low>
+        <high xsi:type="DateTime">
+          <year valueType="t:Integer" value="2014" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </high>
+      </default>
+    </def>
+  </parameters>
+  <valueSets>
+    <def name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+    <def name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+    <def name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+    <def name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+    <def name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+  </valueSets>
+  <contexts>
+    <def name="Patient"/>
+  </contexts>
+  <statements>
+    <def name="Patient" context="Patient">
+      <expression xsi:type="SingletonFrom">
+        <operand dataType="fhir:Patient" templateId="patient-qicore-qicore-patient" xsi:type="Retrieve"/>
+      </expression>
+    </def>
+    <def name="InDemographic" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand xsi:type="GreaterOrEqual">
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="2" xsi:type="Literal"/>
+        </operand>
+        <operand xsi:type="Less">
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="18" xsi:type="Literal"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Pharyngitis" context="Patient" accessLevel="Public">
+      <expression xsi:type="Union">
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Pharyngitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Tonsillitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Antibiotics" context="Patient" accessLevel="Public">
+      <expression dataType="fhir:MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in" xsi:type="Retrieve">
+        <codes name="Antibiotic Medications" preserve="true" xsi:type="ValueSetRef"/>
+      </expression>
+    </def>
+    <def name="TargetEncounters" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="E">
+          <expression dataType="fhir:Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in" xsi:type="Retrieve">
+            <codes name="Ambulatory/ED Visit" preserve="true" xsi:type="ValueSetRef"/>
+          </expression>
+        </source>
+        <relationship alias="P" xsi:type="With">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+        <relationship alias="A" xsi:type="With">
+          <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="And">
+            <operand xsi:type="In">
+              <operand path="dateWritten" scope="A" xsi:type="Property"/>
+              <operand lowClosed="false" highClosed="true" xsi:type="Interval">
+                <low xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </low>
+                <high xsi:type="Add">
+                  <operand xsi:type="Start">
+                    <operand path="period" scope="E" xsi:type="Property"/>
+                  </operand>
+                  <operand value="3" unit="days" xsi:type="Quantity"/>
+                </high>
+              </operand>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <operand xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </operand>
+          </suchThat>
+        </relationship>
+        <where xsi:type="IncludedIn">
+          <operand path="period" scope="E" xsi:type="Property"/>
+          <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+        </where>
+      </expression>
+    </def>
+    <def name="TargetDiagnoses" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="P">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+        </source>
+        <relationship alias="E" xsi:type="With">
+          <expression name="TargetEncounters" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+      </expression>
+    </def>
+    <def name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand xsi:type="Query">
+          <source alias="A">
+            <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          </source>
+          <relationship alias="D" xsi:type="With">
+            <expression name="TargetDiagnoses" xsi:type="ExpressionRef"/>
+            <suchThat xsi:type="And">
+              <operand xsi:type="In">
+                <operand path="dateWritten" scope="A" xsi:type="Property"/>
+                <operand lowClosed="true" highClosed="false" xsi:type="Interval">
+                  <low xsi:type="Subtract">
+                    <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                    <operand value="30" unit="days" xsi:type="Quantity"/>
+                  </low>
+                  <high path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+              <operand xsi:type="Not">
+                <operand xsi:type="IsNull">
+                  <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </suchThat>
+          </relationship>
+        </operand>
+      </expression>
+    </def>
+    <def name="HasTargetEncounter" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand name="TargetEncounters" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InInitialPopulation" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand name="InDemographic" xsi:type="ExpressionRef"/>
+        <operand name="HasTargetEncounter" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InDenominator" context="Patient" accessLevel="Public">
+      <expression valueType="t:Boolean" value="true" xsi:type="Literal"/>
+    </def>
+    <def name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+      <expression name="HasPriorAntibiotics" xsi:type="ExpressionRef"/>
+    </def>
+    <def name="InNumerator" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand xsi:type="Query">
+          <source alias="R">
+            <expression dataType="fhir:Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+              <codes name="Group A Streptococcus Test" preserve="true" xsi:type="ValueSetRef"/>
+            </expression>
+          </source>
+          <where xsi:type="And">
+            <operand xsi:type="In">
+              <operand path="issued" scope="R" xsi:type="Property"/>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <operand path="valueQuantity" scope="R" xsi:type="Property"/>
+              </operand>
+            </operand>
+          </where>
+        </operand>
+      </expression>
+    </def>
+  </statements>
+</library>

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.json
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.json
@@ -1,704 +1,10 @@
 {
   "library" : {
-    "type" : "Library",
-    "identifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "CMS146",
-      "version" : "2"
-    },
-    "schemaIdentifier" : {
-      "type" : "VersionedIdentifier",
-      "id" : "urn:hl7-org:elm",
-      "version" : "r1"
-    },
-    "usings" : {
-      "type" : "Library$Usings",
-      "def" : [ {
-        "type" : "UsingDef",
-        "localIdentifier" : "System",
-        "uri" : "urn:hl7-org:elm-types:r1"
-      }, {
-        "type" : "UsingDef",
-        "localIdentifier" : "QUICK",
-        "uri" : "http://hl7.org/fhir"
-      } ]
-    },
-    "parameters" : {
-      "type" : "Library$Parameters",
-      "def" : [ {
-        "type" : "ParameterDef",
-        "default" : {
-          "type" : "Interval",
-          "low" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2013"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "high" : {
-            "type" : "DateTime",
-            "year" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2014"
-            },
-            "month" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "day" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "1"
-            },
-            "hour" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "minute" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "second" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            },
-            "millisecond" : {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "0"
-            }
-          },
-          "lowClosed" : true,
-          "highClosed" : false
-        },
-        "name" : "MeasurementPeriod",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "valueSets" : {
-      "type" : "Library$ValueSets",
-      "def" : [ {
-        "type" : "ValueSetDef",
-        "name" : "Acute Pharyngitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Acute Tonsillitis",
-        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Ambulatory/ED Visit",
-        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Antibiotic Medications",
-        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ValueSetDef",
-        "name" : "Group A Streptococcus Test",
-        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
-        "accessLevel" : "Public"
-      } ]
-    },
-    "contexts" : {
-      "type" : "Library$Contexts",
-      "def" : [ {
-        "type" : "ContextDef",
-        "name" : "Patient"
-      } ]
-    },
-    "statements" : {
-      "type" : "Library$Statements",
-      "def" : [ {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "SingletonFrom",
-          "operand" : {
-            "type" : "Retrieve",
-            "dataType" : "{http://hl7.org/fhir}Patient",
-            "templateId" : "patient-qicore-qicore-patient"
-          }
-        },
-        "name" : "Patient",
-        "context" : "Patient"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "GreaterOrEqual",
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ],
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              } ],
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "2"
-            } ]
-          }, {
-            "type" : "Less",
-            "signature" : [ {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            }, {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{urn:hl7-org:elm-types:r1}Integer"
-            } ],
-            "operand" : [ {
-              "type" : "CalculateAgeAt",
-              "signature" : [ {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }, {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              } ],
-              "operand" : [ {
-                "type" : "Property",
-                "source" : {
-                  "type" : "ExpressionRef",
-                  "name" : "Patient"
-                },
-                "path" : "birthDate"
-              }, {
-                "type" : "Start",
-                "operand" : {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                }
-              } ],
-              "precision" : "Year"
-            }, {
-              "type" : "Literal",
-              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-              "value" : "18"
-            } ]
-          } ]
-        },
-        "name" : "InDemographic",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Union",
-          "operand" : [ {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Pharyngitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          }, {
-            "type" : "Retrieve",
-            "codes" : {
-              "type" : "ValueSetRef",
-              "name" : "Acute Tonsillitis",
-              "preserve" : true
-            },
-            "dataType" : "{http://hl7.org/fhir}Condition",
-            "templateId" : "condition-qicore-qicore-condition",
-            "codeProperty" : "code",
-            "codeComparator" : "in"
-          } ]
-        },
-        "name" : "Pharyngitis",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Retrieve",
-          "codes" : {
-            "type" : "ValueSetRef",
-            "name" : "Antibiotic Medications",
-            "preserve" : true
-          },
-          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
-          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
-          "codeProperty" : "medication.code",
-          "codeComparator" : "in"
-        },
-        "name" : "Antibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "Retrieve",
-              "codes" : {
-                "type" : "ValueSetRef",
-                "name" : "Ambulatory/ED Visit",
-                "preserve" : true
-              },
-              "dataType" : "{http://hl7.org/fhir}Encounter",
-              "templateId" : "encounter-qicore-qicore-encounter",
-              "codeProperty" : "type",
-              "codeComparator" : "in"
-            },
-            "alias" : "E"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "P"
-          }, {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Antibiotics"
-            },
-            "suchThat" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "dateWritten",
-                  "scope" : "A"
-                }, {
-                  "type" : "Interval",
-                  "low" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  },
-                  "high" : {
-                    "type" : "Add",
-                    "signature" : [ {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                    }, {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}Quantity"
-                    } ],
-                    "operand" : [ {
-                      "type" : "Start",
-                      "operand" : {
-                        "type" : "Property",
-                        "path" : "period",
-                        "scope" : "E"
-                      }
-                    }, {
-                      "type" : "Quantity",
-                      "value" : 3,
-                      "unit" : "days"
-                    } ]
-                  },
-                  "lowClosed" : false,
-                  "highClosed" : true
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "operand" : {
-                    "type" : "Start",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "period",
-                      "scope" : "E"
-                    }
-                  }
-                }
-              } ]
-            },
-            "alias" : "A"
-          } ],
-          "where" : {
-            "type" : "IncludedIn",
-            "signature" : [ {
-              "type" : "IntervalTypeSpecifier",
-              "pointType" : {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }
-            }, {
-              "type" : "IntervalTypeSpecifier",
-              "pointType" : {
-                "type" : "NamedTypeSpecifier",
-                "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-              }
-            } ],
-            "operand" : [ {
-              "type" : "Property",
-              "path" : "period",
-              "scope" : "E"
-            }, {
-              "type" : "ParameterRef",
-              "name" : "MeasurementPeriod"
-            } ]
-          }
-        },
-        "name" : "TargetEncounters",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Query",
-          "source" : [ {
-            "type" : "AliasedQuerySource",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "Pharyngitis"
-            },
-            "alias" : "P"
-          } ],
-          "relationship" : [ {
-            "type" : "With",
-            "expression" : {
-              "type" : "ExpressionRef",
-              "name" : "TargetEncounters"
-            },
-            "suchThat" : {
-              "type" : "OverlapsAfter",
-              "operand" : [ {
-                "type" : "Interval",
-                "low" : {
-                  "type" : "Property",
-                  "path" : "onsetDateTime",
-                  "scope" : "P"
-                },
-                "high" : {
-                  "type" : "Property",
-                  "path" : "abatementDate",
-                  "scope" : "P"
-                },
-                "lowClosed" : true,
-                "highClosed" : true
-              }, {
-                "type" : "Property",
-                "path" : "period",
-                "scope" : "E"
-              } ]
-            },
-            "alias" : "E"
-          } ]
-        },
-        "name" : "TargetDiagnoses",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "Antibiotics"
-              },
-              "alias" : "A"
-            } ],
-            "relationship" : [ {
-              "type" : "With",
-              "expression" : {
-                "type" : "ExpressionRef",
-                "name" : "TargetDiagnoses"
-              },
-              "suchThat" : {
-                "type" : "And",
-                "operand" : [ {
-                  "type" : "In",
-                  "signature" : [ {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }, {
-                    "type" : "IntervalTypeSpecifier",
-                    "pointType" : {
-                      "type" : "NamedTypeSpecifier",
-                      "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                    }
-                  } ],
-                  "operand" : [ {
-                    "type" : "Property",
-                    "path" : "dateWritten",
-                    "scope" : "A"
-                  }, {
-                    "type" : "Interval",
-                    "low" : {
-                      "type" : "Subtract",
-                      "signature" : [ {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                      }, {
-                        "type" : "NamedTypeSpecifier",
-                        "name" : "{urn:hl7-org:elm-types:r1}Quantity"
-                      } ],
-                      "operand" : [ {
-                        "type" : "Property",
-                        "path" : "onsetDateTime",
-                        "scope" : "D"
-                      }, {
-                        "type" : "Quantity",
-                        "value" : 30,
-                        "unit" : "days"
-                      } ]
-                    },
-                    "high" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    },
-                    "lowClosed" : true,
-                    "highClosed" : false
-                  } ]
-                }, {
-                  "type" : "Not",
-                  "operand" : {
-                    "type" : "IsNull",
-                    "operand" : {
-                      "type" : "Property",
-                      "path" : "onsetDateTime",
-                      "scope" : "D"
-                    }
-                  }
-                } ]
-              },
-              "alias" : "D"
-            } ]
-          }
-        },
-        "name" : "HasPriorAntibiotics",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Encounter"
-            }
-          } ],
-          "operand" : {
-            "type" : "ExpressionRef",
-            "name" : "TargetEncounters"
-          }
-        },
-        "name" : "HasTargetEncounter",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "And",
-          "operand" : [ {
-            "type" : "ExpressionRef",
-            "name" : "InDemographic"
-          }, {
-            "type" : "ExpressionRef",
-            "name" : "HasTargetEncounter"
-          } ]
-        },
-        "name" : "InInitialPopulation",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Literal",
-          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
-          "value" : "true"
-        },
-        "name" : "InDenominator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "ExpressionRef",
-          "name" : "HasPriorAntibiotics"
-        },
-        "name" : "InDenominatorExclusions",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      }, {
-        "type" : "ExpressionDef",
-        "expression" : {
-          "type" : "Exists",
-          "signature" : [ {
-            "type" : "ListTypeSpecifier",
-            "elementType" : {
-              "type" : "NamedTypeSpecifier",
-              "name" : "{http://hl7.org/fhir}Observation"
-            }
-          } ],
-          "operand" : {
-            "type" : "Query",
-            "source" : [ {
-              "type" : "AliasedQuerySource",
-              "expression" : {
-                "type" : "Retrieve",
-                "codes" : {
-                  "type" : "ValueSetRef",
-                  "name" : "Group A Streptococcus Test",
-                  "preserve" : true
-                },
-                "dataType" : "{http://hl7.org/fhir}Observation",
-                "templateId" : "observation-qicore-qicore-observation",
-                "codeProperty" : "code",
-                "codeComparator" : "in"
-              },
-              "alias" : "R"
-            } ],
-            "where" : {
-              "type" : "And",
-              "operand" : [ {
-                "type" : "In",
-                "signature" : [ {
-                  "type" : "NamedTypeSpecifier",
-                  "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                }, {
-                  "type" : "IntervalTypeSpecifier",
-                  "pointType" : {
-                    "type" : "NamedTypeSpecifier",
-                    "name" : "{urn:hl7-org:elm-types:r1}DateTime"
-                  }
-                } ],
-                "operand" : [ {
-                  "type" : "Property",
-                  "path" : "issued",
-                  "scope" : "R"
-                }, {
-                  "type" : "ParameterRef",
-                  "name" : "MeasurementPeriod"
-                } ]
-              }, {
-                "type" : "Not",
-                "operand" : {
-                  "type" : "IsNull",
-                  "operand" : {
-                    "type" : "Property",
-                    "path" : "valueQuantity",
-                    "scope" : "R"
-                  }
-                }
-              } ]
-            }
-          }
-        },
-        "name" : "InNumerator",
-        "context" : "Patient",
-        "accessLevel" : "Public"
-      } ]
-    },
     "annotation" : [ {
-      "type" : "CqlToElmInfo",
       "translatorOptions" : "",
-      "signatureLevel" : "Overloads"
+      "signatureLevel" : "Overloads",
+      "type" : "CqlToElmInfo"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -707,9 +13,9 @@
       "endChar" : 54,
       "message" : "Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
     }, {
-      "type" : "CqlToElmError",
       "libraryId" : "CMS146",
       "libraryVersion" : "2",
       "startLine" : 22,
@@ -718,7 +24,890 @@
       "endChar" : 54,
       "message" : "Could not resolve membership operator for terminology target of the retrieve.",
       "errorType" : "semantic",
-      "errorSeverity" : "warning"
-    } ]
+      "errorSeverity" : "warning",
+      "type" : "CqlToElmError"
+    } ],
+    "identifier" : {
+      "id" : "CMS146",
+      "version" : "2"
+    },
+    "schemaIdentifier" : {
+      "id" : "urn:hl7-org:elm",
+      "version" : "r1"
+    },
+    "usings" : {
+      "def" : [ {
+        "localIdentifier" : "System",
+        "uri" : "urn:hl7-org:elm-types:r1",
+        "annotation" : [ ]
+      }, {
+        "localIdentifier" : "QUICK",
+        "uri" : "http://hl7.org/fhir",
+        "annotation" : [ ]
+      } ]
+    },
+    "parameters" : {
+      "def" : [ {
+        "name" : "MeasurementPeriod",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "default" : {
+          "lowClosed" : true,
+          "highClosed" : false,
+          "type" : "Interval",
+          "annotation" : [ ],
+          "low" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2013",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          },
+          "high" : {
+            "type" : "DateTime",
+            "annotation" : [ ],
+            "signature" : [ ],
+            "year" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2014",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "month" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "day" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "1",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "hour" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "minute" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "second" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            },
+            "millisecond" : {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "0",
+              "type" : "Literal",
+              "annotation" : [ ]
+            }
+          }
+        }
+      } ]
+    },
+    "valueSets" : {
+      "def" : [ {
+        "name" : "Acute Pharyngitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Acute Tonsillitis",
+        "id" : "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Ambulatory/ED Visit",
+        "id" : "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Antibiotic Medications",
+        "id" : "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      }, {
+        "name" : "Group A Streptococcus Test",
+        "id" : "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "codeSystem" : [ ]
+      } ]
+    },
+    "contexts" : {
+      "def" : [ {
+        "name" : "Patient",
+        "annotation" : [ ]
+      } ]
+    },
+    "statements" : {
+      "def" : [ {
+        "name" : "Patient",
+        "context" : "Patient",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "SingletonFrom",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "dataType" : "{http://hl7.org/fhir}Patient",
+            "templateId" : "patient-qicore-qicore-patient",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }
+        }
+      }, {
+        "name" : "InDemographic",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "type" : "GreaterOrEqual",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "2",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          }, {
+            "type" : "Less",
+            "annotation" : [ ],
+            "signature" : [ {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }, {
+              "name" : "{urn:hl7-org:elm-types:r1}Integer",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            } ],
+            "operand" : [ {
+              "precision" : "Year",
+              "type" : "CalculateAgeAt",
+              "annotation" : [ ],
+              "signature" : [ {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }, {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              } ],
+              "operand" : [ {
+                "path" : "birthDate",
+                "type" : "Property",
+                "annotation" : [ ],
+                "source" : {
+                  "name" : "Patient",
+                  "type" : "ExpressionRef",
+                  "annotation" : [ ]
+                }
+              }, {
+                "type" : "Start",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                }
+              } ]
+            }, {
+              "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+              "value" : "18",
+              "type" : "Literal",
+              "annotation" : [ ]
+            } ]
+          } ]
+        }
+      }, {
+        "name" : "Pharyngitis",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Union",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Pharyngitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          }, {
+            "dataType" : "{http://hl7.org/fhir}Condition",
+            "templateId" : "condition-qicore-qicore-condition",
+            "codeProperty" : "code",
+            "codeComparator" : "in",
+            "type" : "Retrieve",
+            "annotation" : [ ],
+            "codes" : {
+              "name" : "Acute Tonsillitis",
+              "preserve" : true,
+              "type" : "ValueSetRef",
+              "annotation" : [ ]
+            },
+            "include" : [ ],
+            "codeFilter" : [ ],
+            "dateFilter" : [ ],
+            "otherFilter" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "Antibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "dataType" : "{http://hl7.org/fhir}MedicationPrescription",
+          "templateId" : "medicationprescription-qicore-qicore-medicationprescription",
+          "codeProperty" : "medication.code",
+          "codeComparator" : "in",
+          "type" : "Retrieve",
+          "annotation" : [ ],
+          "codes" : {
+            "name" : "Antibiotic Medications",
+            "preserve" : true,
+            "type" : "ValueSetRef",
+            "annotation" : [ ]
+          },
+          "include" : [ ],
+          "codeFilter" : [ ],
+          "dateFilter" : [ ],
+          "otherFilter" : [ ]
+        }
+      }, {
+        "name" : "TargetEncounters",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "E",
+            "annotation" : [ ],
+            "expression" : {
+              "dataType" : "{http://hl7.org/fhir}Encounter",
+              "templateId" : "encounter-qicore-qicore-encounter",
+              "codeProperty" : "type",
+              "codeComparator" : "in",
+              "type" : "Retrieve",
+              "annotation" : [ ],
+              "codes" : {
+                "name" : "Ambulatory/ED Visit",
+                "preserve" : true,
+                "type" : "ValueSetRef",
+                "annotation" : [ ]
+              },
+              "include" : [ ],
+              "codeFilter" : [ ],
+              "dateFilter" : [ ],
+              "otherFilter" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "P",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          }, {
+            "alias" : "A",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Antibiotics",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "path" : "dateWritten",
+                  "scope" : "A",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "lowClosed" : false,
+                  "highClosed" : true,
+                  "type" : "Interval",
+                  "annotation" : [ ],
+                  "low" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  },
+                  "high" : {
+                    "type" : "Add",
+                    "annotation" : [ ],
+                    "signature" : [ {
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    }, {
+                      "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    } ],
+                    "operand" : [ {
+                      "type" : "Start",
+                      "annotation" : [ ],
+                      "signature" : [ ],
+                      "operand" : {
+                        "path" : "period",
+                        "scope" : "E",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }
+                    }, {
+                      "value" : 3,
+                      "unit" : "days",
+                      "type" : "Quantity",
+                      "annotation" : [ ]
+                    } ]
+                  }
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "type" : "Start",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "period",
+                      "scope" : "E",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                }
+              } ]
+            }
+          } ],
+          "where" : {
+            "type" : "IncludedIn",
+            "annotation" : [ ],
+            "signature" : [ {
+              "type" : "IntervalTypeSpecifier",
+              "annotation" : [ ],
+              "pointType" : {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }
+            }, {
+              "type" : "IntervalTypeSpecifier",
+              "annotation" : [ ],
+              "pointType" : {
+                "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                "type" : "NamedTypeSpecifier",
+                "annotation" : [ ]
+              }
+            } ],
+            "operand" : [ {
+              "path" : "period",
+              "scope" : "E",
+              "type" : "Property",
+              "annotation" : [ ]
+            }, {
+              "name" : "MeasurementPeriod",
+              "type" : "ParameterRef",
+              "annotation" : [ ]
+            } ]
+          }
+        }
+      }, {
+        "name" : "TargetDiagnoses",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Query",
+          "annotation" : [ ],
+          "source" : [ {
+            "alias" : "P",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "Pharyngitis",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            }
+          } ],
+          "let" : [ ],
+          "relationship" : [ {
+            "alias" : "E",
+            "type" : "With",
+            "annotation" : [ ],
+            "expression" : {
+              "name" : "TargetEncounters",
+              "type" : "ExpressionRef",
+              "annotation" : [ ]
+            },
+            "suchThat" : {
+              "type" : "OverlapsAfter",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "lowClosed" : true,
+                "highClosed" : true,
+                "type" : "Interval",
+                "annotation" : [ ],
+                "low" : {
+                  "path" : "onsetDateTime",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                },
+                "high" : {
+                  "path" : "abatementDate",
+                  "scope" : "P",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }
+              }, {
+                "path" : "period",
+                "scope" : "E",
+                "type" : "Property",
+                "annotation" : [ ]
+              } ]
+            }
+          } ]
+        }
+      }, {
+        "name" : "HasPriorAntibiotics",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "A",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "Antibiotics",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ {
+              "alias" : "D",
+              "type" : "With",
+              "annotation" : [ ],
+              "expression" : {
+                "name" : "TargetDiagnoses",
+                "type" : "ExpressionRef",
+                "annotation" : [ ]
+              },
+              "suchThat" : {
+                "type" : "And",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : [ {
+                  "type" : "In",
+                  "annotation" : [ ],
+                  "signature" : [ {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }, {
+                    "type" : "IntervalTypeSpecifier",
+                    "annotation" : [ ],
+                    "pointType" : {
+                      "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                      "type" : "NamedTypeSpecifier",
+                      "annotation" : [ ]
+                    }
+                  } ],
+                  "operand" : [ {
+                    "path" : "dateWritten",
+                    "scope" : "A",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }, {
+                    "lowClosed" : true,
+                    "highClosed" : false,
+                    "type" : "Interval",
+                    "annotation" : [ ],
+                    "low" : {
+                      "type" : "Subtract",
+                      "annotation" : [ ],
+                      "signature" : [ {
+                        "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      }, {
+                        "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "NamedTypeSpecifier",
+                        "annotation" : [ ]
+                      } ],
+                      "operand" : [ {
+                        "path" : "onsetDateTime",
+                        "scope" : "D",
+                        "type" : "Property",
+                        "annotation" : [ ]
+                      }, {
+                        "value" : 30,
+                        "unit" : "days",
+                        "type" : "Quantity",
+                        "annotation" : [ ]
+                      } ]
+                    },
+                    "high" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  } ]
+                }, {
+                  "type" : "Not",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "type" : "IsNull",
+                    "annotation" : [ ],
+                    "signature" : [ ],
+                    "operand" : {
+                      "path" : "onsetDateTime",
+                      "scope" : "D",
+                      "type" : "Property",
+                      "annotation" : [ ]
+                    }
+                  }
+                } ]
+              }
+            } ]
+          }
+        }
+      }, {
+        "name" : "HasTargetEncounter",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Encounter",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : {
+            "name" : "TargetEncounters",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }
+        }
+      }, {
+        "name" : "InInitialPopulation",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "And",
+          "annotation" : [ ],
+          "signature" : [ ],
+          "operand" : [ {
+            "name" : "InDemographic",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          }, {
+            "name" : "HasTargetEncounter",
+            "type" : "ExpressionRef",
+            "annotation" : [ ]
+          } ]
+        }
+      }, {
+        "name" : "InDenominator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+          "value" : "true",
+          "type" : "Literal",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InDenominatorExclusions",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "name" : "HasPriorAntibiotics",
+          "type" : "ExpressionRef",
+          "annotation" : [ ]
+        }
+      }, {
+        "name" : "InNumerator",
+        "context" : "Patient",
+        "accessLevel" : "Public",
+        "annotation" : [ ],
+        "expression" : {
+          "type" : "Exists",
+          "annotation" : [ ],
+          "signature" : [ {
+            "type" : "ListTypeSpecifier",
+            "annotation" : [ ],
+            "elementType" : {
+              "name" : "{http://hl7.org/fhir}Observation",
+              "type" : "NamedTypeSpecifier",
+              "annotation" : [ ]
+            }
+          } ],
+          "operand" : {
+            "type" : "Query",
+            "annotation" : [ ],
+            "source" : [ {
+              "alias" : "R",
+              "annotation" : [ ],
+              "expression" : {
+                "dataType" : "{http://hl7.org/fhir}Observation",
+                "templateId" : "observation-qicore-qicore-observation",
+                "codeProperty" : "code",
+                "codeComparator" : "in",
+                "type" : "Retrieve",
+                "annotation" : [ ],
+                "codes" : {
+                  "name" : "Group A Streptococcus Test",
+                  "preserve" : true,
+                  "type" : "ValueSetRef",
+                  "annotation" : [ ]
+                },
+                "include" : [ ],
+                "codeFilter" : [ ],
+                "dateFilter" : [ ],
+                "otherFilter" : [ ]
+              }
+            } ],
+            "let" : [ ],
+            "relationship" : [ ],
+            "where" : {
+              "type" : "And",
+              "annotation" : [ ],
+              "signature" : [ ],
+              "operand" : [ {
+                "type" : "In",
+                "annotation" : [ ],
+                "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                  "type" : "NamedTypeSpecifier",
+                  "annotation" : [ ]
+                }, {
+                  "type" : "IntervalTypeSpecifier",
+                  "annotation" : [ ],
+                  "pointType" : {
+                    "name" : "{urn:hl7-org:elm-types:r1}DateTime",
+                    "type" : "NamedTypeSpecifier",
+                    "annotation" : [ ]
+                  }
+                } ],
+                "operand" : [ {
+                  "path" : "issued",
+                  "scope" : "R",
+                  "type" : "Property",
+                  "annotation" : [ ]
+                }, {
+                  "name" : "MeasurementPeriod",
+                  "type" : "ParameterRef",
+                  "annotation" : [ ]
+                } ]
+              }, {
+                "type" : "Not",
+                "annotation" : [ ],
+                "signature" : [ ],
+                "operand" : {
+                  "type" : "IsNull",
+                  "annotation" : [ ],
+                  "signature" : [ ],
+                  "operand" : {
+                    "path" : "valueQuantity",
+                    "scope" : "R",
+                    "type" : "Property",
+                    "annotation" : [ ]
+                  }
+                }
+              } ]
+            }
+          }
+        }
+      } ]
+    }
   }
 }

--- a/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.xml
+++ b/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/CMS146v2_Expected_SignatureLevel_Overloads.xml
@@ -1,344 +1,260 @@
-<?xml version='1.1' encoding='UTF-8'?>
-<Library type="Library">
-  <wstxns1:identifier xmlns:wstxns1="urn:hl7-org:elm:r1" wstxns1:type="VersionedIdentifier" id="CMS146" version="2"/>
-  <wstxns2:schemaIdentifier xmlns:wstxns2="urn:hl7-org:elm:r1" wstxns2:type="VersionedIdentifier" id="urn:hl7-org:elm" version="r1"/>
-  <wstxns3:usings xmlns:wstxns3="urn:hl7-org:elm:r1" wstxns3:type="Library$Usings">
-    <wstxns3:def>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
-      <wstxns3:def wstxns3:type="UsingDef" localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
-    </wstxns3:def>
-  </wstxns3:usings>
-  <wstxns4:parameters xmlns:wstxns4="urn:hl7-org:elm:r1" wstxns4:type="Library$Parameters">
-    <wstxns4:def>
-      <wstxns4:def wstxns4:type="ParameterDef" name="MeasurementPeriod" accessLevel="Public">
-        <wstxns4:default wstxns4:type="Interval" lowClosed="true" highClosed="false">
-          <wstxns4:low wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2013"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:low>
-          <wstxns4:high wstxns4:type="DateTime">
-            <wstxns4:year wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2014"/>
-            <wstxns4:month wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:day wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="1"/>
-            <wstxns4:hour wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:minute wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:second wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-            <wstxns4:millisecond wstxns4:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="0"/>
-          </wstxns4:high>
-        </wstxns4:default>
-      </wstxns4:def>
-    </wstxns4:def>
-  </wstxns4:parameters>
-  <wstxns5:valueSets xmlns:wstxns5="urn:hl7-org:elm:r1" wstxns5:type="Library$ValueSets">
-    <wstxns5:def>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
-      <wstxns5:def wstxns5:type="ValueSetDef" name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
-    </wstxns5:def>
-  </wstxns5:valueSets>
-  <wstxns6:contexts xmlns:wstxns6="urn:hl7-org:elm:r1" wstxns6:type="Library$Contexts">
-    <wstxns6:def>
-      <wstxns6:def wstxns6:type="ContextDef" name="Patient"/>
-    </wstxns6:def>
-  </wstxns6:contexts>
-  <wstxns7:statements xmlns:wstxns7="urn:hl7-org:elm:r1" wstxns7:type="Library$Statements">
-    <wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Patient" context="Patient">
-        <wstxns7:expression wstxns7:type="SingletonFrom">
-          <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Patient" templateId="patient-qicore-qicore-patient"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDemographic" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="GreaterOrEqual">
-              <wstxns7:signature>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              </wstxns7:signature>
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="2"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Less">
-              <wstxns7:signature>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-                <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Integer"/>
-              </wstxns7:signature>
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="CalculateAgeAt" precision="Year">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="birthDate">
-                      <wstxns7:source wstxns7:type="ExpressionRef" name="Patient"/>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Start">
-                      <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Integer" value="18"/>
-              </wstxns7:operand>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Pharyngitis" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Union">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Pharyngitis" preserve="true"/>
-            </wstxns7:operand>
-            <wstxns7:operand wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in">
-              <wstxns7:codes wstxns7:type="ValueSetRef" name="Acute Tonsillitis" preserve="true"/>
-            </wstxns7:operand>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="Antibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in">
-          <wstxns7:codes wstxns7:type="ValueSetRef" name="Antibiotic Medications" preserve="true"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetEncounters" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="E">
-              <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in">
-                <wstxns7:codes wstxns7:type="ValueSetRef" name="Ambulatory/ED Visit" preserve="true"/>
-              </wstxns7:expression>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="A">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              <wstxns7:suchThat wstxns7:type="And">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="In">
-                    <wstxns7:operand>
-                      <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                      <wstxns7:operand wstxns7:type="Interval" lowClosed="false" highClosed="true">
-                        <wstxns7:low wstxns7:type="Start">
-                          <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                        </wstxns7:low>
-                        <wstxns7:high wstxns7:type="Add">
-                          <wstxns7:signature>
-                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                            <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
-                          </wstxns7:signature>
-                          <wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Start">
-                              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                            </wstxns7:operand>
-                            <wstxns7:operand wstxns7:type="Quantity" value="3" unit="days"/>
-                          </wstxns7:operand>
-                        </wstxns7:high>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Not">
-                    <wstxns7:operand wstxns7:type="IsNull">
-                      <wstxns7:operand wstxns7:type="Start">
-                        <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-          <wstxns7:where wstxns7:type="IncludedIn">
-            <wstxns7:signature>
-              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-              </wstxns7:signature>
-              <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-              </wstxns7:signature>
-            </wstxns7:signature>
-            <wstxns7:operand>
-              <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-              <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-            </wstxns7:operand>
-          </wstxns7:where>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="TargetDiagnoses" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Query">
-          <wstxns7:source>
-            <wstxns7:source wstxns7:type="AliasedQuerySource" alias="P">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="Pharyngitis"/>
-            </wstxns7:source>
-          </wstxns7:source>
-          <wstxns7:relationship>
-            <wstxns7:relationship wstxns7:type="With" alias="E">
-              <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-              <wstxns7:suchThat wstxns7:type="OverlapsAfter">
-                <wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="true">
-                    <wstxns7:low wstxns7:type="Property" path="onsetDateTime" scope="P"/>
-                    <wstxns7:high wstxns7:type="Property" path="abatementDate" scope="P"/>
-                  </wstxns7:operand>
-                  <wstxns7:operand wstxns7:type="Property" path="period" scope="E"/>
-                </wstxns7:operand>
-              </wstxns7:suchThat>
-            </wstxns7:relationship>
-          </wstxns7:relationship>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="A">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="Antibiotics"/>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:relationship>
-              <wstxns7:relationship wstxns7:type="With" alias="D">
-                <wstxns7:expression wstxns7:type="ExpressionRef" name="TargetDiagnoses"/>
-                <wstxns7:suchThat wstxns7:type="And">
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="In">
-                      <wstxns7:signature>
-                        <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                          <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                        </wstxns7:signature>
-                      </wstxns7:signature>
-                      <wstxns7:operand>
-                        <wstxns7:operand wstxns7:type="Property" path="dateWritten" scope="A"/>
-                        <wstxns7:operand wstxns7:type="Interval" lowClosed="true" highClosed="false">
-                          <wstxns7:low wstxns7:type="Subtract">
-                            <wstxns7:signature>
-                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                              <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}Quantity"/>
-                            </wstxns7:signature>
-                            <wstxns7:operand>
-                              <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                              <wstxns7:operand wstxns7:type="Quantity" value="30" unit="days"/>
-                            </wstxns7:operand>
-                          </wstxns7:low>
-                          <wstxns7:high wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                        </wstxns7:operand>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Not">
-                      <wstxns7:operand wstxns7:type="IsNull">
-                        <wstxns7:operand wstxns7:type="Property" path="onsetDateTime" scope="D"/>
-                      </wstxns7:operand>
-                    </wstxns7:operand>
-                  </wstxns7:operand>
-                </wstxns7:suchThat>
-              </wstxns7:relationship>
-            </wstxns7:relationship>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="HasTargetEncounter" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Encounter"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand wstxns7:type="ExpressionRef" name="TargetEncounters"/>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InInitialPopulation" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="And">
-          <wstxns7:operand>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="InDemographic"/>
-            <wstxns7:operand wstxns7:type="ExpressionRef" name="HasTargetEncounter"/>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Literal" valueType="{urn:hl7-org:elm-types:r1}Boolean" value="true"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InDenominatorExclusions" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="ExpressionRef" name="HasPriorAntibiotics"/>
-      </wstxns7:def>
-      <wstxns7:def wstxns7:type="ExpressionDef" name="InNumerator" context="Patient" accessLevel="Public">
-        <wstxns7:expression wstxns7:type="Exists">
-          <wstxns7:signature>
-            <wstxns7:signature wstxns7:type="ListTypeSpecifier">
-              <wstxns7:elementType wstxns7:type="NamedTypeSpecifier" name="{http://hl7.org/fhir}Observation"/>
-            </wstxns7:signature>
-          </wstxns7:signature>
-          <wstxns7:operand wstxns7:type="Query">
-            <wstxns7:source>
-              <wstxns7:source wstxns7:type="AliasedQuerySource" alias="R">
-                <wstxns7:expression wstxns7:type="Retrieve" dataType="{http://hl7.org/fhir}Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in">
-                  <wstxns7:codes wstxns7:type="ValueSetRef" name="Group A Streptococcus Test" preserve="true"/>
-                </wstxns7:expression>
-              </wstxns7:source>
-            </wstxns7:source>
-            <wstxns7:where wstxns7:type="And">
-              <wstxns7:operand>
-                <wstxns7:operand wstxns7:type="In">
-                  <wstxns7:signature>
-                    <wstxns7:signature wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    <wstxns7:signature wstxns7:type="IntervalTypeSpecifier">
-                      <wstxns7:pointType wstxns7:type="NamedTypeSpecifier" name="{urn:hl7-org:elm-types:r1}DateTime"/>
-                    </wstxns7:signature>
-                  </wstxns7:signature>
-                  <wstxns7:operand>
-                    <wstxns7:operand wstxns7:type="Property" path="issued" scope="R"/>
-                    <wstxns7:operand wstxns7:type="ParameterRef" name="MeasurementPeriod"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-                <wstxns7:operand wstxns7:type="Not">
-                  <wstxns7:operand wstxns7:type="IsNull">
-                    <wstxns7:operand wstxns7:type="Property" path="valueQuantity" scope="R"/>
-                  </wstxns7:operand>
-                </wstxns7:operand>
-              </wstxns7:operand>
-            </wstxns7:where>
-          </wstxns7:operand>
-        </wstxns7:expression>
-      </wstxns7:def>
-    </wstxns7:def>
-  </wstxns7:statements>
-  <wstxns8:annotation xmlns:wstxns8="urn:hl7-org:elm:r1">
-    <wstxns8:annotation wstxns8:type="CqlToElmInfo" translatorOptions="" signatureLevel="Overloads"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning"/>
-    <wstxns8:annotation wstxns8:type="CqlToElmError" libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning"/>
-  </wstxns8:annotation>
-</Library>
+<?xml version="1.0" encoding="UTF-8"?>
+<library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
+  <annotation translatorOptions="" signatureLevel="Overloads" xsi:type="a:CqlToElmInfo"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve code path medication.code for the type of the retrieve QUICK.MedicationPrescription." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <annotation libraryId="CMS146" libraryVersion="2" startLine="22" startChar="5" endLine="22" endChar="54" message="Could not resolve membership operator for terminology target of the retrieve." errorType="semantic" errorSeverity="warning" xsi:type="a:CqlToElmError"/>
+  <identifier id="CMS146" version="2"/>
+  <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
+  <usings>
+    <def localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
+    <def localIdentifier="QUICK" uri="http://hl7.org/fhir"/>
+  </usings>
+  <parameters>
+    <def name="MeasurementPeriod" accessLevel="Public">
+      <default lowClosed="true" highClosed="false" xsi:type="Interval">
+        <low xsi:type="DateTime">
+          <year valueType="t:Integer" value="2013" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </low>
+        <high xsi:type="DateTime">
+          <year valueType="t:Integer" value="2014" xsi:type="Literal"/>
+          <month valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <day valueType="t:Integer" value="1" xsi:type="Literal"/>
+          <hour valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <minute valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <second valueType="t:Integer" value="0" xsi:type="Literal"/>
+          <millisecond valueType="t:Integer" value="0" xsi:type="Literal"/>
+        </high>
+      </default>
+    </def>
+  </parameters>
+  <valueSets>
+    <def name="Acute Pharyngitis" id="2.16.840.1.113883.3.464.1003.102.12.1011" accessLevel="Public"/>
+    <def name="Acute Tonsillitis" id="2.16.840.1.113883.3.464.1003.102.12.1012" accessLevel="Public"/>
+    <def name="Ambulatory/ED Visit" id="2.16.840.1.113883.3.464.1003.101.12.1061" accessLevel="Public"/>
+    <def name="Antibiotic Medications" id="2.16.840.1.113883.3.464.1003.196.12.1001" accessLevel="Public"/>
+    <def name="Group A Streptococcus Test" id="2.16.840.1.113883.3.464.1003.198.12.1012" accessLevel="Public"/>
+  </valueSets>
+  <contexts>
+    <def name="Patient"/>
+  </contexts>
+  <statements>
+    <def name="Patient" context="Patient">
+      <expression xsi:type="SingletonFrom">
+        <operand dataType="fhir:Patient" templateId="patient-qicore-qicore-patient" xsi:type="Retrieve"/>
+      </expression>
+    </def>
+    <def name="InDemographic" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand xsi:type="GreaterOrEqual">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="2" xsi:type="Literal"/>
+        </operand>
+        <operand xsi:type="Less">
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <signature name="t:Integer" xsi:type="NamedTypeSpecifier"/>
+          <operand precision="Year" xsi:type="CalculateAgeAt">
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+            <operand path="birthDate" xsi:type="Property">
+              <source name="Patient" xsi:type="ExpressionRef"/>
+            </operand>
+            <operand xsi:type="Start">
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+          </operand>
+          <operand valueType="t:Integer" value="18" xsi:type="Literal"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Pharyngitis" context="Patient" accessLevel="Public">
+      <expression xsi:type="Union">
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Pharyngitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+        <operand dataType="fhir:Condition" templateId="condition-qicore-qicore-condition" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+          <codes name="Acute Tonsillitis" preserve="true" xsi:type="ValueSetRef"/>
+        </operand>
+      </expression>
+    </def>
+    <def name="Antibiotics" context="Patient" accessLevel="Public">
+      <expression dataType="fhir:MedicationPrescription" templateId="medicationprescription-qicore-qicore-medicationprescription" codeProperty="medication.code" codeComparator="in" xsi:type="Retrieve">
+        <codes name="Antibiotic Medications" preserve="true" xsi:type="ValueSetRef"/>
+      </expression>
+    </def>
+    <def name="TargetEncounters" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="E">
+          <expression dataType="fhir:Encounter" templateId="encounter-qicore-qicore-encounter" codeProperty="type" codeComparator="in" xsi:type="Retrieve">
+            <codes name="Ambulatory/ED Visit" preserve="true" xsi:type="ValueSetRef"/>
+          </expression>
+        </source>
+        <relationship alias="P" xsi:type="With">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+        <relationship alias="A" xsi:type="With">
+          <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="And">
+            <operand xsi:type="In">
+              <operand path="dateWritten" scope="A" xsi:type="Property"/>
+              <operand lowClosed="false" highClosed="true" xsi:type="Interval">
+                <low xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </low>
+                <high xsi:type="Add">
+                  <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                  <signature name="t:Quantity" xsi:type="NamedTypeSpecifier"/>
+                  <operand xsi:type="Start">
+                    <operand path="period" scope="E" xsi:type="Property"/>
+                  </operand>
+                  <operand value="3" unit="days" xsi:type="Quantity"/>
+                </high>
+              </operand>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <operand xsi:type="Start">
+                  <operand path="period" scope="E" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </operand>
+          </suchThat>
+        </relationship>
+        <where xsi:type="IncludedIn">
+          <signature xsi:type="IntervalTypeSpecifier">
+            <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+          </signature>
+          <signature xsi:type="IntervalTypeSpecifier">
+            <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+          </signature>
+          <operand path="period" scope="E" xsi:type="Property"/>
+          <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+        </where>
+      </expression>
+    </def>
+    <def name="TargetDiagnoses" context="Patient" accessLevel="Public">
+      <expression xsi:type="Query">
+        <source alias="P">
+          <expression name="Pharyngitis" xsi:type="ExpressionRef"/>
+        </source>
+        <relationship alias="E" xsi:type="With">
+          <expression name="TargetEncounters" xsi:type="ExpressionRef"/>
+          <suchThat xsi:type="OverlapsAfter">
+            <operand lowClosed="true" highClosed="true" xsi:type="Interval">
+              <low path="onsetDateTime" scope="P" xsi:type="Property"/>
+              <high path="abatementDate" scope="P" xsi:type="Property"/>
+            </operand>
+            <operand path="period" scope="E" xsi:type="Property"/>
+          </suchThat>
+        </relationship>
+      </expression>
+    </def>
+    <def name="HasPriorAntibiotics" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <operand xsi:type="Query">
+          <source alias="A">
+            <expression name="Antibiotics" xsi:type="ExpressionRef"/>
+          </source>
+          <relationship alias="D" xsi:type="With">
+            <expression name="TargetDiagnoses" xsi:type="ExpressionRef"/>
+            <suchThat xsi:type="And">
+              <operand xsi:type="In">
+                <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                <signature xsi:type="IntervalTypeSpecifier">
+                  <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                </signature>
+                <operand path="dateWritten" scope="A" xsi:type="Property"/>
+                <operand lowClosed="true" highClosed="false" xsi:type="Interval">
+                  <low xsi:type="Subtract">
+                    <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+                    <signature name="t:Quantity" xsi:type="NamedTypeSpecifier"/>
+                    <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                    <operand value="30" unit="days" xsi:type="Quantity"/>
+                  </low>
+                  <high path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+              <operand xsi:type="Not">
+                <operand xsi:type="IsNull">
+                  <operand path="onsetDateTime" scope="D" xsi:type="Property"/>
+                </operand>
+              </operand>
+            </suchThat>
+          </relationship>
+        </operand>
+      </expression>
+    </def>
+    <def name="HasTargetEncounter" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Encounter" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand name="TargetEncounters" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InInitialPopulation" context="Patient" accessLevel="Public">
+      <expression xsi:type="And">
+        <operand name="InDemographic" xsi:type="ExpressionRef"/>
+        <operand name="HasTargetEncounter" xsi:type="ExpressionRef"/>
+      </expression>
+    </def>
+    <def name="InDenominator" context="Patient" accessLevel="Public">
+      <expression valueType="t:Boolean" value="true" xsi:type="Literal"/>
+    </def>
+    <def name="InDenominatorExclusions" context="Patient" accessLevel="Public">
+      <expression name="HasPriorAntibiotics" xsi:type="ExpressionRef"/>
+    </def>
+    <def name="InNumerator" context="Patient" accessLevel="Public">
+      <expression xsi:type="Exists">
+        <signature xsi:type="ListTypeSpecifier">
+          <elementType name="fhir:Observation" xsi:type="NamedTypeSpecifier"/>
+        </signature>
+        <operand xsi:type="Query">
+          <source alias="R">
+            <expression dataType="fhir:Observation" templateId="observation-qicore-qicore-observation" codeProperty="code" codeComparator="in" xsi:type="Retrieve">
+              <codes name="Group A Streptococcus Test" preserve="true" xsi:type="ValueSetRef"/>
+            </expression>
+          </source>
+          <where xsi:type="And">
+            <operand xsi:type="In">
+              <signature name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              <signature xsi:type="IntervalTypeSpecifier">
+                <pointType name="t:DateTime" xsi:type="NamedTypeSpecifier"/>
+              </signature>
+              <operand path="issued" scope="R" xsi:type="Property"/>
+              <operand name="MeasurementPeriod" xsi:type="ParameterRef"/>
+            </operand>
+            <operand xsi:type="Not">
+              <operand xsi:type="IsNull">
+                <operand path="valueQuantity" scope="R" xsi:type="Property"/>
+              </operand>
+            </operand>
+          </where>
+        </operand>
+      </expression>
+    </def>
+  </statements>
+</library>

--- a/Src/java/elm-test/build.gradle
+++ b/Src/java/elm-test/build.gradle
@@ -4,8 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':cql-to-elm')
-    // implementation project(':model-jaxb')
+    implementation project(':model-jaxb')
     implementation project(':elm-jaxb')
-    implementation project(':model-jackson')
     implementation project(':elm-jackson')
 }

--- a/Src/java/engine/build.gradle
+++ b/Src/java/engine/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     api project(':elm')
     api project(':cql-to-elm')
 
-    testImplementation project(':model-jackson')
-    testImplementation project(':elm-jackson')
+    testImplementation project(':model-jaxb')
+    testImplementation project(':elm-jaxb')
     testImplementation 'org.mockito:mockito-core:5.4.0'
 }
 


### PR DESCRIPTION
* Remove `elm-jackson` dependencies whereever possible, and swap to `elm-jaxb`
* Change tests that expect Jackson-flavored ELM to expect JAXB-flavored ELM
* Fixed `slf4j` version mismatch. Upstream project (HAPI) introduced 2.0.13