### PR TITLE
Regression fixes (Kotlin feature branch)

### DIFF
--- a/Src/java/cql-to-elm/src/jvmMain/kotlin/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.kt
+++ b/Src/java/cql-to-elm/src/jvmMain/kotlin/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.kt
@@ -47,8 +47,8 @@ class DefaultModelInfoProvider() : ModelInfoProvider, PathAware {
                 currentPath.resolve(
                     "${modelName.lowercase()}-modelinfo${if (modelVersion != null) "-$modelVersion" else ""}.xml"
                 )
-            var modelFile = modelPath.toFile()
-            if (!modelFile.exists()) {
+            var modelFile: File? = modelPath.toFile()
+            if (modelFile?.exists() != true) {
                 val filter = FilenameFilter { _, name ->
                     name.startsWith(modelName.lowercase() + "-modelinfo") && name.endsWith(".xml")
                 }
@@ -56,7 +56,7 @@ class DefaultModelInfoProvider() : ModelInfoProvider, PathAware {
                 var mostRecent: Version? = null
                 try {
                     val requestedVersion = if (modelVersion == null) null else Version(modelVersion)
-                    for (file in currentPath.toFile().listFiles(filter)!!) {
+                    for (file in currentPath.toFile().listFiles(filter)) {
                         var fileName = file.name
                         val indexOfExtension = fileName.lastIndexOf(".")
                         if (indexOfExtension >= 0) {
@@ -93,7 +93,7 @@ class DefaultModelInfoProvider() : ModelInfoProvider, PathAware {
                             }
                         }
                     }
-                    modelFile = mostRecentFile!!
+                    modelFile = mostRecentFile
                 } catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
                     // do nothing, if the version can't be understood as a semantic version, don't
                     // allow unspecified
@@ -101,9 +101,11 @@ class DefaultModelInfoProvider() : ModelInfoProvider, PathAware {
                 }
             }
             try {
-                val inputStream: InputStream = FileInputStream(modelFile)
-                return ModelInfoReaderFactory.getReader("application/xml")
-                    ?.read(inputStream.asSource().buffered())
+                if (modelFile != null) {
+                    val inputStream: InputStream = FileInputStream(modelFile)
+                    return ModelInfoReaderFactory.getReader("application/xml")
+                        ?.read(inputStream.asSource().buffered())
+                }
             } catch (e: IOException) {
                 throw IllegalArgumentException(
                     "Could not load definition for model info ${modelIdentifier.id}.",

--- a/Src/java/elm-xmlutil/build.gradle.kts
+++ b/Src/java/elm-xmlutil/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":model"))
+                api(project(":model-xmlutil"))
                 api(project(":elm"))
             }
         }
@@ -14,7 +15,6 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(project(":cql-to-elm"))
-                implementation(project(":model-xmlutil"))
                 implementation(project(":ucum"))
                 implementation(project(":quick"))
                 implementation("org.xmlunit:xmlunit-assertj:2.10.0")

--- a/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/TypeInjectingXmlReader.kt
+++ b/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/TypeInjectingXmlReader.kt
@@ -1,0 +1,49 @@
+package org.cqframework.cql.elm.serializing.xmlutil
+
+import nl.adaptivity.xmlutil.XMLConstants
+import nl.adaptivity.xmlutil.XmlDelegatingReader
+import nl.adaptivity.xmlutil.XmlReader
+
+// This reader injects the xsi:type attributes into the XML stream with the value of "usebaseclass"
+// if it is not present
+class TypeInjectingXmlReader(reader: XmlReader) : XmlDelegatingReader(reader) {
+
+    override val attributeCount: Int
+        get() = super.attributeCount + 1
+
+    override fun getAttributeNamespace(index: Int): String {
+        if (index == 0) {
+            return XMLConstants.XSI_NS_URI
+        }
+        return super.getAttributeNamespace(index - 1)
+    }
+
+    override fun getAttributePrefix(index: Int): String {
+        if (index == 0) {
+            return XMLConstants.XSI_PREFIX
+        }
+        return super.getAttributePrefix(index - 1)
+    }
+
+    override fun getAttributeLocalName(index: Int): String {
+        if (index == 0) {
+            return "type"
+        }
+        return super.getAttributeLocalName(index - 1)
+    }
+
+    override fun getAttributeValue(index: Int): String {
+        if (index == 0) {
+            return super.getAttributeValue(XMLConstants.XSI_NS_URI, "type") ?: "usebaseclass"
+        }
+        return super.getAttributeValue(index - 1)
+    }
+
+    override fun getAttributeValue(nsUri: String?, localName: String): String? {
+        if (nsUri == XMLConstants.XSI_NS_URI && localName == "type") {
+            super.getAttributeValue(XMLConstants.XSI_NS_URI, "type") ?: "usebaseclass"
+        }
+
+        return super.getAttributeValue(nsUri, localName)
+    }
+}

--- a/Src/java/elm-xmlutil/src/jsMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
+++ b/Src/java/elm-xmlutil/src/jsMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
@@ -2,12 +2,16 @@ package org.cqframework.cql.elm.serializing.xmlutil
 
 import kotlinx.io.Source
 import kotlinx.io.readString
+import nl.adaptivity.xmlutil.xmlStreaming
 import org.cqframework.cql.elm.serializing.ElmLibraryReader
 import org.hl7.elm.r1.Library
 
 actual class ElmXmlLibraryReader actual constructor() : ElmLibraryReader {
     actual override fun read(string: String): Library {
-        return xml.decodeFromString(Library.serializer(), string)
+        return xml.decodeFromReader(
+            Library.serializer(),
+            TypeInjectingXmlReader(xmlStreaming.newReader(string))
+        )
     }
 
     actual override fun read(source: Source): Library {

--- a/Src/java/elm-xmlutil/src/jsMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
+++ b/Src/java/elm-xmlutil/src/jsMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
@@ -5,6 +5,7 @@ import kotlinx.io.readString
 import nl.adaptivity.xmlutil.xmlStreaming
 import org.cqframework.cql.elm.serializing.ElmLibraryReader
 import org.hl7.elm.r1.Library
+import org.hl7.elm_modelinfo.r1.serializing.xmlutil.TypeInjectingXmlReader
 
 actual class ElmXmlLibraryReader actual constructor() : ElmLibraryReader {
     actual override fun read(string: String): Library {

--- a/Src/java/elm-xmlutil/src/jvmMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
+++ b/Src/java/elm-xmlutil/src/jvmMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
@@ -6,6 +6,7 @@ import nl.adaptivity.xmlutil.core.impl.newReader
 import nl.adaptivity.xmlutil.xmlStreaming
 import org.cqframework.cql.elm.serializing.ElmLibraryReader
 import org.hl7.elm.r1.Library
+import org.hl7.elm_modelinfo.r1.serializing.xmlutil.TypeInjectingXmlReader
 
 actual class ElmXmlLibraryReader actual constructor() : ElmLibraryReader {
     actual override fun read(string: String): Library {

--- a/Src/java/elm-xmlutil/src/jvmMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
+++ b/Src/java/elm-xmlutil/src/jvmMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryReader.kt
@@ -9,13 +9,16 @@ import org.hl7.elm.r1.Library
 
 actual class ElmXmlLibraryReader actual constructor() : ElmLibraryReader {
     actual override fun read(string: String): Library {
-        return xml.decodeFromString(Library.serializer(), string)
+        return xml.decodeFromReader(
+            Library.serializer(),
+            TypeInjectingXmlReader(xmlStreaming.newReader(string))
+        )
     }
 
     actual override fun read(source: Source): Library {
         return xml.decodeFromReader(
             Library.serializer(),
-            xmlStreaming.newReader(source.asInputStream(), "UTF-8")
+            TypeInjectingXmlReader(xmlStreaming.newReader(source.asInputStream(), "UTF-8"))
         )
     }
 }

--- a/Src/java/elm-xmlutil/src/jvmTest/java/org/cqframework/cql/elm/serializing/xmlutil/CMS146JsonTest.java
+++ b/Src/java/elm-xmlutil/src/jvmTest/java/org/cqframework/cql/elm/serializing/xmlutil/CMS146JsonTest.java
@@ -44,14 +44,11 @@ class CMS146JsonTest {
         final String actualJson = jsonWithVersion
                 .replaceAll("\"translatorVersion\":\"[^\"]*\",", "")
                 // The original JSON marshaller (JAXB + MOXy) does not output
-                // accessLevel if it is null. (It always emits it otherwise,
-                // even when it's set to the default value.) The new JSON
-                // serializer always emits accessLevel.
-                // We do not set accessLevel in the translator on the
-                // model/context def node, thus the difference in JSON output.
+                // type for the base class in polymorphic hierarchies.
                 .replace(
-                        "\"name\":\"Patient\",\"context\":\"Patient\",\"accessLevel\":\"Public\"",
-                        "\"name\":\"Patient\",\"context\":\"Patient\"");
+                        "\"type\":\"ExpressionDef\",",
+                        "")
+                .replace("\"type\":\"AliasedQuerySource\",", "");
         JSONAssert.assertEquals(expectedJson, actualJson, true);
     }
 

--- a/Src/java/elm-xmlutil/src/jvmTest/java/org/cqframework/cql/elm/serializing/xmlutil/SerializationRoundTripTest.java
+++ b/Src/java/elm-xmlutil/src/jvmTest/java/org/cqframework/cql/elm/serializing/xmlutil/SerializationRoundTripTest.java
@@ -13,6 +13,8 @@ public class SerializationRoundTripTest {
             "OperatorTests/ArithmeticOperators.cql",
             "OperatorTests/ComparisonOperators.cql",
             "OperatorTests/ListOperators.cql",
+            "OperatorTests/Aggregate.cql",
+            "SignatureTests/GenericOverloadsTests.cql",
         };
     }
 
@@ -20,8 +22,10 @@ public class SerializationRoundTripTest {
         return "../cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/" + cqlFile;
     }
 
-    private static final ElmXmlLibraryReader reader = new ElmXmlLibraryReader();
-    private static final ElmXmlLibraryWriter writer = new ElmXmlLibraryWriter();
+    private static final ElmXmlLibraryReader xmlReader = new ElmXmlLibraryReader();
+    private static final ElmXmlLibraryWriter xmlWriter = new ElmXmlLibraryWriter();
+    private static final ElmJsonLibraryReader jsonReader = new ElmJsonLibraryReader();
+    private static final ElmJsonLibraryWriter jsonWriter = new ElmJsonLibraryWriter();
 
     @ParameterizedTest
     @MethodSource("dataMethod")
@@ -30,7 +34,11 @@ public class SerializationRoundTripTest {
         assertEquals(0, translator.getErrors().size());
 
         var xml = translator.toXml();
-        var library = reader.read(xml);
-        assertEquals(xml, writer.writeAsString(library));
+        var library = xmlReader.read(xml);
+        assertEquals(xml, xmlWriter.writeAsString(library));
+
+        var json = translator.toJson();
+        library = jsonReader.read(json);
+        assertEquals(json, jsonWriter.writeAsString(library));
     }
 }

--- a/Src/java/elm/src/jvmTest/java/org/cqframework/cql/elm/visiting/RandomElmGraphTest.kt
+++ b/Src/java/elm/src/jvmTest/java/org/cqframework/cql/elm/visiting/RandomElmGraphTest.kt
@@ -135,6 +135,10 @@ class RandomElmGraphTest {
                 return true
             }
 
+            if (type.simpleName.endsWith("Dummy")) {
+                return true
+            }
+
             return type == QName::class.java ||
                 type == Narrative::class.java ||
                 type == AccessModifier::class.java

--- a/Src/java/model-xmlutil/src/commonMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/TypeInjectingXmlReader.kt
+++ b/Src/java/model-xmlutil/src/commonMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/TypeInjectingXmlReader.kt
@@ -1,4 +1,4 @@
-package org.cqframework.cql.elm.serializing.xmlutil
+package org.hl7.elm_modelinfo.r1.serializing.xmlutil
 
 import nl.adaptivity.xmlutil.XMLConstants
 import nl.adaptivity.xmlutil.XmlDelegatingReader

--- a/Src/java/model-xmlutil/src/jsMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/XmlModelInfoReader.kt
+++ b/Src/java/model-xmlutil/src/jsMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/XmlModelInfoReader.kt
@@ -2,12 +2,16 @@ package org.hl7.elm_modelinfo.r1.serializing.xmlutil
 
 import kotlinx.io.Source
 import kotlinx.io.readString
+import nl.adaptivity.xmlutil.xmlStreaming
 import org.hl7.elm_modelinfo.r1.ModelInfo
 import org.hl7.elm_modelinfo.r1.serializing.ModelInfoReader
 
 actual class XmlModelInfoReader actual constructor() : ModelInfoReader {
     actual override fun read(string: String): ModelInfo {
-        return xml.decodeFromString(ModelInfo.serializer(), string)
+        return xml.decodeFromReader(
+            ModelInfo.serializer(),
+            TypeInjectingXmlReader(xmlStreaming.newReader(string))
+        )
     }
 
     actual override fun read(source: Source): ModelInfo {

--- a/Src/java/model-xmlutil/src/jvmMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/XmlModelInfoReader.kt
+++ b/Src/java/model-xmlutil/src/jvmMain/kotlin/org/hl7/elm_modelinfo/r1/serializing/xmlutil/XmlModelInfoReader.kt
@@ -9,13 +9,16 @@ import org.hl7.elm_modelinfo.r1.serializing.ModelInfoReader
 
 actual class XmlModelInfoReader actual constructor() : ModelInfoReader {
     actual override fun read(string: String): ModelInfo {
-        return xml.decodeFromString(ModelInfo.serializer(), string)
+        return xml.decodeFromReader(
+            ModelInfo.serializer(),
+            TypeInjectingXmlReader(xmlStreaming.newReader(string))
+        )
     }
 
     actual override fun read(source: Source): ModelInfo {
         return xml.decodeFromReader(
             ModelInfo.serializer(),
-            xmlStreaming.newReader(source.asInputStream(), "UTF-8")
+            TypeInjectingXmlReader(xmlStreaming.newReader(source.asInputStream(), "UTF-8"))
         )
     }
 }

--- a/Src/js/xsd-kotlin-gen/generate.js
+++ b/Src/js/xsd-kotlin-gen/generate.js
@@ -537,7 +537,7 @@ function processElements(elements, config, mode) {
               `
 package ${config.packageName}
 
-${element.attributes.name === "Library" || element.attributes.name === "ModelInfo" ? `@nl.adaptivity.xmlutil.serialization.XmlNamespaceDeclSpec("${config.namespacePrefixes.join(";")}")` : ""}
+${element.attributes.name === "Library" || element.attributes.name === "ModelInfo" ? `@nl.adaptivity.xmlutil.serialization.XmlNamespaceDeclSpec("${config.namespaceUri};${config.namespacePrefixes.join(";")}")` : `@nl.adaptivity.xmlutil.serialization.XmlNamespaceDeclSpec("${config.namespaceUri}")`}
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class, nl.adaptivity.xmlutil.ExperimentalXmlUtilApi::class)
 @kotlinx.serialization.Serializable
 ${config.packageName === "org.hl7.elm_modelinfo.r1" ? "" : `@kotlinx.serialization.SerialName(${JSON.stringify(makeLocalName(element.attributes.name))})`}
@@ -616,7 +616,7 @@ ${attributesFields
       }[field.attributes.type];
 
       return `
-            ${config.packageName === "org.hl7.elm_modelinfo.r1" ? "" : `@kotlinx.serialization.SerialName(${JSON.stringify(field.attributes.name)})`}
+            @kotlinx.serialization.SerialName(${JSON.stringify(field.attributes.name)})
             ${type === field.attributes.type ? "@nl.adaptivity.xmlutil.serialization.XmlElement(false)" : ""}
             private var _${makeFieldName(field.attributes.name)}: ${addContextualAnnotationIfNecessary(type, config)}? = null
             

--- a/Src/js/xsd-kotlin-gen/generate.js
+++ b/Src/js/xsd-kotlin-gen/generate.js
@@ -231,6 +231,7 @@ val serializersModule = kotlinx.serialization.modules.SerializersModule {
                    return `subclass(${config.packageName}.${childClass.className}::class)`;
                  })
                  .join("\n")}
+                 ${!parentClass.isAbstract ? `defaultDeserializer { ${config.packageName}.${parentClass.className}.serializer() }` : ""}
             }`;
         })
         .join("\n")}

--- a/Src/js/xsd-kotlin-gen/generate.js
+++ b/Src/js/xsd-kotlin-gen/generate.js
@@ -234,7 +234,7 @@ val serializersModule = kotlinx.serialization.modules.SerializersModule {
                ${
                  !parentClass.isAbstract
                    ? `
-                 subclass(${config.packageName}.${parentClass.className}Base::class, ${config.packageName}.${parentClass.className}BaseSerializer as kotlinx.serialization.KSerializer<${config.packageName}.${parentClass.className}Base>)
+                 subclass(${config.packageName}.${parentClass.className}Dummy::class, ${config.packageName}.${parentClass.className}BaseSerializer as kotlinx.serialization.KSerializer<${config.packageName}.${parentClass.className}Dummy>)
                  defaultDeserializer { ${config.packageName}.${parentClass.className}.serializer() }
                `
                    : ""
@@ -723,10 +723,10 @@ ${getParentAttributes(
 
 @kotlinx.serialization.Serializable
 @nl.adaptivity.xmlutil.serialization.XmlSerialName(${JSON.stringify("usebaseclass")}, ${JSON.stringify(config.namespaceUri)})
-${element.attributes.abstract === "true" ? "abstract" : "open"} class ${element.attributes.name}Base : ${element.attributes.name}()
+${element.attributes.abstract === "true" ? "abstract" : "open"} class ${element.attributes.name}Dummy : ${element.attributes.name}()
 
 val ${element.attributes.name}BaseSerializer = object : kotlinx.serialization.KSerializer<${element.attributes.name}> by ${element.attributes.name}.serializer() {
-    override val descriptor: kotlinx.serialization.descriptors.SerialDescriptor = ${element.attributes.name}Base.serializer().descriptor
+    override val descriptor: kotlinx.serialization.descriptors.SerialDescriptor = ${element.attributes.name}Dummy.serializer().descriptor
 }
 
 `,

--- a/Src/js/xsd-kotlin-gen/generate.js
+++ b/Src/js/xsd-kotlin-gen/generate.js
@@ -617,7 +617,6 @@ ${attributesFields
 
       return `
             ${config.packageName === "org.hl7.elm_modelinfo.r1" ? "" : `@kotlinx.serialization.SerialName(${JSON.stringify(field.attributes.name)})`}
-            @nl.adaptivity.xmlutil.serialization.XmlSerialName(${JSON.stringify(field.attributes.name)}, ${JSON.stringify(config.namespaceUri)})
             ${type === field.attributes.type ? "@nl.adaptivity.xmlutil.serialization.XmlElement(false)" : ""}
             private var _${makeFieldName(field.attributes.name)}: ${addContextualAnnotationIfNecessary(type, config)}? = null
             

--- a/Src/js/xsd-kotlin-gen/generate.js
+++ b/Src/js/xsd-kotlin-gen/generate.js
@@ -231,7 +231,14 @@ val serializersModule = kotlinx.serialization.modules.SerializersModule {
                    return `subclass(${config.packageName}.${childClass.className}::class)`;
                  })
                  .join("\n")}
-                 ${!parentClass.isAbstract ? `defaultDeserializer { ${config.packageName}.${parentClass.className}.serializer() }` : ""}
+               ${
+                 !parentClass.isAbstract
+                   ? `
+                 subclass(${config.packageName}.${parentClass.className}Base::class, ${config.packageName}.${parentClass.className}BaseSerializer as kotlinx.serialization.KSerializer<${config.packageName}.${parentClass.className}Base>)
+                 defaultDeserializer { ${config.packageName}.${parentClass.className}.serializer() }
+               `
+                   : ""
+               }
             }`;
         })
         .join("\n")}
@@ -713,6 +720,15 @@ ${getParentAttributes(
 
 
 }
+
+@kotlinx.serialization.Serializable
+@nl.adaptivity.xmlutil.serialization.XmlSerialName(${JSON.stringify("usebaseclass")}, ${JSON.stringify(config.namespaceUri)})
+${element.attributes.abstract === "true" ? "abstract" : "open"} class ${element.attributes.name}Base : ${element.attributes.name}()
+
+val ${element.attributes.name}BaseSerializer = object : kotlinx.serialization.KSerializer<${element.attributes.name}> by ${element.attributes.name}.serializer() {
+    override val descriptor: kotlinx.serialization.descriptors.SerialDescriptor = ${element.attributes.name}Base.serializer().descriptor
+}
+
 `,
             );
           }


### PR DESCRIPTION
What's included:

- `DefaultModelInfoProvider.load()` returns `null` when there are no candidate model info files (as expected) and does not throw a `NullPointerException`.
- Add `@Polymorphic` annotation to open classes when needed. This fixes, e.g. `FunctionDef` being serialized as `ExpressionDef`. The updated serializer will always output `xsi:type=ExpressionDef` in XML and `"type": "ExpressionDef"` in JSON for base classes which previously was omitted. The tests are updated to check this edge case.
- Use separate backing fields for attributes with default values in XSDs. This fixes, e.g. `accessLevel="Public"` being added where it previously was omitted.
- Add round trip serialization tests for JSON.