### PR TITLE
Add support for mapping Exceptions and Unknown types to FHIR OperationOutcomes

### DIFF
--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/BaseFhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/BaseFhirTypeConverter.java
@@ -72,8 +72,8 @@ abstract class BaseFhirTypeConverter implements FhirTypeConverter {
             throw new IllegalArgumentException("use toFhirTypes(Iterable<Object>) for iterables");
         }
 
-        if (value instanceof Throwable t) {
-            return toFhirOperationOutcome(t);
+        if (value instanceof Exception e) {
+            return toFhirOperationOutcome(e);
         }
 
         if (isFhirType(value)) {
@@ -533,10 +533,10 @@ abstract class BaseFhirTypeConverter implements FhirTypeConverter {
         return TemporalPrecisionEnum.valueOf(name);
     }
 
-    protected String getStackTraceAsString(Throwable throwable) {
+    protected String getStackTraceAsString(Exception exception) {
         StringWriter sw = new StringWriter();
         try (PrintWriter pw = new PrintWriter(sw)) {
-            throwable.printStackTrace(pw);
+            exception.printStackTrace(pw);
         }
         return sw.toString();
     }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
@@ -476,8 +476,8 @@ class Dstu2FhirTypeConverter extends BaseFhirTypeConverter {
     }
 
     @Override
-    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
-        if (value == null) {
+    public IBaseOperationOutcome toFhirOperationOutcome(Exception exception) {
+        if (exception == null) {
             return null;
         }
 
@@ -485,8 +485,8 @@ class Dstu2FhirTypeConverter extends BaseFhirTypeConverter {
         outcome.addIssue()
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDiagnostics(value.getMessage())
-                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+                .setDiagnostics(exception.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(exception)));
 
         return outcome;
     }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.java
@@ -8,9 +8,11 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.dstu2.model.*;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
@@ -471,6 +473,37 @@ class Dstu2FhirTypeConverter extends BaseFhirTypeConverter {
         } else {
             throw new IllegalArgumentException("value is not a FHIR Instant or DateTime");
         }
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
+        if (value == null) {
+            return null;
+        }
+
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                .setCode(OperationOutcome.IssueType.EXCEPTION)
+                .setDiagnostics(value.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+
+        return outcome;
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        var s = (String) ToStringEvaluator.toString(value);
+        var outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                .setCode(OperationOutcome.IssueType.INFORMATIONAL)
+                .addExtension(CQL_TEXT_EXT_URL, new StringType(s));
+        return outcome;
     }
 
     // The built-in "toCalendar" function is bugged.

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
@@ -477,8 +477,8 @@ class Dstu3FhirTypeConverter extends BaseFhirTypeConverter {
     }
 
     @Override
-    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
-        if (value == null) {
+    public IBaseOperationOutcome toFhirOperationOutcome(Exception exception) {
+        if (exception == null) {
             return null;
         }
 
@@ -486,8 +486,8 @@ class Dstu3FhirTypeConverter extends BaseFhirTypeConverter {
         outcome.addIssue()
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDiagnostics(value.getMessage())
-                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+                .setDiagnostics(exception.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(exception)));
 
         return outcome;
     }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.java
@@ -7,9 +7,11 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
@@ -472,5 +474,36 @@ class Dstu3FhirTypeConverter extends BaseFhirTypeConverter {
         } else {
             throw new IllegalArgumentException("value is not a FHIR Instant or DateTime");
         }
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
+        if (value == null) {
+            return null;
+        }
+
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                .setCode(OperationOutcome.IssueType.EXCEPTION)
+                .setDiagnostics(value.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+
+        return outcome;
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        var s = (String) ToStringEvaluator.toString(value);
+        var outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                .setCode(OperationOutcome.IssueType.INFORMATIONAL)
+                .addExtension(CQL_TEXT_EXT_URL, new StringType(s));
+        return outcome;
     }
 }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
@@ -36,7 +36,7 @@ public interface FhirTypeConverter {
     static final String DATA_ABSENT_REASON_UNKNOWN_CODE = "unknown";
     static final String CQL_TYPE_EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-cqlType";
 
-    // Stacktrace of an exception that occurred during CQL evaluation, as the native platform rerpesents it (e.g. Java)
+    // Stacktrace of an exception that occurred during CQL evaluation, as the native platform represents it (e.g. Java)
     static final String NATIVE_STACK_TRACE_EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-nativeStackTrace";
 
     // The CQL representation of a FHIR structure.

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
@@ -85,7 +85,7 @@ public interface FhirTypeConverter {
      */
     public IBaseOperationOutcome toFhirOperationOutcome(Object value);
 
-    public IBaseOperationOutcome toFhirOperationOutcome(Throwable t);
+    public IBaseOperationOutcome toFhirOperationOutcome(Exception exception);
 
     /**
      * Converts a String to a FHIR Id

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
@@ -76,7 +76,7 @@ public interface FhirTypeConverter {
      * types that do not have well-defined FHIR mappings, such as CQL Intervals.
      *
      * The default implementation should use the CQL ToString operator and
-     * embedd the result in a FHIR OperationOutcome with a single issue.
+     * embed the result in a FHIR OperationOutcome with a single issue.
      *
      * @param value the value to convert
      * @return a FHIR OperationOutcome

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/FhirTypeConverter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
@@ -35,6 +36,12 @@ public interface FhirTypeConverter {
     static final String DATA_ABSENT_REASON_UNKNOWN_CODE = "unknown";
     static final String CQL_TYPE_EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-cqlType";
 
+    // Stacktrace of an exception that occurred during CQL evaluation, as the native platform rerpesents it (e.g. Java)
+    static final String NATIVE_STACK_TRACE_EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-nativeStackTrace";
+
+    // The CQL representation of a FHIR structure.
+    static final String CQL_TEXT_EXT_URL = "http://hl7.org/fhir/StructureDefinition/cqf-cqlText";
+
     // CQL-to-FHIR conversions
 
     /**
@@ -63,6 +70,22 @@ public interface FhirTypeConverter {
      * @return an List containing FHIR types, nulls, and sublists
      */
     public List<Object> toFhirTypes(Iterable<?> values);
+
+    /**
+     * Converts an Object to a FHIR OperationOutcome. This is used for arbitrary
+     * types that do not have well-defined FHIR mappings, such as CQL Intervals.
+     *
+     * The default implementation should use the CQL ToString operator and
+     * embedd the result in a FHIR OperationOutcome with a single issue.
+     *
+     * @param value the value to convert
+     * @return a FHIR OperationOutcome
+     *
+     * @return
+     */
+    public IBaseOperationOutcome toFhirOperationOutcome(Object value);
+
+    public IBaseOperationOutcome toFhirOperationOutcome(Throwable t);
 
     /**
      * Converts a String to a FHIR Id
@@ -221,7 +244,7 @@ public interface FhirTypeConverter {
      * @param value a Quantity, Date, or DateTime interval
      * @return A FHIR Range or Period
      */
-    public ICompositeType toFhirInterval(Interval value);
+    public IBase toFhirInterval(Interval value);
 
     /**
      * Converts a CQL Tuple to a FHIR Structure

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
@@ -470,8 +470,8 @@ class R4FhirTypeConverter extends BaseFhirTypeConverter {
     }
 
     @Override
-    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
-        if (value == null) {
+    public IBaseOperationOutcome toFhirOperationOutcome(Exception exception) {
+        if (exception == null) {
             return null;
         }
 
@@ -479,8 +479,8 @@ class R4FhirTypeConverter extends BaseFhirTypeConverter {
         outcome.addIssue()
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDiagnostics(value.getMessage())
-                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+                .setDiagnostics(exception.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(exception)));
 
         return outcome;
     }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.java
@@ -6,10 +6,12 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.*;
+import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
@@ -465,5 +467,36 @@ class R4FhirTypeConverter extends BaseFhirTypeConverter {
         } else {
             throw new IllegalArgumentException("value is not a FHIR Instant or DateTime");
         }
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
+        if (value == null) {
+            return null;
+        }
+
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                .setCode(OperationOutcome.IssueType.EXCEPTION)
+                .setDiagnostics(value.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+
+        return outcome;
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        var s = (String) ToStringEvaluator.toString(value);
+        var outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                .setCode(OperationOutcome.IssueType.INFORMATIONAL)
+                .addExtension(CQL_TEXT_EXT_URL, new StringType(s));
+        return outcome;
     }
 }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
@@ -473,8 +473,8 @@ class R5FhirTypeConverter extends BaseFhirTypeConverter {
     }
 
     @Override
-    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
-        if (value == null) {
+    public IBaseOperationOutcome toFhirOperationOutcome(Exception exception) {
+        if (exception == null) {
             return null;
         }
 
@@ -482,8 +482,8 @@ class R5FhirTypeConverter extends BaseFhirTypeConverter {
         outcome.addIssue()
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDiagnostics(value.getMessage())
-                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+                .setDiagnostics(exception.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(exception)));
 
         return outcome;
     }

--- a/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
+++ b/Src/java/engine-fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.java
@@ -6,10 +6,12 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r5.model.*;
+import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator;
 import org.opencds.cqf.cql.engine.runtime.*;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Ratio;
@@ -468,5 +470,36 @@ class R5FhirTypeConverter extends BaseFhirTypeConverter {
         } else {
             throw new IllegalArgumentException("value is not a FHIR Instant or DateTime");
         }
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Throwable value) {
+        if (value == null) {
+            return null;
+        }
+
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                .setCode(OperationOutcome.IssueType.EXCEPTION)
+                .setDiagnostics(value.getMessage())
+                .addExtension(NATIVE_STACK_TRACE_EXT_URL, new StringType(getStackTraceAsString(value)));
+
+        return outcome;
+    }
+
+    @Override
+    public IBaseOperationOutcome toFhirOperationOutcome(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        var s = (String) ToStringEvaluator.toString(value);
+        var outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+                .setCode(OperationOutcome.IssueType.INFORMATIONAL)
+                .addExtension(CQL_TEXT_EXT_URL, new StringType(s));
+        return outcome;
     }
 }

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -41,7 +41,6 @@ import org.hl7.fhir.dstu2.model.SimpleQuantity;
 import org.hl7.fhir.dstu2.model.StringType;
 import org.hl7.fhir.dstu2.model.TimeType;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.junit.jupiter.api.Assertions;
@@ -500,7 +499,7 @@ class Dstu2TypeConverterTests {
                 true));
         assertTrue(expectedRange.equalsDeep(actualRange));
 
-        ICompositeType expected = typeConverter.toFhirInterval(null);
+        var expected = typeConverter.toFhirInterval(null);
         assertNull(expected);
     }
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -4,6 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,6 +34,7 @@ import org.hl7.fhir.dstu2.model.Encounter;
 import org.hl7.fhir.dstu2.model.IdType;
 import org.hl7.fhir.dstu2.model.InstantType;
 import org.hl7.fhir.dstu2.model.IntegerType;
+import org.hl7.fhir.dstu2.model.OperationOutcome;
 import org.hl7.fhir.dstu2.model.Parameters;
 import org.hl7.fhir.dstu2.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.dstu2.model.Patient;
@@ -504,10 +507,42 @@ class Dstu2TypeConverterTests {
     }
 
     @Test
-    void invalidIntervalToFhirInterval() {
+    // Integer intervals are not supported in FHIR, so we produce the raw
+    // CQL text in an OperationOutcome instead
+    void integerIntervalToFhirOperationOutcome() {
         var interval = new Interval(5, true, 6, true);
+        var result = typeConverter.toFhirInterval(interval);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.INFORMATIONAL, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, issue.getSeverity());
+        var extension = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.CQL_TEXT_EXT_URL))
+                .findFirst();
+        assertTrue(extension.isPresent());
+        assertEquals("Interval[5, 6]", extension.get().getValue().toString());
+    }
 
-        assertThrows(IllegalArgumentException.class, () -> typeConverter.toFhirInterval(interval));
+    @Test
+    void exceptionToFhirOperationOutcome() {
+        var exception = new IllegalArgumentException("Test exception");
+        exception.fillInStackTrace();
+        var result = typeConverter.toFhirOperationOutcome(exception);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.EXCEPTION, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
+        assertEquals("Test exception", issue.getDiagnostics());
+
+        var stackTrace = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.NATIVE_STACK_TRACE_EXT_URL))
+                .findFirst();
+        assertTrue(stackTrace.isPresent());
+        assertNotNull(stackTrace.get().getValue().toString());
     }
 
     private static List<ParametersParameterComponent> getPartsByName(ParametersParameterComponent ppc, String name) {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
@@ -42,7 +42,6 @@ import org.hl7.fhir.dstu3.model.SimpleQuantity;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.fhir.dstu3.model.TimeType;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.junit.jupiter.api.BeforeAll;
@@ -504,7 +503,7 @@ class Dstu3TypeConverterTests {
                 true));
         assertTrue(expectedRange.equalsDeep(actualRange));
 
-        ICompositeType expected = typeConverter.toFhirInterval(null);
+        var expected = typeConverter.toFhirInterval(null);
         assertNull(expected);
     }
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,6 +37,7 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4.model.Patient;
@@ -441,12 +443,6 @@ class R4TypeConverterTests {
     }
 
     @Test
-    void invalidIntervalToFhirPeriod() {
-        var interval = new Interval(5, true, 6, true);
-        assertThrows(IllegalArgumentException.class, () -> typeConverter.toFhirPeriod(interval));
-    }
-
-    @Test
     void intervalToFhirRange() {
         Range expected = new Range()
                 .setLow(new org.hl7.fhir.r4.model.Quantity()
@@ -508,10 +504,42 @@ class R4TypeConverterTests {
     }
 
     @Test
-    void invalidIntervalToFhirInterval() {
+    // Integer intervals are not supported in FHIR, so we produce the raw
+    // CQL text in an OperationOutcome instead
+    void integerIntervalToFhirOperationOutcome() {
         var interval = new Interval(5, true, 6, true);
+        var result = typeConverter.toFhirInterval(interval);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.INFORMATIONAL, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, issue.getSeverity());
+        var extension = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.CQL_TEXT_EXT_URL))
+                .findFirst();
+        assertTrue(extension.isPresent());
+        assertEquals("Interval[5, 6]", extension.get().getValue().toString());
+    }
 
-        assertThrows(IllegalArgumentException.class, () -> typeConverter.toFhirInterval(interval));
+    @Test
+    void exceptionToFhirOperationOutcome() {
+        var exception = new IllegalArgumentException("Test exception");
+        exception.fillInStackTrace();
+        var result = typeConverter.toFhirOperationOutcome(exception);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.EXCEPTION, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
+        assertEquals("Test exception", issue.getDiagnostics());
+
+        var stackTrace = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.NATIVE_STACK_TRACE_EXT_URL))
+                .findFirst();
+        assertTrue(stackTrace.isPresent());
+        assertNotNull(stackTrace.get().getValue().toString());
     }
 
     private static List<ParametersParameterComponent> getPartsByName(ParametersParameterComponent ppc, String name) {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
@@ -22,7 +22,6 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.model.Attachment;
@@ -504,7 +503,7 @@ class R4TypeConverterTests {
                 true));
         assertTrue(expectedRange.equalsDeep(actualRange));
 
-        ICompositeType expected = typeConverter.toFhirInterval(null);
+        var expected = typeConverter.toFhirInterval(null);
         assertNull(expected);
     }
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
@@ -23,7 +23,6 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r5.model.Attachment;
@@ -506,7 +505,7 @@ class R5TypeConverterTests {
                 true));
         assertTrue(expectedRange.equalsDeep(actualRange));
 
-        ICompositeType expected = typeConverter.toFhirInterval(null);
+        var expected = typeConverter.toFhirInterval(null);
         assertNull(expected);
     }
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
@@ -38,6 +38,7 @@ import org.hl7.fhir.r5.model.IdType;
 import org.hl7.fhir.r5.model.InstantType;
 import org.hl7.fhir.r5.model.Integer64Type;
 import org.hl7.fhir.r5.model.IntegerType;
+import org.hl7.fhir.r5.model.OperationOutcome;
 import org.hl7.fhir.r5.model.Parameters;
 import org.hl7.fhir.r5.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r5.model.Patient;
@@ -510,10 +511,42 @@ class R5TypeConverterTests {
     }
 
     @Test
-    void invalidIntervalToFhirInterval() {
+    // Integer intervals are not supported in FHIR, so we produce the raw
+    // CQL text in an OperationOutcome instead
+    void integerIntervalToFhirOperationOutcome() {
         var interval = new Interval(5, true, 6, true);
+        var result = typeConverter.toFhirInterval(interval);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.INFORMATIONAL, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, issue.getSeverity());
+        var extension = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.CQL_TEXT_EXT_URL))
+                .findFirst();
+        assertTrue(extension.isPresent());
+        assertEquals("Interval[5, 6]", extension.get().getValue().toString());
+    }
 
-        assertThrows(IllegalArgumentException.class, () -> typeConverter.toFhirInterval(interval));
+    @Test
+    void exceptionToFhirOperationOutcome() {
+        var exception = new IllegalArgumentException("Test exception");
+        exception.fillInStackTrace();
+        var result = typeConverter.toFhirOperationOutcome(exception);
+        assertNotNull(result);
+        var outcome = assertInstanceOf(OperationOutcome.class, result);
+        assertEquals(1, outcome.getIssue().size());
+        var issue = outcome.getIssue().get(0);
+        assertEquals(OperationOutcome.IssueType.EXCEPTION, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
+        assertEquals("Test exception", issue.getDiagnostics());
+
+        var stackTrace = issue.getExtension().stream()
+                .filter(e -> e.getUrl().equals(FhirTypeConverter.NATIVE_STACK_TRACE_EXT_URL))
+                .findFirst();
+        assertTrue(stackTrace.isPresent());
+        assertNotNull(stackTrace.get().getValue().toString());
     }
 
     private static List<ParametersParameterComponent> getPartsByName(ParametersParameterComponent ppc, String name) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/debug/DebugLibraryResultEntry.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/debug/DebugLibraryResultEntry.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.engine.debug;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,19 +35,14 @@ public class DebugLibraryResultEntry {
     }
 
     public void logDebugResultEntry(final Element node, final Object result) {
-        if (node != null) {
-            if (node.getLocalId() != null) {
-                DebugLocator locator = new DebugLocator(DebugLocator.DebugLocatorType.NODE_ID, node.getLocalId());
-                logDebugResult(locator, result);
-            }
+        requireNonNull(node, "node cannot be null");
+        if (node.getLocalId() != null) {
+            DebugLocator locator = new DebugLocator(DebugLocator.DebugLocatorType.NODE_ID, node.getLocalId());
+            logDebugResult(locator, result);
+        }
 
-            if (node.getLocator() != null) {
-                DebugLocator locator = new DebugLocator(Location.fromLocator(node.getLocator()));
-                logDebugResult(locator, result);
-            }
-        } else {
-            DebugLocator locator = new DebugLocator(
-                    DebugLocator.DebugLocatorType.NODE_TYPE, node.getClass().getSimpleName());
+        if (node.getLocator() != null) {
+            DebugLocator locator = new DebugLocator(Location.fromLocator(node.getLocator()));
             logDebugResult(locator, result);
         }
     }


### PR DESCRIPTION
* Map Java exceptions to an OperationOutcome
* Map CQL types without a well-defined FHIR mapping to OperationOutcomes
* Fix a null-pointer reference