### PR TITLE
Use IdentityHashMaps instead of HashMaps where keys are mutated after insertion

### DIFF
--- a/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
+++ b/Src/java/cql-to-elm/src/main/java/org/cqframework/cql/cql2elm/Cql2ElmVisitor.java
@@ -31,8 +31,10 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
     private final Stack<ExpressionDefinitionInfo> forwards = new Stack<>();
     private final Map<cqlParser.FunctionDefinitionContext, FunctionHeader> functionHeaders = new HashMap<>();
 
-    private final Map<FunctionDef, FunctionHeader> functionHeadersByDef = new HashMap<>();
+    // IdentityHashMaps are used here instead of HashMaps because the keys are mutated after insertion
+    private final Map<FunctionDef, FunctionHeader> functionHeadersByDef = new IdentityHashMap<>();
     private final Map<FunctionHeader, cqlParser.FunctionDefinitionContext> functionDefinitions = new HashMap<>();
+
     private final Stack<TimingOperatorContext> timingOperators = new Stack<>();
     private final List<Retrieve> retrieves = new ArrayList<>();
     private final List<Expression> expressions = new ArrayList<>();
@@ -4397,17 +4399,7 @@ public class Cql2ElmVisitor extends CqlPreprocessorElmCommonVisitor {
     }
 
     private FunctionHeader getFunctionHeaderByDef(FunctionDef fd) {
-        // Shouldn't need to do this, something about the hashCode implementation of
-        // FunctionDef is throwing this off,
-        // Don't have time to investigate right now, this should work fine, could
-        // potentially be improved
-        for (Map.Entry<FunctionDef, FunctionHeader> entry : functionHeadersByDef.entrySet()) {
-            if (entry.getKey() == fd) {
-                return entry.getValue();
-            }
-        }
-
-        return null;
+        return functionHeadersByDef.get(fd);
     }
 
     private FunctionHeader getFunctionHeader(Operator op) {


### PR DESCRIPTION
The keys in the entries added to the `functionHeadersByDef` and `functionDefinitions` `HashMap`s are mutated as the visitor goes on. This breaks subsequent lookups based on `hashCode`s.

`IdentityHashMap`s can be used instead to map and look up by reference.