### PR TITLE
Add model serialization dependency for tests

### DIFF
--- a/Src/java/cqf-fhir-npm/build.gradle
+++ b/Src/java/cqf-fhir-npm/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation project(':cqf-fhir')
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'org.apache.commons:commons-compress:1.24.0'
+    testImplementation project(':model-jaxb')
 }

--- a/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
+++ b/Src/java/cqf-fhir-npm/src/main/java/org/cqframework/fhir/npm/NpmModelInfoProvider.java
@@ -50,7 +50,8 @@ public class NpmModelInfoProvider implements ModelInfoProvider {
                     for (org.hl7.fhir.r5.model.Attachment a : l.getContent()) {
                         if (a.getContentType() != null && a.getContentType().equals("application/xml")) {
                             InputStream is = new ByteArrayInputStream(a.getData());
-                            ModelInfo mi = ModelInfoReaderFactory.getReader("application/xml").read(is);
+                            ModelInfo mi = ModelInfoReaderFactory.getReader("application/xml")
+                                    .read(is);
                             // Set the identifier system to the url of the loaded model info, not the package canonical
                             // since the library with the model info may not be in the same package as the ig
                             if (mi != null && mi.getUrl() != null && modelIdentifier.getSystem() == null) {


### PR DESCRIPTION
`ModelInfoReaderFactory` requires `ModelInfoReaderProvider` implementation from `model-jaxb` or `model-jackson` to work.

Fixes the CI in https://github.com/cqframework/clinical_quality_language/pull/1659.