### PR TITLE
Add "HEDIS Compatibility" to CQL engine options, Add support for non-distinct returns

### DIFF
--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/InEvaluator.java
@@ -116,7 +116,7 @@ public class InEvaluator {
                 return true;
             }
 
-            if (state.getEngineOptions().contains(CqlEngine.Options.DisableEquivalentIn)) {
+            if (state.getEngineOptions().contains(CqlEngine.Options.EnableHedisCompatibilityMode)) {
                 isEqual = EqualEvaluator.equal(left, element, state);
             } else {
                 isEqual = EquivalentEvaluator.equivalent(left, element, state);

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluator.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluator.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.cqframework.cql.elm.visiting.ElmLibraryVisitor;
 import org.hl7.elm.r1.*;
 import org.opencds.cqf.cql.engine.exception.CqlException;
+import org.opencds.cqf.cql.engine.execution.CqlEngine;
 import org.opencds.cqf.cql.engine.execution.State;
 import org.opencds.cqf.cql.engine.execution.Variable;
 import org.opencds.cqf.cql.engine.runtime.CqlList;
@@ -215,7 +216,9 @@ public class QueryEvaluator {
             }
         }
 
-        if (elm.getReturn() != null && elm.getReturn().isDistinct()) {
+        if (elm.getReturn() != null
+                && elm.getReturn().isDistinct()
+                && !state.getEngineOptions().contains(CqlEngine.Options.EnableHedisCompatibilityMode)) {
             result = DistinctEvaluator.distinct(result, state);
         }
 

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -24,7 +24,16 @@ public class CqlEngine {
     public enum Options {
         EnableExpressionCaching,
         EnableValidation,
-        DisableEquivalentIn
+        // HEDIS Compatibility Mode changes the behavior of the CQL
+        // engine to match some expected behavior of the HEDIS
+        // content that is not standards-complaint.
+        // Currently, this includes:
+        //  1. Making the default comparison semantics for lists to be "equivalent"
+        //      (the standard behavior is to use "equal" semantics - note that this is
+        //      expected to be the standard behavior in a future version of the CQL spec)
+        //  2. Ignoring the "all" / "distinct" modifiers for the "return" clause of queries, always return all elements
+        //      (the standard behavior is to return distinct elements)
+        EnableHedisCompatibilityMode
     }
 
     private final Environment environment;

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
@@ -2,9 +2,11 @@ package org.opencds.cqf.cql.engine.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opencds.cqf.cql.engine.debug.DebugMap;
 
@@ -38,16 +40,40 @@ class CqlEngineTest extends CqlTestBase {
     }
 
     @Test
-    public void equivalentInOption() {
-        var libraryResult = engine.evaluate(toElmIdentifier("CqlEquivalentInOptionTest"));
-        var expressionResult =
-                libraryResult.expressionResults.get("QuantityListIncludes").value();
-        assertTrue((Boolean) expressionResult);
+    public void hedisCompatibility() {
+        var libraryResult = engine.evaluate(toElmIdentifier("HedisCompatibilityTest"));
+        var result = libraryResult.expressionResults.get("QuantityListIncludes").value();
+        assertTrue((Boolean) result);
 
-        engine.getState().getEngineOptions().add(CqlEngine.Options.DisableEquivalentIn);
-        libraryResult = engine.evaluate(toElmIdentifier("CqlEquivalentInOptionTest"));
-        expressionResult =
-                libraryResult.expressionResults.get("QuantityListIncludes").value();
-        assertFalse((Boolean) expressionResult);
+        result = libraryResult.expressionResults.get("ReturnUnspecified").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(2, ((List<?>) result).size());
+
+        result = libraryResult.expressionResults.get("ReturnAll").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(5, ((List<?>) result).size());
+
+        result = libraryResult.expressionResults.get("ReturnDistinct").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(2, ((List<?>) result).size());
+
+        engine.getState().getEngineOptions().add(CqlEngine.Options.EnableHedisCompatibilityMode);
+        libraryResult = engine.evaluate(toElmIdentifier("HedisCompatibilityTest"));
+        // equivalent semantics for lists
+        result = libraryResult.expressionResults.get("QuantityListIncludes").value();
+        assertFalse((Boolean) result);
+
+        // no "distinct" behavior for lists
+        result = libraryResult.expressionResults.get("ReturnUnspecified").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(5, ((List<?>) result).size());
+
+        result = libraryResult.expressionResults.get("ReturnAll").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(5, ((List<?>) result).size());
+
+        result = libraryResult.expressionResults.get("ReturnDistinct").value();
+        assertInstanceOf(List.class, result);
+        assertEquals(5, ((List<?>) result).size());
     }
 }

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEngineTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEngineTest.cql
@@ -1,7 +1,7 @@
 library CqlEngineTest
 
 // This is mostly a dummy library to doing some testing on top-level CQL engine Java APIS.
-// It's not meant to test innner execution of the engine
+// It's not meant to test inner execution of the engine
 
 define "AnInteger": 1
 

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEquivalentInOptionTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlEquivalentInOptionTest.cql
@@ -1,7 +1,0 @@
-library CqlEquivalentInOptionTest
-
-// The result of this expression should be "true" when the CQL engine
-// is using "equivalent" semantics for the "in" operator, and false when using "equality" semantics.
-// There's an engine option to control this behavior.
-define "QuantityListIncludes": {
-    ToQuantity('1 \'m\'') } includes ToQuantity('1.1 \'m\'')

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/HedisCompatibilityTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/HedisCompatibilityTest.cql
@@ -1,0 +1,20 @@
+library HedisCompatibilityTest version '1.0.0'
+
+// The result of this expression should be "true" when the CQL engine
+// is using "equivalent" semantics for the "in" operator, and false when using "equality" semantics.
+// There's an engine option to control this behavior.
+define "QuantityListIncludes": {
+    ToQuantity('1 \'m\'') } includes ToQuantity('1.1 \'m\'')
+
+
+// default behavior is "distinct", "all" for HEDIS
+define "ReturnUnspecified":
+   ({1, 1, 1, 2, 2 }) X return X
+
+// both standard and HEDIS behavior is "all"
+define "ReturnAll":
+   ({1, 1, 1, 2, 2 }) X return all X
+
+// standard behavior is "distinct", HEDIS behavior is "all", even if "distinct" is specified
+define "ReturnDistinct":
+    ({1, 1, 1, 2, 2 }) X return distinct X


### PR DESCRIPTION
* Change "EnableEquivalentIn" to "EnableHedisCompatiblity"
  * There are now multiple HEDIS compatibility behaviors we wanted to group
* Ignore `distinct`/`all` modifier for returns, always return all when HEDIS compatibility is on