### PR TITLE
Change default list comparison behavior to use "equivalent" semantics.

### DIFF
--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlComparisonOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlComparisonOperatorsTest.xml
@@ -692,11 +692,11 @@
 		</test>
 		<test name="EquivFloat1Float1WithPrecision">
 			<expression>1.5 ~ 1.55</expression>
-			<output>true</output>
+			<output>false</output>
 		</test>
 		<test name="EquivFloat1Float1WithPrecisionAndZ">
 			<expression>1.50 ~ 1.55</expression>
-			<output>true</output>
+			<output>false</output>
 		</test>
 		<test name="EquivFloatTrailingZero">
 			<expression>1.001 ~ 1.000</expression>

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/EquivalentEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/EquivalentEvaluator.java
@@ -72,8 +72,8 @@ public class EquivalentEvaluator {
             int minScale = Math.min(leftDecimal.scale(), rightDecimal.scale());
             if (minScale >= 0) {
                 return leftDecimal
-                                .setScale(minScale, RoundingMode.FLOOR)
-                                .compareTo(rightDecimal.setScale(minScale, RoundingMode.FLOOR))
+                                .setScale(minScale, RoundingMode.HALF_UP)
+                                .compareTo(rightDecimal.setScale(minScale, RoundingMode.HALF_UP))
                         == 0;
             }
             return leftDecimal.compareTo(rightDecimal) == 0;
@@ -83,7 +83,7 @@ public class EquivalentEvaluator {
             return CqlList.equivalent((Iterable<?>) left, (Iterable<?>) right, state);
         } else if (left instanceof CqlType) {
             return ((CqlType) left).equivalent(right);
-        } else if (left instanceof String && right instanceof String) {
+        } else if (left instanceof String) {
             return ((String) left).equalsIgnoreCase((String) right);
         }
 

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InEvaluator.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.cql.engine.elm.executing;
 
 import java.util.Arrays;
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.engine.execution.CqlEngine;
 import org.opencds.cqf.cql.engine.execution.State;
 import org.opencds.cqf.cql.engine.runtime.BaseTemporal;
 import org.opencds.cqf.cql.engine.runtime.Interval;
@@ -115,8 +116,13 @@ public class InEvaluator {
                 return true;
             }
 
-            isEqual = EqualEvaluator.equal(left, element, state);
-            if ((isEqual != null && isEqual)) {
+            if (state.getEngineOptions().contains(CqlEngine.Options.DisableEquivalentIn)) {
+                isEqual = EqualEvaluator.equal(left, element, state);
+            } else {
+                isEqual = EquivalentEvaluator.equivalent(left, element, state);
+            }
+
+            if (Boolean.TRUE.equals(isEqual)) {
                 return true;
             }
         }

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.cql.engine.execution;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElseGet;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -40,7 +39,8 @@ public class CqlEngine {
     public CqlEngine(Environment environment, Set<Options> engineOptions) {
         requireNonNull(environment.getLibraryManager(), "Environment LibraryManager can not be null.");
         this.environment = environment;
-        this.engineOptions = requireNonNullElseGet(engineOptions, () -> EnumSet.of(Options.EnableExpressionCaching));
+
+        this.engineOptions = engineOptions != null ? engineOptions : EnumSet.of(Options.EnableExpressionCaching);
         this.state = new State(environment, engineOptions);
 
         if (this.engineOptions.contains(CqlEngine.Options.EnableExpressionCaching)) {
@@ -284,7 +284,7 @@ public class CqlEngine {
                     "library %s loaded, but had errors: %s",
                     libraryIdentifier.getId()
                             + (libraryIdentifier.getVersion() != null ? "-" + libraryIdentifier.getVersion() : ""),
-                    String.join(", ", errors.stream().map(e -> e.getMessage()).collect(Collectors.toList()))));
+                    errors.stream().map(Throwable::getMessage).collect(Collectors.joining(", "))));
         }
 
         if (this.engineOptions.contains(Options.EnableValidation)) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/State.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/State.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.engine.execution;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.ZonedDateTime;
 import java.util.*;
 import org.hl7.elm.r1.*;
@@ -17,11 +19,17 @@ import org.opencds.cqf.cql.engine.runtime.DateTime;
 public class State {
 
     public State(Environment environment) {
-        this.environment = environment;
+        this(environment, new HashSet<>());
+    }
+
+    public State(Environment environment, Set<CqlEngine.Options> engineOptions) {
+        this.environment = requireNonNull(environment);
+        this.engineOptions = requireNonNull(engineOptions);
         this.setEvaluationDateTime(ZonedDateTime.now());
     }
 
     private final Cache cache = new Cache();
+    private final Set<CqlEngine.Options> engineOptions;
 
     private final Environment environment;
 
@@ -54,6 +62,10 @@ public class State {
 
     public Map<String, Object> getParameters() {
         return parameters;
+    }
+
+    public Set<CqlEngine.Options> getEngineOptions() {
+        return engineOptions;
     }
 
     public void setParameters(Library library, Map<String, Object> parameters) {

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.cql.engine.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,5 +35,19 @@ class CqlEngineTest extends CqlTestBase {
 
         var debugResult = libraryDebug.get(result.get());
         assertEquals(1, debugResult.size());
+    }
+
+    @Test
+    public void equivalentInOption() {
+        var libraryResult = engine.evaluate(toElmIdentifier("CqlEquivalentInOptionTest"));
+        var expressionResult =
+                libraryResult.expressionResults.get("QuantityListIncludes").value();
+        assertTrue((Boolean) expressionResult);
+
+        engine.getState().getEngineOptions().add(CqlEngine.Options.DisableEquivalentIn);
+        libraryResult = engine.evaluate(toElmIdentifier("CqlEquivalentInOptionTest"));
+        expressionResult =
+                libraryResult.expressionResults.get("QuantityListIncludes").value();
+        assertFalse((Boolean) expressionResult);
     }
 }

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEquivalentInOptionTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEquivalentInOptionTest.cql
@@ -1,0 +1,7 @@
+library CqlEquivalentInOptionTest
+
+// The result of this expression should be "true" when the CQL engine
+// is using "equivalent" semantics for the "in" operator, and false when using "equality" semantics.
+// There's an engine option to control this behavior.
+define "QuantityListIncludes": {
+    ToQuantity('1 \'m\'') } includes ToQuantity('1.1 \'m\'')

--- a/Src/java/qdm/build.gradle
+++ b/Src/java/qdm/build.gradle
@@ -7,16 +7,3 @@ dependencies {
     api project(':elm')
     api project(':model')
 }
-
-generateSources{
-    inputs.dir "${projectDir}/schema"
-
-    doLast {
-        ant.xjc(destdir: xjc.destDir, schema: "${projectDir}/schema/qdm.xsd") {
-            arg(line: xjc.args)
-        }
-        ant.xjc(destdir: xjc.destDir, schema: "${projectDir}/schema/qdm.4.2.xsd") {
-            arg(line: xjc.args)
-        }
-    }
-}


### PR DESCRIPTION
* The next version of the CQL spec adds a new `~in` operator to check for list membership using `equivalence` rather than `equality`.
* This PR changes the CQL engine to behavior to default to that, and adds an option to fall back to the current `equality` behavior.
* It also fixes a couple decimal equivalence tests that were found to be wrong in testing. Decimals should use round-half behavior rather than floor rounding for equivalence.