### PR TITLE
Various fixes post Kotlin conversion

### DIFF
--- a/Src/java/buildSrc/src/main/kotlin/cql.kotlin-conventions.gradle.kts
+++ b/Src/java/buildSrc/src/main/kotlin/cql.kotlin-conventions.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.slf4j:slf4j-simple:2.0.13")
+    testImplementation(kotlin("test"))
 
     // These are JAXB dependencies excluded because the libraries need to work
     // on Android. But for test purposes we use them pretty much everywhere.

--- a/Src/java/buildSrc/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/buildSrc/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -79,6 +79,12 @@ kotlin {
             }
         }
 
+        jvmMain {
+            dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.8.0")
+            }
+        }
+
         jsMain {
             dependencies {
             }

--- a/Src/java/cqf-fhir-npm/src/main/kotlin/org/cqframework/fhir/npm/NpmPackageManager.kt
+++ b/Src/java/cqf-fhir-npm/src/main/kotlin/org/cqframework/fhir/npm/NpmPackageManager.kt
@@ -18,7 +18,7 @@ constructor(
     npmList: MutableList<NpmPackage>? = null,
 ) : ILoggingService {
     private val fspcm: FilesystemPackageCacheManager
-    @JvmField val npmList: MutableList<NpmPackage> = npmList ?: ArrayList()
+    val npmList: MutableList<NpmPackage> = npmList ?: ArrayList()
 
     init {
 

--- a/Src/java/cqf-fhir-npm/src/main/kotlin/org/cqframework/fhir/npm/NpmProcessor.kt
+++ b/Src/java/cqf-fhir-npm/src/main/kotlin/org/cqframework/fhir/npm/NpmProcessor.kt
@@ -3,7 +3,7 @@ package org.cqframework.fhir.npm
 import org.cqframework.fhir.utilities.IGContext
 import org.hl7.cql.model.NamespaceInfo
 
-class NpmProcessor(
+open class NpmProcessor(
     /**
      * The igContext for the npmProcessor (i.e. the root IG that defines dependencies accessible in
      * the context) Note that this may be null in the case that there is no IG context
@@ -39,7 +39,7 @@ class NpmProcessor(
             return null
         }
 
-    val namespaces: MutableList<NamespaceInfo>
+    open val namespaces: MutableList<NamespaceInfo>
         get() {
             val namespaceInfos: MutableList<NamespaceInfo> = ArrayList()
             if (packageManager != null) {

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
@@ -381,7 +381,7 @@ abstract class FhirModelResolver<
         try {
             if (value is Iterable<*>) {
                 for (`val` in value) {
-                    child.mutator.addValue(base, setBaseValue(`val`!!, base))
+                    child.mutator.addValue(base, setBaseValue(`val`, base))
                 }
             } else {
                 child.mutator.setValue(base, setBaseValue(value, base))

--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/data/CompositeDataProvider.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/data/CompositeDataProvider.kt
@@ -5,10 +5,10 @@ import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
 import org.opencds.cqf.cql.engine.runtime.Code
 import org.opencds.cqf.cql.engine.runtime.Interval
 
-class CompositeDataProvider(
+open class CompositeDataProvider(
     protected var modelResolver: ModelResolver?,
     protected var retrieveProvider: RetrieveProvider?,
-) : org.opencds.cqf.cql.engine.data.DataProvider {
+) : DataProvider {
     @Deprecated("Use packageNames instead")
     override var packageName: String?
         get() = this.modelResolver!!.packageName

--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/data/SystemDataProvider.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/data/SystemDataProvider.kt
@@ -165,6 +165,7 @@ open class SystemDataProvider : BaseModelResolver(), DataProvider {
     }
 
     override fun resolveType(typeName: String?): Class<*> {
+        // Important: Boolean, Integer, and Long must be mapped to their Java Object types here
         when (typeName) {
             "Boolean" -> return Boolean::class.javaObjectType
             "Integer" -> return Int::class.javaObjectType

--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/elm/executing/SplitEvaluator.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/elm/executing/SplitEvaluator.kt
@@ -1,5 +1,6 @@
 package org.opencds.cqf.cql.engine.elm.executing
 
+import org.apache.commons.lang3.StringUtils
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument
 
 /*
@@ -12,19 +13,17 @@ If the stringToSplit argument does not contain any appearances of the separator,
 */
 object SplitEvaluator {
     @JvmStatic
+    @Suppress("ReturnCount")
     fun split(stringToSplit: Any?, separator: Any?): Any? {
         if (stringToSplit == null) {
             return null
         }
 
         if (stringToSplit is String) {
-            val result: MutableList<Any?> = ArrayList<Any?>()
             if (separator == null) {
-                result.add(stringToSplit)
-            } else {
-                result.addAll(stringToSplit.split(separator as String))
+                return mutableListOf(stringToSplit)
             }
-            return result
+            return StringUtils.split(stringToSplit, separator as String).toMutableList()
         }
 
         throw InvalidOperatorArgument(

--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/execution/Libraries.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/execution/Libraries.kt
@@ -7,6 +7,7 @@ import org.opencds.cqf.cql.engine.exception.CqlException
 
 /** This class provides static utility methods for resolving ELM elements from a ELM library. */
 object Libraries {
+    @JvmStatic
     fun resolveLibraryRef(libraryName: String?, relativeTo: Library): IncludeDef {
         for (includeDef in relativeTo.includes!!.def) {
             if (includeDef.localIdentifier.equals(libraryName)) {
@@ -17,6 +18,7 @@ object Libraries {
         throw CqlException("Could not resolve library reference '${libraryName}'.")
     }
 
+    @JvmStatic
     fun resolveAllExpressionRef(name: String?, relativeTo: Library): MutableList<ExpressionDef> {
         // Assumption: List of defs is sorted.
         val defs = relativeTo.statements!!.def
@@ -41,6 +43,7 @@ object Libraries {
         return defs.subList(first, last)
     }
 
+    @JvmStatic
     fun resolveExpressionRef(name: String?, relativeTo: Library): ExpressionDef {
         // Assumption: List of defs is sorted.
         val result =
@@ -56,6 +59,7 @@ object Libraries {
         )
     }
 
+    @JvmStatic
     fun resolveCodeSystemRef(name: String?, relativeTo: Library): CodeSystemDef {
         for (codeSystemDef in relativeTo.codeSystems!!.def) {
             if (codeSystemDef.name.equals(name)) {
@@ -68,6 +72,7 @@ object Libraries {
         )
     }
 
+    @JvmStatic
     fun resolveValueSetRef(name: String?, relativeTo: Library): ValueSetDef {
         for (valueSetDef in relativeTo.valueSets!!.def) {
             if (valueSetDef.name.equals(name)) {
@@ -80,6 +85,7 @@ object Libraries {
         )
     }
 
+    @JvmStatic
     fun resolveCodeRef(name: String?, relativeTo: Library): CodeDef {
         for (codeDef in relativeTo.codes!!.def) {
             if (codeDef.name.equals(name)) {
@@ -92,6 +98,7 @@ object Libraries {
         )
     }
 
+    @JvmStatic
     fun resolveParameterRef(name: String?, relativeTo: Library): ParameterDef {
         for (parameterDef in relativeTo.parameters!!.def) {
             if (parameterDef.name.equals(name)) {
@@ -104,6 +111,7 @@ object Libraries {
         )
     }
 
+    @JvmStatic
     fun resolveConceptRef(name: String?, relativeTo: Library): ConceptDef {
         for (conceptDef in relativeTo.concepts!!.def) {
             if (conceptDef.name.equals(name)) {
@@ -114,12 +122,14 @@ object Libraries {
         throw CqlException("Could not resolve concept reference '${name}'.")
     }
 
+    @JvmStatic
     fun getFunctionDefs(name: String?, relativeTo: Library): List<FunctionDef> {
         val defs = resolveAllExpressionRef(name, relativeTo)
 
         return defs.filter { obj -> obj is FunctionDef }.map { obj -> obj as FunctionDef }
     }
 
+    @JvmStatic
     fun toVersionedIdentifier(includeDef: IncludeDef): VersionedIdentifier {
         return VersionedIdentifier()
             .withSystem(getUriPart(includeDef.path))

--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/model/CachingModelResolverDecorator.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/model/CachingModelResolverDecorator.kt
@@ -3,7 +3,7 @@ package org.opencds.cqf.cql.engine.model
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
-class CachingModelResolverDecorator(val innerResolver: ModelResolver) : ModelResolver {
+open class CachingModelResolverDecorator(val innerResolver: ModelResolver) : ModelResolver {
     @Suppress("deprecation")
     @Deprecated("use packageNames instead")
     override var packageName: String?

--- a/Src/java/engine/src/test/kotlin/org/opencds/cqf/cql/engine/elm/executing/SplitEvaluatorTest.kt
+++ b/Src/java/engine/src/test/kotlin/org/opencds/cqf/cql/engine/elm/executing/SplitEvaluatorTest.kt
@@ -1,0 +1,16 @@
+package org.opencds.cqf.cql.engine.elm.executing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SplitEvaluatorTest {
+    @Test
+    fun testSplit() {
+        assertEquals(null, SplitEvaluator.split(null, "abc"))
+        assertEquals(mutableListOf("test"), SplitEvaluator.split("test", null))
+        assertEquals(mutableListOf("test"), SplitEvaluator.split("test", ""))
+        assertEquals(mutableListOf("es"), SplitEvaluator.split("test", "t"))
+        assertEquals(mutableListOf("t", "st"), SplitEvaluator.split("teeest", "e"))
+        assertEquals(mutableListOf("test"), SplitEvaluator.split("test", "abc"))
+    }
+}


### PR DESCRIPTION
* Small changes as we prepare for the v4 release
* Fix SplitEvaluator implementation to match the original Java version https://github.com/cqframework/clinical_quality_language/blob/2a301b15f8bc849328da2338d00cf0b51e2bb632/Src/java/engine/src/main/java/org/opencds/cqf/cql/engine/elm/executing/SplitEvaluator.java#L30
* Add tests for SplitEvaluator covering some edge cases