### PR TITLE
Added check for extension path on primitive types in version specific ModelResolver classes

### DIFF
--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MoneyQuantity;
 import org.hl7.fhir.r4.model.OidType;
 import org.hl7.fhir.r4.model.PositiveIntType;
+import org.hl7.fhir.r4.model.PrimitiveType;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.SimpleQuantity;
@@ -99,9 +100,14 @@ public class R4FhirModelResolver
 
     @Override
     protected Object resolveProperty(Object target, String path) {
-        // This is kind of a hack to get around contained resources - HAPI doesn't have ResourceContainer type for STU3
+        // This is kind of a hack to get around contained resources - HAPI doesn't have ResourceContainer type for R4
         if (target instanceof Resource && ((Resource) target).fhirType().equals(path)) {
             return target;
+        }
+
+        // Account for extensions on primitives
+        if (target instanceof PrimitiveType && path.equals("extension")) {
+            return ((PrimitiveType<?>) target).getExtension();
         }
 
         return super.resolveProperty(target, path);

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R5FhirModelResolver.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R5FhirModelResolver.java
@@ -28,6 +28,7 @@ import org.hl7.fhir.r5.model.MarkdownType;
 import org.hl7.fhir.r5.model.MoneyQuantity;
 import org.hl7.fhir.r5.model.OidType;
 import org.hl7.fhir.r5.model.PositiveIntType;
+import org.hl7.fhir.r5.model.PrimitiveType;
 import org.hl7.fhir.r5.model.Quantity;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.SimpleQuantity;
@@ -101,9 +102,14 @@ public class R5FhirModelResolver
     @Override
     protected Object resolveProperty(Object target, String path) {
         // This is kind of a hack to get around contained resources - HAPI doesn't have
-        // ResourceContainer type for STU3
+        // ResourceContainer type for R5
         if (target instanceof Resource && ((Resource) target).fhirType().equals(path)) {
             return target;
+        }
+
+        // Account for extensions on primitives
+        if (target instanceof PrimitiveType && path.equals("extension")) {
+            return ((PrimitiveType<?>) target).getExtension();
         }
 
         return super.resolveProperty(target, path);

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.cql.engine.fhir.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.math.BigDecimal;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -17,6 +19,7 @@ import java.util.List;
 import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r5.model.BaseDateTimeType;
 import org.hl7.fhir.r5.model.DateTimeType;
+import org.hl7.fhir.r5.model.DateType;
 import org.hl7.fhir.r5.model.Enumeration;
 import org.hl7.fhir.r5.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.r5.model.Enumerations.BindingStrength;
@@ -24,6 +27,7 @@ import org.hl7.fhir.r5.model.Enumerations.FHIRTypes;
 import org.hl7.fhir.r5.model.Enumerations.FHIRVersion;
 import org.hl7.fhir.r5.model.Enumerations.PublicationStatus;
 import org.hl7.fhir.r5.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r5.model.Extension;
 import org.hl7.fhir.r5.model.IdType;
 import org.hl7.fhir.r5.model.Patient;
 import org.hl7.fhir.r5.model.Quantity;
@@ -328,5 +332,24 @@ class TestR5ModelResolver {
 
         var value = resolver.resolvePath(dt, "value");
         assertNull(value);
+    }
+
+    @Test
+    void resolveBirthDateExtensionPatient() throws ParseException {
+        final var resolver = new R5FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R5));
+
+        final var patient = new Patient();
+        var birthDate = org.apache.commons.lang3.time.DateUtils.parseDate("1974-12-25", "yyyy-dd-MM");
+        patient.setBirthDate(birthDate);
+        patient.getBirthDateElement()
+                .addExtension(
+                        "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                        new DateTimeType("1974-12-25T14:35:45-05:00"));
+        var result = resolver.resolvePath(patient, "birthDate");
+        assertInstanceOf(DateType.class, result);
+        result = resolver.resolvePath(patient, "birthDate.extension");
+        assertInstanceOf(List.class, result);
+        assertEquals(1, ((List<?>) result).size());
+        assertInstanceOf(Extension.class, ((List<?>) result).get(0));
     }
 }


### PR DESCRIPTION
- Fix for #1559
- Added simple tests

I did run into a test failure locally, but it did not appear to be associated with the work in this PR.