### PR TITLE
Add evaluation result setter

### DIFF
--- a/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResult.kt
+++ b/Src/java/engine/src/main/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResult.kt
@@ -19,9 +19,14 @@ class EvaluationResult {
         return expressionResults[name]
     }
 
-    /** Returns the ExpressionResult for the given expression name. */
+    /** Returns the ExpressionResult for the given expression reference. */
     operator fun get(ref: EvaluationExpressionRef): ExpressionResult? {
         return results[ref]
+    }
+
+    /** Sets the ExpressionResult for the given expression reference. */
+    operator fun set(ref: EvaluationExpressionRef, result: ExpressionResult) {
+        results[ref] = result
     }
 
     var debugResult: DebugResult? = null

--- a/Src/java/engine/src/test/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResultTest.kt
+++ b/Src/java/engine/src/test/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResultTest.kt
@@ -1,0 +1,18 @@
+package org.opencds.cqf.cql.engine.execution
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EvaluationResultTest {
+
+    @Test
+    fun getterAndSetterTest() {
+        val evaluationResult = EvaluationResult()
+        val expressionRef = EvaluationExpressionRef("expr1")
+        val expressionResult = ExpressionResult(5, null)
+
+        // Test setting and getting by reference
+        evaluationResult[expressionRef] = expressionResult
+        assertEquals(expressionResult, evaluationResult[expressionRef])
+    }
+}


### PR DESCRIPTION
Adds a setter to map-like `EvaluationResult`. This is needed e.g. in CR tests where `EvaluationResult`s are put together manually.