### PR TITLE
JS-export `QName`, `BigDecimal`, ELM classes

### DIFF
--- a/Src/java/build-logic/src/main/kotlin/XsdKotlinGenTask.kt
+++ b/Src/java/build-logic/src/main/kotlin/XsdKotlinGenTask.kt
@@ -13,7 +13,12 @@ import javax.xml.parsers.SAXParserFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-data class Config(val project: String, val xsd: String, val outputDir: String)
+data class Config(
+    val project: String,
+    val xsd: String,
+    val outputDir: String,
+    val jsExport: Boolean,
+)
 
 // Entry points for schema parsing and code generation
 val configs =
@@ -22,11 +27,13 @@ val configs =
             project = "cql",
             xsd = "../../cql-lm/schema/model/modelinfo.xsd",
             outputDir = "../cql/build/generated/sources/cql/commonMain/kotlin",
+            jsExport = false,
         ),
         Config(
             project = "elm",
             xsd = "../../cql-lm/schema/elm/library.xsd",
             outputDir = "../elm/build/generated/sources/elm/commonMain/kotlin",
+            jsExport = true,
         ),
     )
 
@@ -350,7 +357,7 @@ fun getOwnAttributes(complexType: XSComplexType): List<XSAttributeUse> {
 }
 
 // Creates a class for a complex type with nested classes for nested anonymous complex types
-fun buildClass(complexType: XSComplexType, className: ClassName): TypeSpec {
+fun getClassBuilder(complexType: XSComplexType, className: ClassName): TypeSpec.Builder {
     return TypeSpec.classBuilder(className)
         .apply {
             if (complexType.isAbstract) {
@@ -503,7 +510,10 @@ fun buildClass(complexType: XSComplexType, className: ClassName): TypeSpec {
                             )
 
                         // Add a nested class for the anonymous complex type
-                        addType(buildClass(elementDecl.type.asComplexType(), nestedClassName))
+                        addType(
+                            getClassBuilder(elementDecl.type.asComplexType(), nestedClassName)
+                                .build()
+                        )
 
                         addElement(elementDecl, nestedClassName, className, particle.isRepeated)
                     } else {
@@ -608,7 +618,6 @@ fun buildClass(complexType: XSComplexType, className: ClassName): TypeSpec {
                 .build()
         )
         .addType(TypeSpec.companionObjectBuilder().build())
-        .build()
 }
 
 // Returns all subtypes of a complex type (including indirect subtypes)
@@ -1124,6 +1133,29 @@ fun FileSpec.Builder.addSerializers(
     return this
 }
 
+// Adds `@JsOnlyExport`
+fun TypeSpec.Builder.addJsExport(): TypeSpec.Builder {
+    addAnnotation(
+        AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
+            .addMember("%T::class", ClassName("kotlin.js", "ExperimentalJsExport"))
+            .build()
+    )
+    addAnnotation(ClassName("org.cqframework.cql.shared", "JsOnlyExport"))
+
+    return this
+}
+
+// Adds `@file:Suppress("UNNECESSARY_SAFE_CALL")`
+fun FileSpec.Builder.addSuppressSafeCalls(): FileSpec.Builder {
+    addAnnotation(
+        AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
+            .addMember("%S", "UNNECESSARY_SAFE_CALL")
+            .build()
+    )
+
+    return this
+}
+
 open class XsdKotlinGenTask : DefaultTask() {
 
     @TaskAction
@@ -1156,6 +1188,11 @@ open class XsdKotlinGenTask : DefaultTask() {
                     FileSpec.builder(typeName)
                         .addType(
                             TypeSpec.enumBuilder(typeName)
+                                .apply {
+                                    if (config.jsExport) {
+                                        addJsExport()
+                                    }
+                                }
                                 .primaryConstructor(
                                     FunSpec.constructorBuilder()
                                         .addParameter("value", String::class)
@@ -1226,8 +1263,17 @@ open class XsdKotlinGenTask : DefaultTask() {
 
                     // Generate the class and XML and JSON parsers and serializers
                     FileSpec.builder(className)
-                        .addType(buildClass(complexType, className))
+                        .addType(
+                            getClassBuilder(complexType, className)
+                                .apply {
+                                    if (config.jsExport) {
+                                        addJsExport()
+                                    }
+                                }
+                                .build()
+                        )
                         .addSerializers(complexType, className)
+                        .addSuppressSafeCalls()
                         .build()
                         .writeTo(File(project.projectDir, config.outputDir))
                 }

--- a/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -48,6 +48,10 @@ kotlin {
     jvm()
 
     js {
+        compilerOptions {
+            // Enable support for BigInt
+            freeCompilerArgs.add("-Xes-long-as-bigint")
+        }
         useEsModules()
         browser {
             testTask {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/util/ReflectionJs.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/util/ReflectionJs.kt
@@ -30,6 +30,7 @@ data class JavaClassJs<T : Any>(private val kClass: KClass<T>) {
     fun getName(): String {
         return when (kClass) {
             Int::class -> "Integer"
+            Long::class -> "Long"
             BigDecimal::class -> "BigDecimal"
             else -> kClass.simpleName ?: unknownSimpleName
         }

--- a/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/BigDecimalJs.kt
+++ b/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/BigDecimalJs.kt
@@ -1,16 +1,24 @@
+@file:OptIn(ExperimentalJsExport::class)
+
 package org.cqframework.cql.shared
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal as KtBigDecimal
 import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.RoundingMode as KtRoundingMode
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
 
 /** A minimal pure-Kotlin implementation of BigDecimal for non-Java environments. */
 @Suppress("TooManyFunctions")
-data class BigDecimalJs(private val value: KtBigDecimal) {
-    constructor(value: Int) : this(KtBigDecimal.fromInt(value))
+@JsOnlyExport
+@JsName("BigDecimal")
+class BigDecimalJs private constructor(private val value: KtBigDecimal) {
+    @JsName("fromInt") constructor(value: Int) : this(KtBigDecimal.fromInt(value))
 
-    constructor(value: Long) : this(KtBigDecimal.fromLong(value))
+    @JsName("fromLong") constructor(value: Long) : this(KtBigDecimal.fromLong(value))
 
+    @JsName("fromString")
     constructor(
         value: String
     ) : this(
@@ -25,7 +33,7 @@ data class BigDecimalJs(private val value: KtBigDecimal) {
         )
     )
 
-    constructor(value: Double) : this(KtBigDecimal.fromDouble(value))
+    @JsName("fromDouble") constructor(value: Double) : this(KtBigDecimal.fromDouble(value))
 
     fun toPlainString(): String {
         return this.value.toPlainString()
@@ -43,10 +51,12 @@ data class BigDecimalJs(private val value: KtBigDecimal) {
         return this.value.scale.toInt()
     }
 
+    @JsExport.Ignore
     fun setScale(scale: Int): BigDecimalJs {
         return BigDecimalJs(this.value.scale(scale.toLong()))
     }
 
+    @JsExport.Ignore
     fun setScale(scale: Int, roundingMode: RoundingModeJs): BigDecimalJs {
         return BigDecimalJs(
             KtBigDecimal.parseStringWithMode(
@@ -84,10 +94,12 @@ data class BigDecimalJs(private val value: KtBigDecimal) {
         return BigDecimalJs(this.value.multiply(value.value))
     }
 
+    @JsExport.Ignore
     fun divide(value: BigDecimalJs): BigDecimalJs {
         return BigDecimalJs(this.value.divide(value.value))
     }
 
+    @JsExport.Ignore
     fun divide(value: BigDecimalJs, scale: Int, roundingMode: RoundingModeJs): BigDecimalJs {
         return BigDecimalJs(
             this.value.divide(
@@ -118,11 +130,27 @@ data class BigDecimalJs(private val value: KtBigDecimal) {
         return this.value.longValue()
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        if (other is BigDecimalJs) {
+            return this.value == other.value
+        }
+
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return this.value.hashCode()
+    }
+
     override fun toString(): String {
         return this.value.toString()
     }
 }
 
+@JsOnlyExport
+@JsName("RoundingMode")
 enum class RoundingModeJs {
     CEILING,
     FLOOR,

--- a/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QName.kt
+++ b/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QName.kt
@@ -3,9 +3,7 @@
 package org.cqframework.cql.shared
 
 /** A minimal multiplatform implementation of QName. */
-expect class QName {
-    constructor(namespaceURI: String, localPart: String, prefix: String)
-
+expect class QName(namespaceURI: String, localPart: String, prefix: String) {
     constructor(namespaceURI: String, localPart: String)
 
     constructor(localPart: String)

--- a/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QNameJs.kt
+++ b/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QNameJs.kt
@@ -1,15 +1,22 @@
 package org.cqframework.cql.shared
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
 /** A minimal pure-Kotlin implementation of QName for non-Java environments. */
-class QNameJs
-constructor(
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
+@JsName("QName")
+class QNameJs(
     private val namespaceURI: String,
     private val localPart: String,
     private val prefix: String,
 ) {
+    @JsExport.Ignore
     constructor(namespaceURI: String, localPart: String) : this(namespaceURI, localPart, "")
 
-    constructor(localPart: String) : this("", localPart, "")
+    @JsExport.Ignore constructor(localPart: String) : this("", localPart, "")
 
     fun getPrefix(): String = prefix
 


### PR DESCRIPTION
`QName`, `BigDecimal` and ELM classes (e.g. `VersionedIdentifier`) can be used from JavaScript﻿:

```js
import { VersionedIdentifier } from "@cqframework/cql/elm";

const versionedIdentifier = new VersionedIdentifier().withId("exampleId");
console.log(versionedIdentifier.id);
```