### PR TITLE
Make the engine expression cache bigger

### DIFF
--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Cache.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Cache.java
@@ -16,24 +16,22 @@ public class Cache {
 
     private boolean enableExpressionCache = false;
 
-    private Map<FunctionRef, FunctionDef> functionCache = new HashMap<>();
+    private final Map<FunctionRef, FunctionDef> functionCache = new HashMap<>();
 
-    @SuppressWarnings("serial")
-    private Map<VersionedIdentifier, Map<String, ExpressionResult>> expressions =
+    private final Map<VersionedIdentifier, Map<String, ExpressionResult>> expressions =
             new LinkedHashMap<VersionedIdentifier, Map<String, ExpressionResult>>(10, 0.9f, true) {
                 @Override
                 protected boolean removeEldestEntry(
                         Map.Entry<VersionedIdentifier, Map<String, ExpressionResult>> eldestEntry) {
-                    return size() > 10;
+                    return size() > 50;
                 }
             };
 
-    @SuppressWarnings("serial")
     protected Map<String, ExpressionResult> constructLibraryExpressionHashMap() {
         return new LinkedHashMap<String, ExpressionResult>(15, 0.9f, true) {
             @Override
             protected boolean removeEldestEntry(Map.Entry<String, ExpressionResult> eldestEntry) {
-                return size() > 15;
+                return size() > 300;
             }
         };
     }


### PR DESCRIPTION
* Certain sets of content were blowing up the engine expression cache, causing many reevaluations of the same expression
* This PR changes the number of libraries cached to 50, and the number of expressions cached per library to 300
  * This was based on some analysis of CQL content out in the wild