### PR TITLE
Translator supports namespaces

### DIFF
--- a/Src/java/cqf-fhir/src/main/java/org/cqframework/fhir/utilities/IGContext.java
+++ b/Src/java/cqf-fhir/src/main/java/org/cqframework/fhir/utilities/IGContext.java
@@ -16,8 +16,24 @@ import org.hl7.fhir.utilities.IniFile;
 import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.Utilities;
 import org.hl7.fhir.utilities.VersionUtilities;
+import org.slf4j.LoggerFactory;
 
 public class IGContext {
+    private static class DefaultLogger implements ILoggingService {
+        private final org.slf4j.Logger log = LoggerFactory.getLogger(IGContext.class);
+
+        public void logMessage(String s) {
+            log.warn(s);
+        }
+
+        public void logDebugMessage(LogCategory logCategory, String s) {
+            log.debug("{}: {}", logCategory, s);
+        }
+
+        public boolean isDebugLogging() {
+            return log.isDebugEnabled();
+        }
+    }
 
     private ILoggingService logger;
 
@@ -67,6 +83,10 @@ public class IGContext {
 
     public IGContext(ILoggingService logger) {
         this.logger = logger;
+    }
+
+    public IGContext() {
+        this.logger = new DefaultLogger();
     }
 
     public void initializeFromIg(String rootDir, String igPath, String fhirVersion) {

--- a/Src/java/cql-to-elm-cli/build.gradle
+++ b/Src/java/cql-to-elm-cli/build.gradle
@@ -9,6 +9,8 @@ application {
 
 dependencies {
     implementation project(':cql-to-elm')
+    implementation project(':cqf-fhir')
+    implementation project(':cqf-fhir-npm')
     implementation project(':quick')
     implementation project(':qdm')
     implementation project(':model-jaxb')
@@ -17,6 +19,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-simple:2.0.13'
     implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.5'
     implementation 'org.eclipse.persistence:org.eclipse.persistence.moxy:4.0.2'
+    implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-r5"
     testImplementation project(':model-jaxb')
     testImplementation project(':elm-jaxb')
 }

--- a/Src/java/cql-to-elm-cli/src/main/java/org/cqframework/cql/cql2elm/cli/Main.java
+++ b/Src/java/cql-to-elm-cli/src/main/java/org/cqframework/cql/cql2elm/cli/Main.java
@@ -98,7 +98,8 @@ public class Main {
             libraryManager.getLibrarySourceLoader().registerProvider(sp);
 
             String packageId = igContext.getPackageId();
-            String canonicalBase = igContext.getCanonicalBase();;
+            String canonicalBase = igContext.getCanonicalBase();
+
             if (packageId != null && !packageId.isEmpty() && canonicalBase != null && !canonicalBase.isEmpty()) {
                 namespaceInfo = new NamespaceInfo(packageId, canonicalBase);
             }


### PR DESCRIPTION
This is a working POC of adding support for CQL namespaces, it works with the example found here https://github.com/reason-healthcare/crmi-reusable-cql

This PR adds an option `-root-dir` that when present attempts to use the IG resource dependencies and CQL namespaces.