### PR TITLE
Ensure IDs within CQL files match the library identifiers used.  Fix …

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/LibraryManager.java
@@ -228,20 +228,18 @@ public class LibraryManager {
             }
 
             result = compiler.getCompiledLibrary();
-            if (libraryIdentifier.getVersion() != null
-                    && !libraryIdentifier
-                            .getVersion()
-                            .equals(result.getIdentifier().getVersion())) {
+
+            if (result == null) {
                 throw new CqlIncludeException(
                         String.format(
-                                "Library %s was included as version %s, but version %s of the library was found.",
-                                libraryPath,
-                                libraryIdentifier.getVersion(),
-                                result.getIdentifier().getVersion()),
+                                "Could not load source for library %s, version %s.",
+                                libraryPath, libraryIdentifier.getVersion()),
                         libraryIdentifier.getSystem(),
                         libraryIdentifier.getId(),
                         libraryIdentifier.getVersion());
             }
+
+            validateIdentifiers(libraryIdentifier, result, libraryPath);
 
         } catch (IOException e) {
             throw new CqlIncludeException(
@@ -254,17 +252,37 @@ public class LibraryManager {
                     e);
         }
 
-        if (result == null) {
+        sortStatements(result);
+        return result;
+    }
+
+    private void validateIdentifiers(
+            VersionedIdentifier libraryIdentifier, CompiledLibrary result, String libraryPath) {
+
+        var resultIdentifier = result.getIdentifier();
+
+        var areIdsEqual = libraryIdentifier.getId().equals(resultIdentifier.getId());
+        var libraryIdentifierVersion = libraryIdentifier.getVersion();
+        var resultIdentifierVersion = resultIdentifier.getVersion();
+
+        // If the library VersionedIdentifier used to query is null, then don't compare to the result library version,
+        // since we're doing a broader search
+        final boolean areIdentifiersValid;
+        if (libraryIdentifierVersion == null) {
+            areIdentifiersValid = areIdsEqual;
+        } else {
+            var areVersionsEqual = libraryIdentifierVersion.equals(resultIdentifier.getVersion());
+            areIdentifiersValid = areIdsEqual && areVersionsEqual;
+        }
+
+        if (!areIdentifiersValid) {
             throw new CqlIncludeException(
                     String.format(
-                            "Could not load source for library %s, version %s.",
-                            libraryPath, libraryIdentifier.getVersion()),
+                            "Library %s was included with version %s, but id: %s and version %s of the library was found.",
+                            libraryPath, libraryIdentifierVersion, resultIdentifier.getId(), resultIdentifierVersion),
                     libraryIdentifier.getSystem(),
                     libraryIdentifier.getId(),
-                    libraryIdentifier.getVersion());
-        } else {
-            sortStatements(result);
-            return result;
+                    libraryIdentifierVersion == null ? "null" : libraryIdentifierVersion);
         }
     }
 

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlTimezoneTests.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlTimezoneTests.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("removal")
 class CqlTimezoneTests extends CqlTestBase {
-    private static final VersionedIdentifier library = new VersionedIdentifier().withId("CqlTimezoneTests");
+    private static final VersionedIdentifier library = new VersionedIdentifier().withId("CqlTimeZoneTests");
 
     @MethodSource("timezones")
     @ParameterizedTest

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatchTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatchTest.java
@@ -1,0 +1,61 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.cqframework.cql.cql2elm.CqlIncludeException;
+import org.hl7.elm.r1.VersionedIdentifier;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class InvalidCqlLibraryIdentifierMismatchTest extends CqlTestBase {
+
+    private static Stream<Arguments> evaluateWithMatchedLibraryIdsParams() {
+        return Stream.of(Arguments.of(
+                new VersionedIdentifier().withId("ValidCqlLibraryIdentifierMatches"),
+                new VersionedIdentifier().withId("ValidCqlLibraryIdentifierMatchesWithVersion"),
+                new VersionedIdentifier()
+                        .withId("ValidCqlLibraryIdentifierMatchesWithVersion")
+                        .withVersion("1.0.0")));
+    }
+
+    private static Stream<Arguments> evaluateWithMismatchedLibraryIdsParams() {
+        return Stream.of(
+                Arguments.of(
+                        new VersionedIdentifier().withId("InvalidCqlLibraryIdentifierMismatch"),
+                        "Library InvalidCqlLibraryIdentifierMismatch was included with version null, but id: Mismatched and version null of the library was found."),
+                Arguments.of(
+                        new VersionedIdentifier()
+                                .withId("InvalidCqlLibraryIdentifierMismatch")
+                                .withVersion("1.0.0"),
+                        "Library InvalidCqlLibraryIdentifierMismatch was included with version 1.0.0, but id: Mismatched and version null of the library was found."),
+                Arguments.of(
+                        new VersionedIdentifier().withId("InvalidCqlLibraryIdentifierMismatchWithVersion"),
+                        "Library InvalidCqlLibraryIdentifierMismatchWithVersion was included with version null, but id: MismatchedWithVersion and version 1.0.0 of the library was found."),
+                Arguments.of(
+                        // If we match only on version, we should still fail
+                        new VersionedIdentifier()
+                                .withId("InvalidCqlLibraryIdentifierMismatchWithVersion")
+                                .withVersion("1.0.0"),
+                        "Library InvalidCqlLibraryIdentifierMismatchWithVersion was included with version 1.0.0, but id: MismatchedWithVersion and version 1.0.0 of the library was found."));
+    }
+
+    @ParameterizedTest
+    @MethodSource("evaluateWithMatchedLibraryIdsParams")
+    void evaluateWithMismatchedLibraryIds(VersionedIdentifier libraryIdentifierToSearch) {
+        // We're simply asserting that we do not fail
+        assertNotNull(engine.evaluate(libraryIdentifierToSearch));
+    }
+
+    @ParameterizedTest
+    @MethodSource("evaluateWithMismatchedLibraryIdsParams")
+    void evaluateWithMismatchedLibraryIds(
+            VersionedIdentifier libraryIdentifierToSearch, String expectedExceptionMessage) {
+        var exception = assertThrows(CqlIncludeException.class, () -> engine.evaluate(libraryIdentifierToSearch));
+
+        assertEquals(expectedExceptionMessage, exception.getMessage());
+    }
+}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
@@ -1,4 +1,4 @@
-library ListOperator
+library CqlListOperatorsTest
 
 //Sort
 define simpleList: {4, 5, 1, 6, 2, 1}

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlLogicalOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlLogicalOperatorsTest.cql
@@ -1,4 +1,4 @@
-library LogicalOperator
+library CqlLogicalOperatorsTest
 
 //And
 define TrueAndTrue : true and true

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlNullologicalOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlNullologicalOperatorsTest.cql
@@ -1,4 +1,4 @@
-library NullologicalOperator version '1'
+library CqlNullologicalOperatorsTest version '1'
 
 //Coalesce
 define CoalesceANull : Coalesce('a', null)

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlStringOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlStringOperatorsTest.cql
@@ -1,4 +1,4 @@
-library StringOperator version '1'
+library CqlStringOperatorsTest version '1'
 
 codesystem "LOINC": 'http://loinc.org'
 

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTypeOperatorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTypeOperatorsTest.cql
@@ -1,4 +1,4 @@
-library TypeOperator version '1'
+library CqlTypeOperatorsTest version '1'
 
 //As
 define AsQuantity: 45.5 'g' as Quantity

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTypesTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlTypesTest.cql
@@ -1,4 +1,4 @@
-library Types version '1'
+library CqlTypesTest version '1'
 
 codesystem "LOINC": 'http://loinc.org'
 

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlValueLiteralsAndSelectorsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlValueLiteralsAndSelectorsTest.cql
@@ -1,4 +1,4 @@
-library ValueLiteralsAndSelectors version '1'
+library CqlValueLiteralsAndSelectorsTest version '1'
 
 context Unfiltered
 

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/EmptyStringsTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/EmptyStringsTest.cql
@@ -1,4 +1,4 @@
-library EmptyStrings version '1'
+library EmptyStringsTest version '1'
 
 define Null : null
 define Empty : ''

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/FunctionOverloadTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/FunctionOverloadTest.cql
@@ -1,4 +1,4 @@
-library FunctionOverload version '1.0.000'
+library FunctionOverloadTest version '1.0.000'
 
 define function TestAny(a Integer):
   a

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatch.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatch.cql
@@ -1,0 +1,1 @@
+library Mismatched

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatchWithVersion.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/InvalidCqlLibraryIdentifierMismatchWithVersion.cql
@@ -1,0 +1,1 @@
+library MismatchedWithVersion version '1.0.0'

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ProfilingTest.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ProfilingTest.cql
@@ -1,4 +1,4 @@
-library ProfileTest
+library ProfilingTest
 
 define function F(X Integer): X + 1
 

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ValidCqlLibraryIdentifierMatches.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ValidCqlLibraryIdentifierMatches.cql
@@ -1,0 +1,1 @@
+library ValidCqlLibraryIdentifierMatches

--- a/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ValidCqlLibraryIdentifierMatchesWithVersion.cql
+++ b/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/ValidCqlLibraryIdentifierMatchesWithVersion.cql
@@ -1,0 +1,1 @@
+library ValidCqlLibraryIdentifierMatchesWithVersion version '1.0.0'


### PR DESCRIPTION
…all tests to comply with this new edict.  Add another test class toe exercise this logic specifically.