### PR TITLE
CQL Engine:  Seggregate CQL compile errors from warnings and infos

### DIFF
--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opencds.cqf.cql.engine.exception.CqlException;
 import org.opencds.cqf.cql.engine.execution.CqlEngine;
 
 class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTestBase {
@@ -39,6 +41,9 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
             EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTest3");
     private static final VersionedIdentifier LIB_WARNING_HIDING =
             EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTestWarningHiding");
+    private static final VersionedIdentifier LIB_ERROR_INVALID_CAST_EXPRESSION =
+            EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTestErrorInvalidCastExpression");
+
     private static final List<VersionedIdentifier> ALL_LIB_IDS = List.of(LIB_1, LIB_2, LIB_3);
 
     private static final String UNION_EXPRESSION = "Union";
@@ -130,15 +135,37 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
     void ensureWarningsAreSeparateFromErrors() {
         var engine = getCqlEngineForFhirNewLibMgr(true);
 
-        var multiLibResults = engine.evaluate(List.of(LIB_1, LIB_WARNING_HIDING), null);
+        var multiLibResults =
+                engine.evaluate(List.of(LIB_1, LIB_WARNING_HIDING, LIB_ERROR_INVALID_CAST_EXPRESSION), null);
 
-        assertFalse(multiLibResults.hasExceptions());
+        assertTrue(multiLibResults.hasExceptions());
+        assertTrue(multiLibResults.hasWarnings());
+        assertFalse(multiLibResults.getWarnings().isEmpty());
+        assertFalse(multiLibResults.getExceptions().isEmpty());
+
         assertTrue(multiLibResults.containsResultsFor(LIB_1));
         assertFalse(multiLibResults.containsWarningsFor(LIB_1));
         assertFalse(multiLibResults.containsExceptionsFor(LIB_1));
+
         assertTrue(multiLibResults.containsResultsFor(LIB_WARNING_HIDING));
         assertTrue(multiLibResults.containsWarningsFor(LIB_WARNING_HIDING));
         assertFalse(multiLibResults.containsExceptionsFor(LIB_WARNING_HIDING));
+
+        var warning = multiLibResults.getWarningFor(LIB_WARNING_HIDING);
+        assertInstanceOf(CqlException.class, warning);
+        assertTrue(warning.getMessage()
+                .contains("An alias identifier Definition is hiding another identifier of the same name."));
+
+        assertFalse(multiLibResults.containsResultsFor(LIB_ERROR_INVALID_CAST_EXPRESSION));
+        assertFalse(multiLibResults.containsWarningsFor(LIB_ERROR_INVALID_CAST_EXPRESSION));
+        assertTrue(multiLibResults.containsExceptionsFor(LIB_ERROR_INVALID_CAST_EXPRESSION));
+
+        var error = multiLibResults.getExceptionFor(LIB_ERROR_INVALID_CAST_EXPRESSION);
+        assertInstanceOf(CqlException.class, error);
+        assertTrue(
+                error.getMessage()
+                        .contains(
+                                "Expression of type 'List of System.Integer' cannot be cast as a value of type 'System.Integer'."));
     }
 
     private static Stream<Arguments> multiLibParams() {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
@@ -37,6 +37,8 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
             EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTest2");
     private static final VersionedIdentifier LIB_3 =
             EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTest3");
+    private static final VersionedIdentifier LIB_WARNING_HIDING =
+            EvaluatedResourceTestUtils.forId("EvaluatedResourcesMultiLibLinearDepsTestWarningHiding");
     private static final List<VersionedIdentifier> ALL_LIB_IDS = List.of(LIB_1, LIB_2, LIB_3);
 
     private static final String UNION_EXPRESSION = "Union";
@@ -124,6 +126,20 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
         assertThat(multiLibException.getMessage(), startsWith("Could not load source for library bad"));
     }
 
+    @Test
+    void hiding() {
+        var engine = getCqlEngineForFhirNewLibMgr(true);
+
+        var multiLibResults = engine.evaluate(List.of(LIB_1, LIB_WARNING_HIDING), null);
+
+        assertTrue(multiLibResults.containsResultsFor(LIB_1));
+        assertFalse(multiLibResults.containsWarningsFor(LIB_1));
+        assertFalse(multiLibResults.containsExceptionsFor(LIB_1));
+        assertTrue(multiLibResults.containsResultsFor(LIB_WARNING_HIDING));
+        assertTrue(multiLibResults.containsWarningsFor(LIB_WARNING_HIDING));
+        assertFalse(multiLibResults.containsExceptionsFor(LIB_WARNING_HIDING));
+    }
+
     private static Stream<Arguments> multiLibParams() {
         return Stream.of(
                 Arguments.of(
@@ -167,7 +183,7 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
 
         var engine = getCqlEngineForFhirNewLibMgr(expressionCaching);
 
-        var results = engine.evaluate(getAllLibraryIdentifiers(), Set.of(expressionName));
+        var results = engine.evaluate(ALL_LIB_IDS, Set.of(expressionName));
 
         var evaluationResultForIdentifier = results.getResultFor(libId);
 

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTest.java
@@ -127,11 +127,12 @@ class EvaluatedResourcesMultiLibLinearDepsTest extends FhirExecutionMultiLibTest
     }
 
     @Test
-    void hiding() {
+    void ensureWarningsAreSeparateFromErrors() {
         var engine = getCqlEngineForFhirNewLibMgr(true);
 
         var multiLibResults = engine.evaluate(List.of(LIB_1, LIB_WARNING_HIDING), null);
 
+        assertFalse(multiLibResults.hasExceptions());
         assertTrue(multiLibResults.containsResultsFor(LIB_1));
         assertFalse(multiLibResults.containsWarningsFor(LIB_1));
         assertFalse(multiLibResults.containsExceptionsFor(LIB_1));

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionMultiLibTestBase.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionMultiLibTestBase.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.cql.engine.fhir.data;
 
-import static org.opencds.cqf.cql.engine.fhir.data.EvaluatedResourceTestUtils.setupCql;
-
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import java.util.ArrayList;
@@ -11,9 +9,7 @@ import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
 import org.hl7.elm.r1.Library;
-import org.hl7.elm.r1.VersionedIdentifier;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
 import org.opencds.cqf.cql.engine.execution.CqlEngine;
 import org.opencds.cqf.cql.engine.execution.Environment;
@@ -103,23 +99,6 @@ public abstract class FhirExecutionMultiLibTestBase {
         libraryManager.getLibrarySourceLoader().clearProviders();
         libraryManager.getLibrarySourceLoader().registerProvider(new FhirLibrarySourceProvider());
         libraryManager.getLibrarySourceLoader().registerProvider(new TestLibrarySourceProvider());
-    }
-
-    @BeforeEach
-    public void beforeEachTestMethod() {
-        setupCql(this.getClass(), libraries, libraryManager);
-    }
-
-    protected List<VersionedIdentifier> getAllLibraryIdentifiers() {
-        return libraries.stream().map(Library::getIdentifier).toList();
-    }
-
-    public static org.hl7.elm.r1.VersionedIdentifier toElmIdentifier(String name) {
-        return new org.hl7.elm.r1.VersionedIdentifier().withId(name);
-    }
-
-    public static org.hl7.elm.r1.VersionedIdentifier toElmIdentifier(String name, String version) {
-        return new org.hl7.elm.r1.VersionedIdentifier().withId(name).withVersion(version);
     }
 
     private LibraryManager buildNewLibraryManager() {

--- a/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionMultiLibTestBase.java
+++ b/Src/java/engine-fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionMultiLibTestBase.java
@@ -2,13 +2,10 @@ package org.opencds.cqf.cql.engine.fhir.data;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import java.util.ArrayList;
-import java.util.List;
 import org.cqframework.cql.cql2elm.CqlCompilerOptions;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.quick.FhirLibrarySourceProvider;
-import org.hl7.elm.r1.Library;
 import org.junit.jupiter.api.BeforeAll;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
 import org.opencds.cqf.cql.engine.execution.CqlEngine;
@@ -63,8 +60,6 @@ public abstract class FhirExecutionMultiLibTestBase {
     protected static R4FhirModelResolver r4ModelResolver;
     protected static RestFhirRetrieveProvider r4RetrieveProvider;
     protected static CompositeDataProvider r4Provider;
-
-    private final List<Library> libraries = new ArrayList<>();
 
     // TODO: LD: figure out how to compile the CQLs only once for the whole test class
     @BeforeAll

--- a/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestErrorInvalidCastExpression.cql
+++ b/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestErrorInvalidCastExpression.cql
@@ -1,0 +1,4 @@
+library EvaluatedResourcesMultiLibLinearDepsTestErrorInvalidCastExpression
+
+// This is a deliberate CQL syntax error
+define InvalidCastExpression: { 1, 2, 3 } as Integer

--- a/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestWarningHiding.cql
+++ b/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestWarningHiding.cql
@@ -4,4 +4,4 @@ using FHIR version '4.0.1'
 include "FHIRHelpers" version '4.0.1'
 
 define "Definition":
-    ({1, 2, 3}) "Definition" return "Definition" //Warn, hides line 45
+    ({1, 2, 3}) "Definition" return "Definition" //Warn, hides line 6

--- a/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestWarningHiding.cql
+++ b/Src/java/engine-fhir/src/test/resources/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourcesMultiLibLinearDepsTestWarningHiding.cql
@@ -1,0 +1,7 @@
+library EvaluatedResourcesMultiLibLinearDepsTestWarningHiding
+
+using FHIR version '4.0.1'
+include "FHIRHelpers" version '4.0.1'
+
+define "Definition":
+    ({1, 2, 3}) "Definition" return "Definition" //Warn, hides line 45

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -430,12 +430,10 @@ public class CqlEngine {
 
         var resultBuilder = LoadMultiLibResult.builder();
 
-        if (CqlCompilerException.hasErrors(resolvedLibraryResults.allErrors())) {
-            for (CompiledLibraryResult libraryResult : resolvedLibraryResults.allResults()) {
-                if (!libraryResult.errors().isEmpty()) {
-                    var identifier = libraryResult.compiledLibrary().getIdentifier();
-                    resultBuilder.addException(identifier, wrapException(identifier, libraryResult.errors()));
-                }
+        for (CompiledLibraryResult libraryResult : resolvedLibraryResults.allResults()) {
+            if (!libraryResult.errors().isEmpty()) {
+                var identifier = libraryResult.compiledLibrary().getIdentifier();
+                resultBuilder.addExceptionsOrWarnings(identifier, libraryResult.errors());
             }
         }
 
@@ -460,7 +458,7 @@ public class CqlEngine {
             } catch (CqlException | CqlCompilerException exception) {
                 // As with previous code, per searched library identifier, this is an all or nothing operation:
                 // stop at the first Exception and don't capture subsequent errors for subsequent included libraries.
-                resultBuilder.addException(library.getIdentifier(), exception);
+                resultBuilder.addExceptionOrWarning(library.getIdentifier(), exception);
             }
         }
 
@@ -475,14 +473,6 @@ public class CqlEngine {
             });
             // TODO: Validate Expressions as well?
         }
-    }
-
-    private CqlException wrapException(VersionedIdentifier libraryIdentifier, List<CqlCompilerException> exceptions) {
-        return new CqlException("Library %s loaded, but had errors: %s"
-                .formatted(
-                        libraryIdentifier.getId()
-                                + (libraryIdentifier.getVersion() != null ? "-" + libraryIdentifier.getVersion() : ""),
-                        exceptions.stream().map(Throwable::getMessage).collect(Collectors.joining(", "))));
     }
 
     private void validateDataRequirements(Library library) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.cql.engine.execution;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.hl7.elm.r1.VersionedIdentifier;
 
 /**
@@ -12,10 +13,12 @@ import org.hl7.elm.r1.VersionedIdentifier;
 public class EvaluationResultsForMultiLib {
     private final Map<VersionedIdentifier, EvaluationResult> results;
     private final Map<VersionedIdentifier, RuntimeException> exceptions;
+    private final Map<VersionedIdentifier, CqlCompilerException> warnings;
 
     private EvaluationResultsForMultiLib(Builder builder) {
         this.results = Collections.unmodifiableMap(builder.results);
         this.exceptions = Collections.unmodifiableMap(builder.exceptions);
+        this.warnings = Collections.unmodifiableMap(builder.warnings);
     }
 
     public Map<VersionedIdentifier, EvaluationResult> getResults() {
@@ -26,12 +29,20 @@ public class EvaluationResultsForMultiLib {
         return exceptions;
     }
 
+    public Map<VersionedIdentifier, CqlCompilerException> getWarnings() {
+        return warnings;
+    }
+
     public boolean containsResultsFor(VersionedIdentifier libraryIdentifier) {
         return getResultFor(libraryIdentifier) != null;
     }
 
     public boolean containsExceptionsFor(VersionedIdentifier libraryIdentifier) {
         return getExceptionFor(libraryIdentifier) != null;
+    }
+
+    public boolean containsWarningsFor(VersionedIdentifier libraryIdentifier) {
+        return getWarningFor(libraryIdentifier) != null;
     }
 
     public EvaluationResult getResultFor(VersionedIdentifier libraryIdentifier) {
@@ -86,13 +97,31 @@ public class EvaluationResultsForMultiLib {
         return null;
     }
 
+    public RuntimeException getWarningFor(VersionedIdentifier libraryIdentifier) {
+        if (warnings.containsKey(libraryIdentifier)) {
+            return warnings.get(libraryIdentifier);
+        }
+
+        if (libraryIdentifier.getVersion() == null
+                || libraryIdentifier.getVersion().isEmpty()) {
+            // If the version is not specified, try to match by ID only
+            return warnings.entrySet().stream()
+                    .filter(entry -> matchIdentifiersForExceptions(libraryIdentifier, entry))
+                    .findFirst()
+                    .map(Map.Entry::getValue)
+                    .orElse(null);
+        }
+
+        return null;
+    }
+
     private boolean matchIdentifiersForResults(
             VersionedIdentifier libraryIdentifier, Map.Entry<VersionedIdentifier, EvaluationResult> entry) {
         return entry.getKey().getId().equals(libraryIdentifier.getId());
     }
 
     private boolean matchIdentifiersForExceptions(
-            VersionedIdentifier libraryIdentifier, Map.Entry<VersionedIdentifier, RuntimeException> entry) {
+            VersionedIdentifier libraryIdentifier, Map.Entry<VersionedIdentifier, ? extends RuntimeException> entry) {
         return entry.getKey().getId().equals(libraryIdentifier.getId());
     }
 
@@ -119,9 +148,11 @@ public class EvaluationResultsForMultiLib {
     static class Builder {
         private final LinkedHashMap<VersionedIdentifier, EvaluationResult> results = new LinkedHashMap<>();
         private final LinkedHashMap<VersionedIdentifier, RuntimeException> exceptions = new LinkedHashMap<>();
+        private final LinkedHashMap<VersionedIdentifier, CqlCompilerException> warnings = new LinkedHashMap<>();
 
         Builder(LoadMultiLibResult loadMultiLibResult) {
             exceptions.putAll(loadMultiLibResult.getExceptions());
+            warnings.putAll(loadMultiLibResult.getWarnings());
         }
 
         void addResult(VersionedIdentifier libraryId, EvaluationResult evaluationResult) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
@@ -13,6 +13,7 @@ import org.hl7.elm.r1.VersionedIdentifier;
 public class EvaluationResultsForMultiLib {
     private final Map<VersionedIdentifier, EvaluationResult> results;
     private final Map<VersionedIdentifier, RuntimeException> exceptions;
+    // LUKETODO:  add a test for identifier hiding and assert it's part of the warnings
     private final Map<VersionedIdentifier, CqlCompilerException> warnings;
 
     private EvaluationResultsForMultiLib(Builder builder) {

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
@@ -140,6 +140,10 @@ public class EvaluationResultsForMultiLib {
         return !exceptions.isEmpty();
     }
 
+    public boolean hasWarnings() {
+        return !warnings.isEmpty();
+    }
+
     static Builder builder(LoadMultiLibResult loadMultiLibResult) {
         return new Builder(loadMultiLibResult);
     }

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/EvaluationResultsForMultiLib.java
@@ -3,7 +3,6 @@ package org.opencds.cqf.cql.engine.execution;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.hl7.elm.r1.VersionedIdentifier;
 
 /**
@@ -13,8 +12,7 @@ import org.hl7.elm.r1.VersionedIdentifier;
 public class EvaluationResultsForMultiLib {
     private final Map<VersionedIdentifier, EvaluationResult> results;
     private final Map<VersionedIdentifier, RuntimeException> exceptions;
-    // LUKETODO:  add a test for identifier hiding and assert it's part of the warnings
-    private final Map<VersionedIdentifier, CqlCompilerException> warnings;
+    private final Map<VersionedIdentifier, RuntimeException> warnings;
 
     private EvaluationResultsForMultiLib(Builder builder) {
         this.results = Collections.unmodifiableMap(builder.results);
@@ -30,7 +28,7 @@ public class EvaluationResultsForMultiLib {
         return exceptions;
     }
 
-    public Map<VersionedIdentifier, CqlCompilerException> getWarnings() {
+    public Map<VersionedIdentifier, RuntimeException> getWarnings() {
         return warnings;
     }
 
@@ -149,7 +147,7 @@ public class EvaluationResultsForMultiLib {
     static class Builder {
         private final LinkedHashMap<VersionedIdentifier, EvaluationResult> results = new LinkedHashMap<>();
         private final LinkedHashMap<VersionedIdentifier, RuntimeException> exceptions = new LinkedHashMap<>();
-        private final LinkedHashMap<VersionedIdentifier, CqlCompilerException> warnings = new LinkedHashMap<>();
+        private final LinkedHashMap<VersionedIdentifier, RuntimeException> warnings = new LinkedHashMap<>();
 
         Builder(LoadMultiLibResult loadMultiLibResult) {
             exceptions.putAll(loadMultiLibResult.getExceptions());

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/LoadMultiLibResult.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/LoadMultiLibResult.java
@@ -1,12 +1,16 @@
 package org.opencds.cqf.cql.engine.execution;
 
+import static java.util.function.Predicate.not;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.VersionedIdentifier;
+import org.opencds.cqf.cql.engine.exception.CqlException;
 
 /**
  * Track results and exceptions for multiple libraries in a single load operation, to support partial
@@ -15,7 +19,7 @@ import org.hl7.elm.r1.VersionedIdentifier;
 class LoadMultiLibResult {
     private final Map<VersionedIdentifier, Library> results;
     private final Map<VersionedIdentifier, RuntimeException> exceptions;
-    private final Map<VersionedIdentifier, CqlCompilerException> warnings;
+    private final Map<VersionedIdentifier, RuntimeException> warnings;
 
     private LoadMultiLibResult(Builder builder) {
         this.results = Collections.unmodifiableMap(builder.results);
@@ -64,7 +68,7 @@ class LoadMultiLibResult {
         return exceptions;
     }
 
-    Map<VersionedIdentifier, CqlCompilerException> getWarnings() {
+    Map<VersionedIdentifier, RuntimeException> getWarnings() {
         return warnings;
     }
 
@@ -75,24 +79,55 @@ class LoadMultiLibResult {
     public static class Builder {
         private final LinkedHashMap<VersionedIdentifier, Library> results = new LinkedHashMap<>();
         private final LinkedHashMap<VersionedIdentifier, RuntimeException> exceptions = new LinkedHashMap<>();
-        private final LinkedHashMap<VersionedIdentifier, CqlCompilerException> warnings = new LinkedHashMap<>();
+        private final LinkedHashMap<VersionedIdentifier, RuntimeException> warnings = new LinkedHashMap<>();
 
         void addResult(VersionedIdentifier libraryId, Library library) {
             this.results.put(libraryId, library);
         }
 
-        void addException(VersionedIdentifier libraryId, RuntimeException exception) {
+        void addExceptionOrWarning(VersionedIdentifier libraryId, RuntimeException exception) {
+            addExceptionsOrWarnings(libraryId, List.of(exception));
+        }
 
-            if (exception instanceof CqlCompilerException cqlCompilerException
-                    && CqlCompilerException.ErrorSeverity.Error != cqlCompilerException.getSeverity()) {
-                this.warnings.put(libraryId, cqlCompilerException);
-            } else {
-                this.exceptions.put(libraryId, exception);
+        void addExceptionsOrWarnings(VersionedIdentifier libraryId, List<? extends RuntimeException> exceptions) {
+            if (exceptions == null || exceptions.isEmpty()) {
+                return;
+            }
+
+            exceptions.stream()
+                    .filter(not(CqlCompilerException.class::isInstance))
+                    .forEach(nonCompilerException -> this.exceptions.put(libraryId, nonCompilerException));
+
+            var exceptionsBySeverity = exceptions.stream()
+                    .filter(CqlCompilerException.class::isInstance)
+                    .map(CqlCompilerException.class::cast)
+                    .collect(Collectors.groupingBy(CqlCompilerException::getSeverity));
+
+            for (CqlCompilerException.ErrorSeverity errorSeverity : exceptionsBySeverity.keySet()) {
+
+                var wrappedExceptions = wrapExceptions(libraryId, exceptionsBySeverity.get(errorSeverity));
+
+                if (errorSeverity == CqlCompilerException.ErrorSeverity.Error) {
+                    this.exceptions.put(libraryId, wrappedExceptions);
+                } else {
+                    this.warnings.put(libraryId, wrappedExceptions);
+                }
             }
         }
 
         LoadMultiLibResult build() {
             return new LoadMultiLibResult(this);
+        }
+
+        private static CqlException wrapExceptions(
+                VersionedIdentifier libraryIdentifier, List<CqlCompilerException> exceptions) {
+            return new CqlException("Library %s loaded, but had errors: %s"
+                    .formatted(
+                            libraryIdentifier.getId()
+                                    + (libraryIdentifier.getVersion() != null
+                                            ? "-" + libraryIdentifier.getVersion()
+                                            : ""),
+                            exceptions.stream().map(Throwable::getMessage).collect(Collectors.joining(", "))));
         }
     }
 }

--- a/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/LoadMultiLibResult.java
+++ b/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/execution/LoadMultiLibResult.java
@@ -103,11 +103,11 @@ class LoadMultiLibResult {
                     .map(CqlCompilerException.class::cast)
                     .collect(Collectors.groupingBy(CqlCompilerException::getSeverity));
 
-            for (CqlCompilerException.ErrorSeverity errorSeverity : exceptionsBySeverity.keySet()) {
+            for (var exceptionsGroupedBySeverity : exceptionsBySeverity.entrySet()) {
 
-                var wrappedExceptions = wrapExceptions(libraryId, exceptionsBySeverity.get(errorSeverity));
+                var wrappedExceptions = wrapExceptions(libraryId, exceptionsGroupedBySeverity.getValue());
 
-                if (errorSeverity == CqlCompilerException.ErrorSeverity.Error) {
+                if (CqlCompilerException.ErrorSeverity.Error == exceptionsGroupedBySeverity.getKey()) {
                     this.exceptions.put(libraryId, wrappedExceptions);
                 } else {
                     this.warnings.put(libraryId, wrappedExceptions);

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineMultipleLibrariesTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineMultipleLibrariesTest.java
@@ -298,6 +298,8 @@ class CqlEngineMultipleLibrariesTest extends CqlTestBase {
         var libraryResults = evalResultsForMultiLib.getResults();
         assertEquals(3, libraryResults.size());
         assertFalse(evalResultsForMultiLib.hasExceptions());
+        assertTrue(evalResultsForMultiLib.getExceptions().isEmpty());
+        assertFalse(evalResultsForMultiLib.hasWarnings());
 
         var evaluationResult1 = findResultsByLibId("MultiLibrary1", libraryResults);
         var evaluationResult2 = findResultsByLibId("MultiLibrary2", libraryResults);
@@ -397,11 +399,24 @@ class CqlEngineMultipleLibrariesTest extends CqlTestBase {
     private static void sanityCheckForMultiLib(
             EvaluationResultsForMultiLib evalResultsForMultiLib, VersionedIdentifier libraryIdentifier) {
         assertTrue(evalResultsForMultiLib.containsResultsFor(libraryIdentifier));
+
+        var bogusId = new VersionedIdentifier().withId("bogus");
+        assertFalse(evalResultsForMultiLib.containsResultsFor(bogusId));
+        assertFalse(evalResultsForMultiLib.containsWarningsFor(new VersionedIdentifier().withId("bogus")));
+        assertFalse(evalResultsForMultiLib.containsExceptionsFor(new VersionedIdentifier().withId("bogus")));
+
+        var bogusVersion = libraryIdentifier.withVersion("bogus");
+        assertFalse(evalResultsForMultiLib.containsResultsFor(bogusVersion));
+        assertFalse(evalResultsForMultiLib.containsWarningsFor(bogusVersion));
+        assertFalse(evalResultsForMultiLib.containsExceptionsFor(bogusVersion));
+
         // versionless identifier searches should work as well
         assertTrue(evalResultsForMultiLib.containsResultsFor(libraryIdentifier.withVersion(null)));
         assertThrows(IllegalStateException.class, evalResultsForMultiLib::getOnlyResultOrThrow);
         assertFalse(evalResultsForMultiLib.containsExceptionsFor(libraryIdentifier));
         assertFalse(evalResultsForMultiLib.containsWarningsFor(libraryIdentifier));
+        assertTrue(evalResultsForMultiLib.getExceptions().isEmpty());
+        assertTrue(evalResultsForMultiLib.getWarnings().isEmpty());
         assertNotNull(evalResultsForMultiLib.getResultFor(libraryIdentifier));
         assertNull(evalResultsForMultiLib.getExceptionFor(libraryIdentifier));
         assertNull(evalResultsForMultiLib.getWarningFor(libraryIdentifier));

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineMultipleLibrariesTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineMultipleLibrariesTest.java
@@ -401,7 +401,9 @@ class CqlEngineMultipleLibrariesTest extends CqlTestBase {
         assertTrue(evalResultsForMultiLib.containsResultsFor(libraryIdentifier.withVersion(null)));
         assertThrows(IllegalStateException.class, evalResultsForMultiLib::getOnlyResultOrThrow);
         assertFalse(evalResultsForMultiLib.containsExceptionsFor(libraryIdentifier));
+        assertFalse(evalResultsForMultiLib.containsWarningsFor(libraryIdentifier));
         assertNotNull(evalResultsForMultiLib.getResultFor(libraryIdentifier));
         assertNull(evalResultsForMultiLib.getExceptionFor(libraryIdentifier));
+        assertNull(evalResultsForMultiLib.getWarningFor(libraryIdentifier));
     }
 }

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
@@ -44,7 +44,6 @@ class CqlEngineTest extends CqlTestBase {
         assertEquals(1, debugResult.size());
     }
 
-    // LUKETODO: fix actual behaviour or assertion
     @Test
     void invalidCql() {
         var versionedIdentifier = toElmIdentifier("Invalid");

--- a/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
+++ b/Src/java/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTest.java
@@ -44,6 +44,7 @@ class CqlEngineTest extends CqlTestBase {
         assertEquals(1, debugResult.size());
     }
 
+    // LUKETODO: fix actual behaviour or assertion
     @Test
     void invalidCql() {
         var versionedIdentifier = toElmIdentifier("Invalid");


### PR DESCRIPTION
- In EvaluatedResultsForMultiLib, capture INFO and WARN CQL compile exceptions separately from errors
- This is intended for downstream clients to do more finer-grained error handling