### PR TITLE
Upgrade XmlUtil to 0.91.0-RC1 (Kotlin feature branch)

### DIFF
--- a/Src/java/buildSrc/build.gradle.kts
+++ b/Src/java/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
@@ -16,7 +16,7 @@ dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
     implementation("com.github.node-gradle:gradle-node-plugin:7.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-serialization:2.0.20")
+    implementation("org.jetbrains.kotlin:kotlin-serialization:2.1.0")
 }
 
 kotlin {

--- a/Src/java/buildSrc/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/buildSrc/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -25,8 +25,8 @@ spotless {
 
 kotlin {
     compilerOptions {
-        apiVersion.set(KotlinVersion.KOTLIN_2_0)
-        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        apiVersion.set(KotlinVersion.KOTLIN_2_1)
+        languageVersion.set(KotlinVersion.KOTLIN_2_1)
     }
     jvmToolchain(17)
     jvm {
@@ -78,8 +78,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.pdvrieze.xmlutil:core:0.90.4-20241203.194031-11")
-                implementation("io.github.pdvrieze.xmlutil:serialization:0.90.4-20241203.194031-11")
+                implementation("io.github.pdvrieze.xmlutil:core:0.91.0-RC1")
+                implementation("io.github.pdvrieze.xmlutil:serialization:0.91.0-RC1")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.6.0")
                 implementation("io.github.oshai:kotlin-logging:7.0.3")
@@ -88,15 +88,16 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation("io.github.pdvrieze.xmlutil:serialization-jvm:0.90.4-20241203.194031-11")
+                implementation("io.github.pdvrieze.xmlutil:serialization-jvm:0.91.0-RC1")
+                implementation("io.github.pdvrieze.xmlutil:core-jdk:0.91.0-RC1")
                 implementation("org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.6.0")
             }
         }
 
         jsMain {
             dependencies {
-                implementation("io.github.pdvrieze.xmlutil:core-js:0.90.4-20241203.194031-11")
-                implementation("io.github.pdvrieze.xmlutil:serialization-js:0.90.4-20241203.194031-11")
+                implementation("io.github.pdvrieze.xmlutil:core-js:0.91.0-RC1")
+                implementation("io.github.pdvrieze.xmlutil:serialization-js:0.91.0-RC1")
             }
         }
 

--- a/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryCommon.kt
+++ b/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryCommon.kt
@@ -8,19 +8,23 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.serializersModuleOf
 import nl.adaptivity.xmlutil.QName
 import nl.adaptivity.xmlutil.XMLConstants
+import nl.adaptivity.xmlutil.XmlDeclMode
 import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
+import nl.adaptivity.xmlutil.serialization.FormatCache
 import nl.adaptivity.xmlutil.serialization.XML
 import nl.adaptivity.xmlutil.serialization.structure.SafeParentInfo
 import org.cqframework.cql.elm.serializing.BigDecimalXmlSerializer
 
-val builder =
+internal val builder =
     DefaultXmlSerializationPolicy.Builder().apply {
         // Use xsi:type for handling polymorphism
         typeDiscriminatorName = QName(XMLConstants.XSI_NS_URI, "type", XMLConstants.XSI_PREFIX)
+        // Use the dummy format cache from the XmlUtil library to disable caching
+        formatCache = FormatCache.Dummy
     }
 
 @OptIn(ExperimentalSerializationApi::class)
-val customPolicy =
+internal val customPolicy =
     object : DefaultXmlSerializationPolicy(builder) {
         override fun isTransparentPolymorphic(
             serializerParent: SafeParentInfo,
@@ -38,7 +42,7 @@ val customPolicy =
     }
 
 // Mixed content can include text and Narrative elements
-val mixedContentSerializersModule = SerializersModule {
+internal val mixedContentSerializersModule = SerializersModule {
     polymorphic(Any::class) {
         polymorphic(Any::class, String::class, String.serializer())
         polymorphic(
@@ -57,5 +61,5 @@ internal val xml =
             org.hl7.cql_annotations.r1.serializersModule
     ) {
         policy = customPolicy
-        xmlDeclMode = nl.adaptivity.xmlutil.XmlDeclMode.Charset
+        xmlDeclMode = XmlDeclMode.Charset
     }

--- a/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryCommon.kt
+++ b/Src/java/elm-xmlutil/src/commonMain/kotlin/org/cqframework/cql/elm/serializing/xmlutil/ElmXmlLibraryCommon.kt
@@ -1,31 +1,24 @@
 package org.cqframework.cql.elm.serializing.xmlutil
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.plus
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.serializersModuleOf
-import nl.adaptivity.xmlutil.QName
-import nl.adaptivity.xmlutil.XMLConstants
-import nl.adaptivity.xmlutil.XmlDeclMode
-import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
-import nl.adaptivity.xmlutil.serialization.FormatCache
-import nl.adaptivity.xmlutil.serialization.XML
+import nl.adaptivity.xmlutil.*
+import nl.adaptivity.xmlutil.serialization.*
 import nl.adaptivity.xmlutil.serialization.structure.SafeParentInfo
 import org.cqframework.cql.elm.serializing.BigDecimalXmlSerializer
 
-internal val builder =
-    DefaultXmlSerializationPolicy.Builder().apply {
+private val defaultPolicy =
+    @Suppress("DEPRECATION")
+    DefaultXmlSerializationPolicy {
         // Use xsi:type for handling polymorphism
         typeDiscriminatorName = QName(XMLConstants.XSI_NS_URI, "type", XMLConstants.XSI_PREFIX)
-        // Use the dummy format cache from the XmlUtil library to disable caching
-        formatCache = FormatCache.Dummy
     }
 
-@OptIn(ExperimentalSerializationApi::class)
-internal val customPolicy =
-    object : DefaultXmlSerializationPolicy(builder) {
+private val customPolicy =
+    object : XmlSerializationPolicy by defaultPolicy {
         override fun isTransparentPolymorphic(
             serializerParent: SafeParentInfo,
             tagParent: SafeParentInfo
@@ -37,12 +30,12 @@ internal val customPolicy =
             ) {
                 return true
             }
-            return super.isTransparentPolymorphic(serializerParent, tagParent)
+            return defaultPolicy.isTransparentPolymorphic(serializerParent, tagParent)
         }
     }
 
 // Mixed content can include text and Narrative elements
-internal val mixedContentSerializersModule = SerializersModule {
+private val mixedContentSerializersModule = SerializersModule {
     polymorphic(Any::class) {
         polymorphic(Any::class, String::class, String.serializer())
         polymorphic(
@@ -53,13 +46,19 @@ internal val mixedContentSerializersModule = SerializersModule {
     }
 }
 
+@OptIn(ExperimentalXmlUtilApi::class)
 internal val xml =
     XML(
+        XmlConfig(
+            @Suppress("DEPRECATION")
+            XmlConfig.Builder().apply {
+                policy = customPolicy
+                xmlDeclMode = XmlDeclMode.Charset
+                isCachingEnabled = false
+            }
+        ),
         serializersModuleOf(BigDecimalXmlSerializer) +
             mixedContentSerializersModule +
             org.hl7.elm.r1.serializersModule +
             org.hl7.cql_annotations.r1.serializersModule
-    ) {
-        policy = customPolicy
-        xmlDeclMode = XmlDeclMode.Charset
-    }
+    )

--- a/Src/java/kotlin-js-store/yarn.lock
+++ b/Src/java/kotlin-js-store/yarn.lock
@@ -104,23 +104,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/eslint-scope@^3.7.3":
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
-  integrity sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==
-  dependencies:
-    "@types/eslint" "*"
-    "@types/estree" "*"
-
-"@types/eslint@*":
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.1.tgz#d5795ad732ce81715f27f75da913004a56751584"
-  integrity sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*", "@types/estree@^1.0.5":
+"@types/estree@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
@@ -177,7 +161,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -916,7 +900,7 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.17.1"
 
-enhanced-resolve@^5.17.0:
+enhanced-resolve@^5.17.1:
   version "5.18.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz#728ab082f8b7b6836de51f1637aab5d3b9568faf"
   integrity sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==
@@ -1596,10 +1580,10 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
-  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
+karma@6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
+  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1630,6 +1614,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kotlin-web-helpers@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.0.0.tgz#b112096b273c1e733e0b86560998235c09a19286"
+  integrity sha512-xkVGl60Ygn/zuLkDPx+oHj7jeLR7hCvoNF99nhwXMn8a3ApB4lLiC9pk4ol4NHPjyoCbvQctBqvzUcp8pkqyWw==
+  dependencies:
+    format-util "^1.0.5"
 
 launch-editor@^2.6.0:
   version "2.9.1"
@@ -1787,10 +1778,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.0.tgz#9e5cbed8fa9b37537a25bd1f7fb4f6fc45458b9a"
-  integrity sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==
+mocha@10.7.3:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
+  integrity sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==
   dependencies:
     ansi-colors "^4.1.3"
     browser-stdout "^1.3.1"
@@ -2709,12 +2700,11 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.93.0:
-  version "5.93.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.93.0.tgz#2e89ec7035579bdfba9760d26c63ac5c3462a5e5"
-  integrity sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==
+webpack@5.94.0:
+  version "5.94.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
+  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
   dependencies:
-    "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.12.1"
     "@webassemblyjs/wasm-edit" "^1.12.1"
@@ -2723,7 +2713,7 @@ webpack@5.93.0:
     acorn-import-attributes "^1.9.5"
     browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.17.0"
+    enhanced-resolve "^5.17.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"

--- a/Src/java/settings.gradle.kts
+++ b/Src/java/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        kotlin("jvm") version "2.0.20"
+        kotlin("jvm") version "2.1.0"
     }
 }
 


### PR DESCRIPTION
What's included:

 - XmlUtil upgraded to 0.91.0-RC1
 - Kotlin upgraded to 2.1.0
 - characters below 0x20 like `\f` are properly escaped in ELM XML (JVM only)