### PR TITLE
Add Write and ReadAccessor caches for the SystemDataProvider

### DIFF
--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
@@ -57,7 +57,6 @@ public class SystemDataProvider extends BaseModelResolver implements DataProvide
         }
     }
 
-
     static class AccessorKey {
         private final String path;
         private final Class<?> type;

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/State.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/State.java
@@ -25,14 +25,14 @@ public class State {
 
     private final Environment environment;
 
-    private Deque<String> currentContext = new ArrayDeque<>();
+    private final Deque<String> currentContext = new ArrayDeque<>();
 
     private Deque<Deque<Variable>> windows = new ArrayDeque<>();
-    private Deque<Library> currentLibrary = new ArrayDeque<>();
+    private final Deque<Library> currentLibrary = new ArrayDeque<>();
 
-    private Deque<HashSet<Object>> evaluatedResourceStack = new ArrayDeque<>();
+    private final Deque<HashSet<Object>> evaluatedResourceStack = new ArrayDeque<>();
 
-    private Map<String, Object> parameters = new HashMap<>();
+    private final Map<String, Object> parameters = new HashMap<>();
     private Map<String, Object> contextValues = new HashMap<>();
 
     private ZonedDateTime evaluationZonedDateTime;


### PR DESCRIPTION
* This PR adds Write/ReadAccessor caches to the SystemDataProvider so that the reflection to create those is only done once. This results in a speed-up for long-lived instances of the Engine.
* The number of built-in types for CQL and their corresponding getter/setters is limited, so the cache should no grow idefinitely.
* In principle, we could achieve the same speed-up by code-genning all the accessors.