### PR TITLE
Replace Conversion with sealed hierarchy

### DIFF
--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
@@ -2055,7 +2055,7 @@ class LibraryBuilder(
             is Conversion.ChoiceNarrowingCast -> {
                 val castedOperand = buildAs(expression, conversion.innerConversion.fromType)
                 var result = convertExpression(castedOperand, conversion.innerConversion)
-                if (conversion.hasAlternativeConversions()) {
+                if (conversion.alternativeConversions.isNotEmpty()) {
                     val caseResult = objectFactory.createCase()
                     caseResult.resultType = result.resultType
                     caseResult.caseItem.add(
@@ -2064,7 +2064,7 @@ class LibraryBuilder(
                             .withWhen(buildIs(expression, conversion.innerConversion.fromType))
                             .withThen(result)
                     )
-                    for (alternative in conversion.getAlternativeConversions()) {
+                    for (alternative in conversion.alternativeConversions) {
                         caseResult.caseItem.add(
                             objectFactory
                                 .createCaseItem()

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
@@ -1752,9 +1752,10 @@ class LibraryBuilder(
         return expression
     }
 
-    private fun convertListExpression(expression: Expression?, conversion: Conversion): Expression {
-        val fromType: ListType = conversion.fromType as ListType
-        val toType: ListType = conversion.toType as ListType
+    private fun convertListExpression(
+        expression: Expression?,
+        conversion: Conversion.ListConversion,
+    ): Expression {
         return objectFactory
             .createQuery()
             .withSource(
@@ -1763,7 +1764,7 @@ class LibraryBuilder(
                         .createAliasedQuerySource()
                         .withAlias("X")
                         .withExpression(expression)
-                        .withResultType(fromType)
+                        .withResultType(conversion.fromType)
                 )
             )
             .withReturn(
@@ -1775,13 +1776,13 @@ class LibraryBuilder(
                             objectFactory
                                 .createAliasRef()
                                 .withName("X")
-                                .withResultType(fromType.elementType),
-                            conversion.conversion!!,
+                                .withResultType(conversion.fromType.elementType),
+                            conversion.elementConversion,
                         )
                     )
-                    .withResultType(toType)
+                    .withResultType(conversion.toType)
             )
-            .withResultType(toType)
+            .withResultType(conversion.toType)
     }
 
     private fun reportWarning(message: String, expression: Element?) {
@@ -1793,14 +1794,16 @@ class LibraryBuilder(
         recordParsingException(warning)
     }
 
-    private fun demoteListExpression(expression: Expression?, conversion: Conversion): Expression {
-        val fromType = conversion.fromType as ListType
+    private fun demoteListExpression(
+        expression: Expression?,
+        conversion: Conversion.ListDemotion,
+    ): Expression {
         val singletonFrom = objectFactory.createSingletonFrom().withOperand(expression)
-        singletonFrom.resultType = fromType.elementType
+        singletonFrom.resultType = conversion.fromType.elementType
         resolveUnaryCall("System", "SingletonFrom", singletonFrom)
         // WARNING:
         reportWarning("List-valued expression was demoted to a singleton.", expression)
-        val inner = conversion.conversion
+        val inner = conversion.elementConversion
         return if (inner != null) {
             convertExpression(singletonFrom, inner)
         } else {
@@ -1808,9 +1811,12 @@ class LibraryBuilder(
         }
     }
 
-    private fun promoteListExpression(expression: Expression, conversion: Conversion): Expression {
+    private fun promoteListExpression(
+        expression: Expression,
+        conversion: Conversion.ListPromotion,
+    ): Expression {
         var expression = expression
-        val inner = conversion.conversion
+        val inner = conversion.elementConversion
         if (inner != null) {
             expression = convertExpression(expression, inner)
         }
@@ -1830,15 +1836,14 @@ class LibraryBuilder(
 
     private fun demoteIntervalExpression(
         expression: Expression?,
-        conversion: Conversion,
+        conversion: Conversion.IntervalDemotion,
     ): Expression {
-        val fromType = conversion.fromType as IntervalType
         val pointFrom = objectFactory.createPointFrom().withOperand(expression)
-        pointFrom.resultType = fromType.pointType
+        pointFrom.resultType = conversion.fromType.pointType
         resolveUnaryCall("System", "PointFrom", pointFrom)
         // WARNING:
         reportWarning("Interval-valued expression was demoted to a point.", expression)
-        val inner = conversion.conversion
+        val inner = conversion.pointConversion
         return if (inner != null) {
             convertExpression(pointFrom, inner)
         } else {
@@ -1848,10 +1853,10 @@ class LibraryBuilder(
 
     private fun promoteIntervalExpression(
         expression: Expression,
-        conversion: Conversion,
+        conversion: Conversion.IntervalPromotion,
     ): Expression {
         var expression = expression
-        val inner = conversion.conversion
+        val inner = conversion.pointConversion
         if (inner != null) {
             expression = convertExpression(expression, inner)
         }
@@ -1879,11 +1884,8 @@ class LibraryBuilder(
 
     private fun convertIntervalExpression(
         expression: Expression?,
-        conversion: Conversion,
+        conversion: Conversion.IntervalConversion,
     ): Expression {
-        val fromType: IntervalType = conversion.fromType as IntervalType
-        val toType: IntervalType = conversion.toType as IntervalType
-
         // Optimization: when the expression is an Interval literal, directly convert the bounds
         // and preserve the lowClosed/highClosed booleans. This avoids unnecessary runtime Property
         // extraction for values known at compile time (constant folding).
@@ -1891,11 +1893,10 @@ class LibraryBuilder(
         // chains where convertExpression applies a cast before the interval conversion).
         val interval = unwrapIntervalLiteral(expression)
         if (interval != null) {
-            return constantFoldIntervalConversion(interval, conversion, toType)
+            return constantFoldIntervalConversion(interval, conversion)
         }
 
         // For non-literal intervals, extract bounds via Property access at runtime
-        val inner = conversion.conversion!!
         return objectFactory
             .createInterval()
             .withLow(
@@ -1904,8 +1905,8 @@ class LibraryBuilder(
                         .createProperty()
                         .withSource(expression)
                         .withPath("low")
-                        .withResultType(fromType.pointType),
-                    inner,
+                        .withResultType(conversion.fromType.pointType),
+                    conversion.pointConversion,
                 )
             )
             .withLowClosedExpression(
@@ -1921,8 +1922,8 @@ class LibraryBuilder(
                         .createProperty()
                         .withSource(expression)
                         .withPath("high")
-                        .withResultType(fromType.pointType),
-                    inner,
+                        .withResultType(conversion.fromType.pointType),
+                    conversion.pointConversion,
                 )
             )
             .withHighClosedExpression(
@@ -1932,7 +1933,7 @@ class LibraryBuilder(
                     .withPath("highClosed")
                     .withResultType(resolveTypeName("System", "Boolean"))
             )
-            .withResultType(toType)
+            .withResultType(conversion.toType)
     }
 
     /** Unwrap an expression to find an Interval literal, including through As casts. */
@@ -1946,19 +1947,19 @@ class LibraryBuilder(
     /** Constant-fold an interval conversion by directly converting the literal's bounds. */
     private fun constantFoldIntervalConversion(
         interval: org.hl7.elm.r1.Interval,
-        conversion: Conversion,
-        toType: IntervalType,
+        conversion: Conversion.IntervalConversion,
     ): Expression {
         val low = interval.low
         val high = interval.high
-        val inner = conversion.conversion!!
         return objectFactory
             .createInterval()
-            .withLow(if (low != null) convertExpression(low, inner) else null)
+            .withLow(if (low != null) convertExpression(low, conversion.pointConversion) else null)
             .withLowClosed(interval.lowClosed)
-            .withHigh(if (high != null) convertExpression(high, inner) else null)
+            .withHigh(
+                if (high != null) convertExpression(high, conversion.pointConversion) else null
+            )
             .withHighClosed(interval.highClosed)
-            .withResultType(toType)
+            .withResultType(conversion.toType)
     }
 
     fun buildAs(expression: Expression?, asType: DataType?): As {
@@ -2052,15 +2053,15 @@ class LibraryBuilder(
                 collapseTypeCase(buildAs(expression, conversion.toType))
             }
             is Conversion.ChoiceNarrowingCast -> {
-                val castedOperand = buildAs(expression, conversion.conversion.fromType)
-                var result = convertExpression(castedOperand, conversion.conversion)
+                val castedOperand = buildAs(expression, conversion.innerConversion.fromType)
+                var result = convertExpression(castedOperand, conversion.innerConversion)
                 if (conversion.hasAlternativeConversions()) {
                     val caseResult = objectFactory.createCase()
                     caseResult.resultType = result.resultType
                     caseResult.caseItem.add(
                         objectFactory
                             .createCaseItem()
-                            .withWhen(buildIs(expression, conversion.conversion.fromType))
+                            .withWhen(buildIs(expression, conversion.innerConversion.fromType))
                             .withThen(result)
                     )
                     for (alternative in conversion.getAlternativeConversions()) {
@@ -2082,8 +2083,8 @@ class LibraryBuilder(
                 result
             }
             is Conversion.ChoiceWideningCast -> {
-                val castedOperand = buildAs(expression, conversion.conversion.fromType)
-                convertExpression(castedOperand, conversion.conversion)
+                val castedOperand = buildAs(expression, conversion.innerConversion.fromType)
+                convertExpression(castedOperand, conversion.innerConversion)
             }
             is Conversion.ListConversion -> convertListExpression(expression, conversion)
             is Conversion.ListDemotion -> demoteListExpression(expression, conversion)

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
@@ -1800,8 +1800,9 @@ class LibraryBuilder(
         resolveUnaryCall("System", "SingletonFrom", singletonFrom)
         // WARNING:
         reportWarning("List-valued expression was demoted to a singleton.", expression)
-        return if (conversion.conversion != null) {
-            convertExpression(singletonFrom, conversion.conversion)
+        val inner = conversion.conversion
+        return if (inner != null) {
+            convertExpression(singletonFrom, inner)
         } else {
             singletonFrom
         }
@@ -1809,8 +1810,9 @@ class LibraryBuilder(
 
     private fun promoteListExpression(expression: Expression, conversion: Conversion): Expression {
         var expression = expression
-        if (conversion.conversion != null) {
-            expression = convertExpression(expression, conversion.conversion)
+        val inner = conversion.conversion
+        if (inner != null) {
+            expression = convertExpression(expression, inner)
         }
         if (expression.resultType == resolveTypeName("System", "Boolean")) {
             // WARNING:
@@ -1836,8 +1838,9 @@ class LibraryBuilder(
         resolveUnaryCall("System", "PointFrom", pointFrom)
         // WARNING:
         reportWarning("Interval-valued expression was demoted to a point.", expression)
-        return if (conversion.conversion != null) {
-            convertExpression(pointFrom, conversion.conversion)
+        val inner = conversion.conversion
+        return if (inner != null) {
+            convertExpression(pointFrom, inner)
         } else {
             pointFrom
         }
@@ -1848,8 +1851,9 @@ class LibraryBuilder(
         conversion: Conversion,
     ): Expression {
         var expression = expression
-        if (conversion.conversion != null) {
-            expression = convertExpression(expression, conversion.conversion)
+        val inner = conversion.conversion
+        if (inner != null) {
+            expression = convertExpression(expression, inner)
         }
         return resolveToInterval(expression)
     }
@@ -1891,6 +1895,7 @@ class LibraryBuilder(
         }
 
         // For non-literal intervals, extract bounds via Property access at runtime
+        val inner = conversion.conversion!!
         return objectFactory
             .createInterval()
             .withLow(
@@ -1900,7 +1905,7 @@ class LibraryBuilder(
                         .withSource(expression)
                         .withPath("low")
                         .withResultType(fromType.pointType),
-                    conversion.conversion!!,
+                    inner,
                 )
             )
             .withLowClosedExpression(
@@ -1917,7 +1922,7 @@ class LibraryBuilder(
                         .withSource(expression)
                         .withPath("high")
                         .withResultType(fromType.pointType),
-                    conversion.conversion,
+                    inner,
                 )
             )
             .withHighClosedExpression(
@@ -1946,11 +1951,12 @@ class LibraryBuilder(
     ): Expression {
         val low = interval.low
         val high = interval.high
+        val inner = conversion.conversion!!
         return objectFactory
             .createInterval()
-            .withLow(if (low != null) convertExpression(low, conversion.conversion!!) else null)
+            .withLow(if (low != null) convertExpression(low, inner) else null)
             .withLowClosed(interval.lowClosed)
-            .withHigh(if (high != null) convertExpression(high, conversion.conversion!!) else null)
+            .withHigh(if (high != null) convertExpression(high, inner) else null)
             .withHighClosed(interval.highClosed)
             .withResultType(toType)
     }
@@ -2029,34 +2035,23 @@ class LibraryBuilder(
     }
 
     @JsExport.Ignore
-    @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth")
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
     fun convertExpression(expression: Expression, conversion: Conversion): Expression {
-        if (
-            conversion.isCast &&
-                (conversion.fromType.isSuperTypeOf(conversion.toType) ||
-                    conversion.fromType.isCompatibleWith(conversion.toType))
-        ) {
-            if (conversion.fromType is ChoiceType && conversion.toType is ChoiceType) {
-
-                if ((conversion.fromType).isSubSetOf(conversion.toType)) {
-                    // conversion between compatible choice types requires no cast (i.e.
-                    // choice<Integer, String> can be safely passed to choice<Integer, String,
-                    // DateTime>
-                    return expression
+        return when (conversion) {
+            is Conversion.Cast -> {
+                if (conversion.fromType is ChoiceType && conversion.toType is ChoiceType) {
+                    if (conversion.fromType.isSubSetOf(conversion.toType)) {
+                        // conversion between compatible choice types requires no cast (i.e.
+                        // choice<Integer, String> can be safely passed to choice<Integer, String,
+                        // DateTime>
+                        return expression
+                    }
+                    // Otherwise, the choice is narrowing and a run-time As is required (to use
+                    // only the expected target types)
                 }
-                // Otherwise, the choice is narrowing and a run-time As is required (to use only the
-                // expected target types)
+                collapseTypeCase(buildAs(expression, conversion.toType))
             }
-            val castedOperand = buildAs(expression, conversion.toType)
-            return collapseTypeCase(castedOperand)
-        } else
-            @Suppress("ComplexCondition")
-            if (
-                conversion.isCast &&
-                    conversion.conversion != null &&
-                    (conversion.fromType.isSuperTypeOf(conversion.conversion.fromType) ||
-                        conversion.fromType.isCompatibleWith(conversion.conversion.fromType))
-            ) {
+            is Conversion.ChoiceNarrowingCast -> {
                 val castedOperand = buildAs(expression, conversion.conversion.fromType)
                 var result = convertExpression(castedOperand, conversion.conversion)
                 if (conversion.hasAlternativeConversions()) {
@@ -2068,7 +2063,7 @@ class LibraryBuilder(
                             .withWhen(buildIs(expression, conversion.conversion.fromType))
                             .withThen(result)
                     )
-                    for (alternative: Conversion in conversion.getAlternativeConversions()) {
+                    for (alternative in conversion.getAlternativeConversions()) {
                         caseResult.caseItem.add(
                             objectFactory
                                 .createCaseItem()
@@ -2084,21 +2079,19 @@ class LibraryBuilder(
                     caseResult.withElse(buildNull(result.resultType))
                     result = caseResult
                 }
-
-                return result
-            } else if (conversion.isListConversion) {
-                return convertListExpression(expression, conversion)
-            } else if (conversion.isListDemotion) {
-                return demoteListExpression(expression, conversion)
-            } else if (conversion.isListPromotion) {
-                return promoteListExpression(expression, conversion)
-            } else if (conversion.isIntervalConversion) {
-                return convertIntervalExpression(expression, conversion)
-            } else if (conversion.isIntervalDemotion) {
-                return demoteIntervalExpression(expression, conversion)
-            } else if (conversion.isIntervalPromotion) {
-                return promoteIntervalExpression(expression, conversion)
-            } else if (conversion.operator != null) {
+                result
+            }
+            is Conversion.ChoiceWideningCast -> {
+                val castedOperand = buildAs(expression, conversion.conversion.fromType)
+                convertExpression(castedOperand, conversion.conversion)
+            }
+            is Conversion.ListConversion -> convertListExpression(expression, conversion)
+            is Conversion.ListDemotion -> demoteListExpression(expression, conversion)
+            is Conversion.ListPromotion -> promoteListExpression(expression, conversion)
+            is Conversion.IntervalConversion -> convertIntervalExpression(expression, conversion)
+            is Conversion.IntervalDemotion -> demoteIntervalExpression(expression, conversion)
+            is Conversion.IntervalPromotion -> promoteIntervalExpression(expression, conversion)
+            is Conversion.OperatorConversion -> {
                 val functionRef =
                     objectFactory
                         .createFunctionRef()
@@ -2108,87 +2101,19 @@ class LibraryBuilder(
                 val systemFunctionInvocation =
                     systemFunctionResolver.resolveSystemFunction(functionRef)
                 if (systemFunctionInvocation != null) {
-                    return systemFunctionInvocation.expression
-                }
-                resolveCall(
-                    functionRef.libraryName,
-                    functionRef.name!!,
-                    FunctionRefInvocation(functionRef),
-                    allowPromotionAndDemotion = false,
-                    allowFluent = false,
-                )
-                return functionRef
-            } else {
-                if (conversion.toType == resolveTypeName("System", "Boolean")) {
-                    return objectFactory
-                        .createToBoolean()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Integer")) {
-                    return objectFactory
-                        .createToInteger()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Long")) {
-                    return objectFactory
-                        .createToLong()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Decimal")) {
-                    return objectFactory
-                        .createToDecimal()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "String")) {
-                    return objectFactory
-                        .createToString()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Date")) {
-                    return objectFactory
-                        .createToDate()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "DateTime")) {
-                    return objectFactory
-                        .createToDateTime()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Time")) {
-                    return objectFactory
-                        .createToTime()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Quantity")) {
-                    return objectFactory
-                        .createToQuantity()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Ratio")) {
-                    return objectFactory
-                        .createToRatio()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
-                } else if (conversion.toType == resolveTypeName("System", "Concept")) {
-                    return objectFactory
-                        .createToConcept()
-                        .withOperand(expression)
-                        .withResultType(conversion.toType)
+                    systemFunctionInvocation.expression
                 } else {
-                    val convertedOperand =
-                        objectFactory
-                            .createConvert()
-                            .withOperand(expression)
-                            .withResultType(conversion.toType)
-                    if (convertedOperand.resultType is NamedType) {
-                        convertedOperand.toType = dataTypeToQName(convertedOperand.resultType)
-                    } else {
-                        convertedOperand.toTypeSpecifier =
-                            dataTypeToTypeSpecifier(convertedOperand.resultType)
-                    }
-                    return convertedOperand
+                    resolveCall(
+                        functionRef.libraryName,
+                        functionRef.name!!,
+                        FunctionRefInvocation(functionRef),
+                        allowPromotionAndDemotion = false,
+                        allowFluent = false,
+                    )
+                    functionRef
                 }
             }
+        }
     }
 
     /**

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/CompiledLibrary.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/CompiledLibrary.kt
@@ -113,7 +113,11 @@ class CompiledLibrary {
     }
 
     fun add(conversion: Conversion) {
-        require(!conversion.isCast) {
+        require(
+            conversion !is Conversion.Cast &&
+                conversion !is Conversion.ChoiceNarrowingCast &&
+                conversion !is Conversion.ChoiceWideningCast
+        ) {
             "Casting conversions cannot be registered as part of a library."
         }
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/CompiledLibrary.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/CompiledLibrary.kt
@@ -26,7 +26,7 @@ class CompiledLibrary {
     private val namespace: MutableMap<String, Element> = HashMap()
     val operatorMap: OperatorMap = OperatorMap()
     private val functionDefs: MutableMap<Operator, FunctionDef> = HashMap()
-    private val conversions: MutableList<Conversion> = ArrayList()
+    private val conversions: MutableList<Conversion.OperatorConversion> = ArrayList()
 
     private fun checkNamespace(identifier: String) {
         val existingResolvedIdentifierContext = resolve(identifier)
@@ -112,15 +112,7 @@ class CompiledLibrary {
         return operatorMap.containsOperator(operator)
     }
 
-    fun add(conversion: Conversion) {
-        require(
-            conversion !is Conversion.Cast &&
-                conversion !is Conversion.ChoiceNarrowingCast &&
-                conversion !is Conversion.ChoiceWideningCast
-        ) {
-            "Casting conversions cannot be registered as part of a library."
-        }
-
+    fun add(conversion: Conversion.OperatorConversion) {
         conversions.add(conversion)
     }
 
@@ -241,7 +233,7 @@ class CompiledLibrary {
         return resolution
     }
 
-    fun getConversions(): List<Conversion> {
+    fun getConversions(): List<Conversion.OperatorConversion> {
         return conversions
     }
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
@@ -26,6 +26,22 @@ sealed class Conversion {
             get() =
                 if (toType is ClassType) ConversionScore.ComplexConversion.score
                 else ConversionScore.SimpleConversion.score
+
+        companion object {
+            fun singletonOperand(operator: Operator): DataType {
+                require(operator.signature.operandTypes.size == 1) {
+                    "Conversion operator must be unary."
+                }
+                return operator.signature.operandTypes[0]
+            }
+
+            fun ensureResultType(operator: Operator): DataType {
+                requireNotNull(operator.resultType) {
+                    "Conversion operator must have a result type."
+                }
+                return operator.resultType!!
+            }
+        }
     }
 
     class Cast(override val fromType: DataType, override val toType: DataType) : Conversion() {
@@ -37,17 +53,8 @@ sealed class Conversion {
         override val fromType: ChoiceType,
         override val toType: DataType,
         val innerConversion: Conversion,
+        val alternativeConversions: List<Conversion> = emptyList(),
     ) : Conversion() {
-        private val alternativeConversions: MutableList<Conversion> = mutableListOf()
-
-        fun getAlternativeConversions(): List<Conversion> = alternativeConversions
-
-        fun hasAlternativeConversions(): Boolean = alternativeConversions.isNotEmpty()
-
-        fun addAlternativeConversion(alternativeConversion: Conversion) {
-            alternativeConversions.add(alternativeConversion)
-        }
-
         override val score: Int
             get() = ConversionScore.Cast.score + innerConversion.score
     }
@@ -123,19 +130,5 @@ sealed class Conversion {
     ) : Conversion() {
         override val score: Int
             get() = ConversionScore.IntervalDemotion.score + (pointConversion?.score ?: 0)
-    }
-
-    companion object {
-        fun singletonOperand(operator: Operator): DataType {
-            require(operator.signature.operandTypes.size == 1) {
-                "Conversion operator must be unary."
-            }
-            return operator.signature.operandTypes[0]
-        }
-
-        fun ensureResultType(operator: Operator): DataType {
-            requireNotNull(operator.resultType) { "Conversion operator must have a result type." }
-            return operator.resultType!!
-        }
     }
 }

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
@@ -15,20 +15,12 @@ sealed class Conversion {
     open val isImplicit: Boolean
         get() = true
 
-    @Suppress("MemberNameEqualsClassName")
-    open val conversion: Conversion?
-        get() = null
-
-    open val operator: Operator?
-        get() = null
-
-    val isGeneric: Boolean
-        get() = operator is GenericOperator
-
-    class OperatorConversion(override val operator: Operator, override val isImplicit: Boolean) :
+    class OperatorConversion(val operator: Operator, override val isImplicit: Boolean) :
         Conversion() {
         override val fromType: DataType = singletonOperand(operator)
         override val toType: DataType = ensureResultType(operator)
+        val isGeneric: Boolean
+            get() = operator is GenericOperator
 
         override val score: Int
             get() =
@@ -44,7 +36,7 @@ sealed class Conversion {
     class ChoiceNarrowingCast(
         override val fromType: ChoiceType,
         override val toType: DataType,
-        override val conversion: Conversion,
+        val innerConversion: Conversion,
     ) : Conversion() {
         private val alternativeConversions: MutableList<Conversion> = mutableListOf()
 
@@ -57,80 +49,80 @@ sealed class Conversion {
         }
 
         override val score: Int
-            get() = ConversionScore.Cast.score + conversion.score
+            get() = ConversionScore.Cast.score + innerConversion.score
     }
 
     class ChoiceWideningCast(
         override val fromType: DataType,
         override val toType: ChoiceType,
-        override val conversion: Conversion,
+        val innerConversion: Conversion,
     ) : Conversion() {
         override val score: Int
-            get() = ConversionScore.Cast.score + conversion.score
+            get() = ConversionScore.Cast.score + innerConversion.score
     }
 
     class ListConversion(
         override val fromType: ListType,
         override val toType: ListType,
-        override val conversion: Conversion,
+        val elementConversion: Conversion,
     ) : Conversion() {
         override val score: Int
             get() {
                 val baseScore =
                     if (toType.elementType is SimpleType) ConversionScore.SimpleConversion.score
                     else ConversionScore.ComplexConversion.score
-                return baseScore + conversion.score
+                return baseScore + elementConversion.score
             }
     }
 
     class ListPromotion(
         override val fromType: DataType,
         override val toType: ListType,
-        override val conversion: Conversion?,
+        val elementConversion: Conversion?,
     ) : Conversion() {
         override val score: Int
-            get() = ConversionScore.ListPromotion.score + (conversion?.score ?: 0)
+            get() = ConversionScore.ListPromotion.score + (elementConversion?.score ?: 0)
     }
 
     class ListDemotion(
         override val fromType: ListType,
         override val toType: DataType,
-        override val conversion: Conversion?,
+        val elementConversion: Conversion?,
     ) : Conversion() {
         override val score: Int
-            get() = ConversionScore.ListDemotion.score + (conversion?.score ?: 0)
+            get() = ConversionScore.ListDemotion.score + (elementConversion?.score ?: 0)
     }
 
     class IntervalConversion(
         override val fromType: IntervalType,
         override val toType: IntervalType,
-        override val conversion: Conversion,
+        val pointConversion: Conversion,
     ) : Conversion() {
         override val score: Int
             get() {
                 val baseScore =
                     if (toType.pointType is SimpleType) ConversionScore.SimpleConversion.score
                     else ConversionScore.ComplexConversion.score
-                return baseScore + conversion.score
+                return baseScore + pointConversion.score
             }
     }
 
     class IntervalPromotion(
         override val fromType: DataType,
         override val toType: IntervalType,
-        override val conversion: Conversion?,
+        val pointConversion: Conversion?,
     ) : Conversion() {
         override val score: Int
-            get() = ConversionScore.IntervalPromotion.score + (conversion?.score ?: 0)
+            get() = ConversionScore.IntervalPromotion.score + (pointConversion?.score ?: 0)
     }
 
     class IntervalDemotion(
         override val fromType: IntervalType,
         override val toType: DataType,
-        override val conversion: Conversion?,
+        val pointConversion: Conversion?,
     ) : Conversion() {
         override val score: Int
-            get() = ConversionScore.IntervalDemotion.score + (conversion?.score ?: 0)
+            get() = ConversionScore.IntervalDemotion.score + (pointConversion?.score ?: 0)
     }
 
     companion object {

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Conversion.kt
@@ -1,12 +1,6 @@
 package org.cqframework.cql.cql2elm.model
 
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.Cast
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.ComplexConversion
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.IntervalDemotion
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.IntervalPromotion
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.ListDemotion
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.ListPromotion
-import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore.SimpleConversion
+import org.cqframework.cql.cql2elm.model.ConversionMap.ConversionScore
 import org.hl7.cql.model.ChoiceType
 import org.hl7.cql.model.ClassType
 import org.hl7.cql.model.DataType
@@ -14,150 +8,130 @@ import org.hl7.cql.model.IntervalType
 import org.hl7.cql.model.ListType
 import org.hl7.cql.model.SimpleType
 
-class Conversion(
-    val fromType: DataType,
-    val toType: DataType,
-    val isImplicit: Boolean = false,
-    val conversion: Conversion? = null,
-    val operator: Operator? = null,
-) {
-    constructor(
-        operator: Operator,
-        isImplicit: Boolean,
-    ) : this(singletonOperand(operator), ensureResultType(operator), isImplicit, null, operator)
+sealed class Conversion {
+    abstract val fromType: DataType
+    abstract val toType: DataType
+    abstract val score: Int
+    open val isImplicit: Boolean
+        get() = true
 
-    constructor(fromType: DataType, toType: DataType) : this(fromType, toType, true) {
-        this.isCast = true
-    }
+    @Suppress("MemberNameEqualsClassName")
+    open val conversion: Conversion?
+        get() = null
 
-    constructor(
-        fromType: ChoiceType,
-        toType: DataType,
-        choiceConversion: Conversion,
-    ) : this(fromType, toType, true, choiceConversion) {
-        this.isCast = true
-    }
-
-    constructor(
-        fromType: DataType,
-        toType: ChoiceType,
-        choiceConversion: Conversion,
-    ) : this(fromType, toType, true, choiceConversion) {
-        this.isCast = true
-    }
-
-    constructor(
-        fromType: ListType,
-        toType: ListType,
-        elementConversion: Conversion,
-    ) : this(fromType, toType, true, elementConversion) {
-        this.isListConversion = true
-    }
-
-    constructor(
-        fromType: ListType,
-        toType: DataType,
-        elementConversion: Conversion?,
-    ) : this(fromType, toType, true, elementConversion) {
-        this.isListDemotion = true
-    }
-
-    constructor(
-        fromType: DataType,
-        toType: ListType,
-        elementConversion: Conversion?,
-    ) : this(fromType, toType, true, elementConversion) {
-        this.isListPromotion = true
-    }
-
-    constructor(
-        fromType: IntervalType,
-        toType: DataType,
-        elementConversion: Conversion?,
-    ) : this(fromType, toType, true, elementConversion) {
-        this.isIntervalDemotion = true
-    }
-
-    constructor(
-        fromType: DataType,
-        toType: IntervalType,
-        elementConversion: Conversion?,
-    ) : this(fromType, toType, true, elementConversion) {
-        this.isIntervalPromotion = true
-    }
-
-    constructor(
-        fromType: IntervalType,
-        toType: IntervalType,
-        pointConversion: Conversion,
-    ) : this(fromType, toType, true, pointConversion) {
-        this.isIntervalConversion = true
-    }
-
-    private val alternativeConversions: MutableList<Conversion> = mutableListOf()
-
-    fun getAlternativeConversions(): List<Conversion> {
-        return alternativeConversions
-    }
-
-    fun hasAlternativeConversions(): Boolean {
-        return alternativeConversions.isNotEmpty()
-    }
-
-    fun addAlternativeConversion(alternativeConversion: Conversion) {
-        require(fromType is ChoiceType) {
-            "Alternative conversions can only be used with choice types"
-        }
-
-        // Should also guard against adding an alternative that is not one of the component
-        // types of the fromType
-        // This should never happen though with current usage
-        alternativeConversions.add(alternativeConversion)
-    }
-
-    val score: Int
-        get() {
-            val nestedScore = conversion?.score ?: 0
-            return when {
-                isCast -> Cast.score + nestedScore
-                isIntervalDemotion -> IntervalDemotion.score + nestedScore
-                isListDemotion -> ListDemotion.score + nestedScore
-                isIntervalPromotion -> IntervalPromotion.score + nestedScore
-                isListPromotion -> ListPromotion.score + nestedScore
-                isListConversion && toType is ListType && toType.elementType is SimpleType ->
-                    SimpleConversion.score + nestedScore
-                isListConversion -> ComplexConversion.score + nestedScore
-                isIntervalConversion && toType is IntervalType && toType.pointType is SimpleType ->
-                    SimpleConversion.score + nestedScore
-                isIntervalConversion -> ComplexConversion.score + nestedScore
-                toType is ClassType -> ComplexConversion.score + nestedScore
-                else -> SimpleConversion.score + nestedScore
-            }
-        }
+    open val operator: Operator?
+        get() = null
 
     val isGeneric: Boolean
         get() = operator is GenericOperator
 
-    var isCast: Boolean = false
-        private set
+    class OperatorConversion(override val operator: Operator, override val isImplicit: Boolean) :
+        Conversion() {
+        override val fromType: DataType = singletonOperand(operator)
+        override val toType: DataType = ensureResultType(operator)
 
-    var isListConversion: Boolean = false
-        private set
+        override val score: Int
+            get() =
+                if (toType is ClassType) ConversionScore.ComplexConversion.score
+                else ConversionScore.SimpleConversion.score
+    }
 
-    var isListPromotion: Boolean = false
-        private set
+    class Cast(override val fromType: DataType, override val toType: DataType) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.Cast.score
+    }
 
-    var isListDemotion: Boolean = false
-        private set
+    class ChoiceNarrowingCast(
+        override val fromType: ChoiceType,
+        override val toType: DataType,
+        override val conversion: Conversion,
+    ) : Conversion() {
+        private val alternativeConversions: MutableList<Conversion> = mutableListOf()
 
-    var isIntervalConversion: Boolean = false
-        private set
+        fun getAlternativeConversions(): List<Conversion> = alternativeConversions
 
-    var isIntervalPromotion: Boolean = false
-        private set
+        fun hasAlternativeConversions(): Boolean = alternativeConversions.isNotEmpty()
 
-    var isIntervalDemotion: Boolean = false
-        private set
+        fun addAlternativeConversion(alternativeConversion: Conversion) {
+            alternativeConversions.add(alternativeConversion)
+        }
+
+        override val score: Int
+            get() = ConversionScore.Cast.score + conversion.score
+    }
+
+    class ChoiceWideningCast(
+        override val fromType: DataType,
+        override val toType: ChoiceType,
+        override val conversion: Conversion,
+    ) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.Cast.score + conversion.score
+    }
+
+    class ListConversion(
+        override val fromType: ListType,
+        override val toType: ListType,
+        override val conversion: Conversion,
+    ) : Conversion() {
+        override val score: Int
+            get() {
+                val baseScore =
+                    if (toType.elementType is SimpleType) ConversionScore.SimpleConversion.score
+                    else ConversionScore.ComplexConversion.score
+                return baseScore + conversion.score
+            }
+    }
+
+    class ListPromotion(
+        override val fromType: DataType,
+        override val toType: ListType,
+        override val conversion: Conversion?,
+    ) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.ListPromotion.score + (conversion?.score ?: 0)
+    }
+
+    class ListDemotion(
+        override val fromType: ListType,
+        override val toType: DataType,
+        override val conversion: Conversion?,
+    ) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.ListDemotion.score + (conversion?.score ?: 0)
+    }
+
+    class IntervalConversion(
+        override val fromType: IntervalType,
+        override val toType: IntervalType,
+        override val conversion: Conversion,
+    ) : Conversion() {
+        override val score: Int
+            get() {
+                val baseScore =
+                    if (toType.pointType is SimpleType) ConversionScore.SimpleConversion.score
+                    else ConversionScore.ComplexConversion.score
+                return baseScore + conversion.score
+            }
+    }
+
+    class IntervalPromotion(
+        override val fromType: DataType,
+        override val toType: IntervalType,
+        override val conversion: Conversion?,
+    ) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.IntervalPromotion.score + (conversion?.score ?: 0)
+    }
+
+    class IntervalDemotion(
+        override val fromType: IntervalType,
+        override val toType: DataType,
+        override val conversion: Conversion?,
+    ) : Conversion() {
+        override val score: Int
+            get() = ConversionScore.IntervalDemotion.score + (conversion?.score ?: 0)
+    }
 
     companion object {
         fun singletonOperand(operator: Operator): DataType {

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
@@ -36,7 +36,7 @@ class ConversionMap {
     }
 
     private val map: MutableMap<DataType, MutableList<Conversion>> = HashMap()
-    val genericConversions: MutableList<Conversion> = ArrayList()
+    val genericConversions: MutableList<Conversion.OperatorConversion> = ArrayList()
     var isListDemotionEnabled: Boolean = true
     var isListPromotionEnabled: Boolean = true
     var isIntervalDemotionEnabled: Boolean = false
@@ -47,7 +47,9 @@ class ConversionMap {
     }
 
     fun getConversionOperator(fromType: DataType, toType: DataType): Operator? {
-        return this.getConversions(fromType).firstOrNull { it.toType == toType }?.operator
+        return (getConversions(fromType).firstOrNull { it.toType == toType }
+                as? Conversion.OperatorConversion)
+            ?.operator
     }
 
     fun add(conversion: Conversion) {
@@ -61,7 +63,7 @@ class ConversionMap {
         // used because the
         // generic conversions
         // are not added in the SystemLibraryHelper.
-        if (conversion.isGeneric) {
+        if (conversion is Conversion.OperatorConversion && conversion.isGeneric) {
             val conversions = genericConversions
             check(!hasConversion(conversion, conversions)) {
                 "Conversion from ${conversion.fromType} to ${conversion.toType} is already defined."
@@ -257,22 +259,20 @@ class ConversionMap {
     ): Boolean {
         var operatorsInstantiated = false
         for (c in genericConversions) {
-            if (c.operator != null) {
-                // instantiate the generic...
-                val instantiationResult =
-                    (c.operator as GenericOperator).instantiate(
-                        Signature(fromType),
-                        operatorMap,
-                        this,
-                        false,
-                    )
-                val operator = instantiationResult.operator
-                if (operator != null && !operatorMap.containsOperator(operator)) {
-                    operatorMap.addOperator(operator)
-                    val conversion = Conversion.OperatorConversion(operator, true)
-                    this.add(conversion)
-                    operatorsInstantiated = true
-                }
+            // instantiate the generic...
+            val instantiationResult =
+                (c.operator as GenericOperator).instantiate(
+                    Signature(fromType),
+                    operatorMap,
+                    this,
+                    false,
+                )
+            val operator = instantiationResult.operator
+            if (operator != null && !operatorMap.containsOperator(operator)) {
+                operatorMap.addOperator(operator)
+                val conversion = Conversion.OperatorConversion(operator, true)
+                this.add(conversion)
+                operatorsInstantiated = true
             }
         }
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
@@ -97,7 +97,7 @@ class ConversionMap {
 
     private fun findCompatibleConversion(fromType: DataType, toType: DataType): Conversion? {
         if (fromType.isCompatibleWith(toType)) {
-            return Conversion(fromType, toType)
+            return Conversion.Cast(fromType, toType)
         }
 
         return null
@@ -109,13 +109,13 @@ class ConversionMap {
         allowPromotionAndDemotion: Boolean,
         operatorMap: OperatorMap,
     ): Conversion? {
-        var result: Conversion? = null
+        var result: Conversion.ChoiceNarrowingCast? = null
         for (choice in fromType.types) {
             val choiceConversion =
                 findConversion(choice, toType, true, allowPromotionAndDemotion, operatorMap)
             if (choiceConversion != null) {
                 if (result == null) {
-                    result = Conversion(fromType, toType, choiceConversion)
+                    result = Conversion.ChoiceNarrowingCast(fromType, toType, choiceConversion)
                 } else {
                     result.addAlternativeConversion(choiceConversion)
                 }
@@ -133,7 +133,7 @@ class ConversionMap {
     ): Conversion? {
         for (choice in toType.types) {
             findConversion(fromType, choice, true, allowPromotionAndDemotion, operatorMap)?.let {
-                return Conversion(fromType, toType, it)
+                return Conversion.ChoiceWideningCast(fromType, toType, it)
             }
         }
 
@@ -152,7 +152,7 @@ class ConversionMap {
                 allowPromotionAndDemotion = false,
                 operatorMap = operatorMap,
             )
-            ?.let { Conversion(fromType, toType, it) }
+            ?.let { Conversion.ListConversion(fromType, toType, it) }
     }
 
     private fun findIntervalConversion(
@@ -167,7 +167,7 @@ class ConversionMap {
                 allowPromotionAndDemotion = false,
                 operatorMap = operatorMap,
             )
-            ?.let { Conversion(fromType, toType, it) }
+            ?.let { Conversion.IntervalConversion(fromType, toType, it) }
     }
 
     private fun findListDemotion(
@@ -177,7 +177,7 @@ class ConversionMap {
     ): Conversion? {
         val elementType = fromType.elementType
         return if (elementType.isSubTypeOf(toType)) {
-            Conversion(fromType, toType, null)
+            Conversion.ListDemotion(fromType, toType, null)
         } else {
             findConversion(
                     elementType,
@@ -186,7 +186,7 @@ class ConversionMap {
                     allowPromotionAndDemotion = false,
                     operatorMap = operatorMap,
                 )
-                ?.let { Conversion(fromType, toType, it) }
+                ?.let { Conversion.ListDemotion(fromType, toType, it) }
         }
     }
 
@@ -196,7 +196,7 @@ class ConversionMap {
         operatorMap: OperatorMap,
     ): Conversion? {
         return if (fromType.isSubTypeOf(toType.elementType)) {
-            Conversion(fromType, toType, null)
+            Conversion.ListPromotion(fromType, toType, null)
         } else {
             findConversion(
                     fromType,
@@ -205,7 +205,7 @@ class ConversionMap {
                     allowPromotionAndDemotion = false,
                     operatorMap = operatorMap,
                 )
-                ?.let { Conversion(fromType, toType, it) }
+                ?.let { Conversion.ListPromotion(fromType, toType, it) }
         }
     }
 
@@ -216,7 +216,7 @@ class ConversionMap {
     ): Conversion? {
         val pointType = fromType.pointType
         return if (pointType.isSubTypeOf(toType)) {
-            Conversion(fromType, toType, null)
+            Conversion.IntervalDemotion(fromType, toType, null)
         } else {
             findConversion(
                     pointType,
@@ -225,7 +225,7 @@ class ConversionMap {
                     allowPromotionAndDemotion = false,
                     operatorMap = operatorMap,
                 )
-                ?.let { Conversion(fromType, toType, it) }
+                ?.let { Conversion.IntervalDemotion(fromType, toType, it) }
         }
     }
 
@@ -235,7 +235,7 @@ class ConversionMap {
         operatorMap: OperatorMap,
     ): Conversion? {
         return if (fromType.isSubTypeOf(toType.pointType)) {
-            Conversion(fromType, toType, null)
+            Conversion.IntervalPromotion(fromType, toType, null)
         } else {
             findConversion(
                     fromType,
@@ -244,7 +244,7 @@ class ConversionMap {
                     allowPromotionAndDemotion = false,
                     operatorMap = operatorMap,
                 )
-                ?.let { Conversion(fromType, toType, it) }
+                ?.let { Conversion.IntervalPromotion(fromType, toType, it) }
         }
     }
 
@@ -269,7 +269,7 @@ class ConversionMap {
                 val operator = instantiationResult.operator
                 if (operator != null && !operatorMap.containsOperator(operator)) {
                     operatorMap.addOperator(operator)
-                    val conversion = Conversion(operator, true)
+                    val conversion = Conversion.OperatorConversion(operator, true)
                     this.add(conversion)
                     operatorsInstantiated = true
                 }

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ConversionMap.kt
@@ -35,35 +35,30 @@ class ConversionMap {
         ListPromotion(9),
     }
 
-    private val map: MutableMap<DataType, MutableList<Conversion>> = HashMap()
+    private val map: MutableMap<DataType, MutableList<Conversion.OperatorConversion>> = HashMap()
     val genericConversions: MutableList<Conversion.OperatorConversion> = ArrayList()
     var isListDemotionEnabled: Boolean = true
     var isListPromotionEnabled: Boolean = true
     var isIntervalDemotionEnabled: Boolean = false
     var isIntervalPromotionEnabled: Boolean = false
 
-    private fun hasConversion(conversion: Conversion, conversions: List<Conversion>): Boolean {
+    private fun hasConversion(
+        conversion: Conversion.OperatorConversion,
+        conversions: List<Conversion.OperatorConversion>,
+    ): Boolean {
         return conversions.any { it.toType == conversion.toType }
     }
 
     fun getConversionOperator(fromType: DataType, toType: DataType): Operator? {
-        return (getConversions(fromType).firstOrNull { it.toType == toType }
-                as? Conversion.OperatorConversion)
-            ?.operator
+        return getConversions(fromType).firstOrNull { it.toType == toType }?.operator
     }
 
-    fun add(conversion: Conversion) {
+    fun add(conversion: Conversion.OperatorConversion) {
         // NOTE: The conversion map supports generic conversions, however, they turned out to be
-        // quite expensive
-        // computationally
-        // so we introduced list promotion and demotion instead (we should add interval promotion
-        // and demotion too,
-        // would be quite useful)
-        // Generic conversions could still be potentially useful, so I left the code, but it's never
-        // used because the
-        // generic conversions
-        // are not added in the SystemLibraryHelper.
-        if (conversion is Conversion.OperatorConversion && conversion.isGeneric) {
+        // quite expensive computationally, so we introduced list promotion and demotion instead.
+        // Generic conversions could still be potentially useful, so I left the code, but it's
+        // never used because the generic conversions are not added in the SystemLibraryHelper.
+        if (conversion.isGeneric) {
             val conversions = genericConversions
             check(!hasConversion(conversion, conversions)) {
                 "Conversion from ${conversion.fromType} to ${conversion.toType} is already defined."
@@ -80,15 +75,15 @@ class ConversionMap {
         }
     }
 
-    fun getConversions(fromType: DataType): MutableList<Conversion> {
+    fun getConversions(fromType: DataType): MutableList<Conversion.OperatorConversion> {
         return map.getOrPut(fromType) { ArrayList() }
     }
 
     /*
     Returns conversions for the given type, or any supertype, recursively
      */
-    private fun getAllConversions(fromType: DataType?): List<Conversion> {
-        val conversions: MutableList<Conversion> = ArrayList()
+    private fun getAllConversions(fromType: DataType?): List<Conversion.OperatorConversion> {
+        val conversions: MutableList<Conversion.OperatorConversion> = ArrayList()
         var currentType = fromType
         while (currentType != null && currentType != DataType.ANY) {
             conversions.addAll(getConversions(currentType))
@@ -111,20 +106,14 @@ class ConversionMap {
         allowPromotionAndDemotion: Boolean,
         operatorMap: OperatorMap,
     ): Conversion? {
-        var result: Conversion.ChoiceNarrowingCast? = null
-        for (choice in fromType.types) {
-            val choiceConversion =
+        val matches =
+            fromType.types.mapNotNull { choice ->
                 findConversion(choice, toType, true, allowPromotionAndDemotion, operatorMap)
-            if (choiceConversion != null) {
-                if (result == null) {
-                    result = Conversion.ChoiceNarrowingCast(fromType, toType, choiceConversion)
-                } else {
-                    result.addAlternativeConversion(choiceConversion)
-                }
             }
-        }
 
-        return result
+        if (matches.isEmpty()) return null
+
+        return Conversion.ChoiceNarrowingCast(fromType, toType, matches.first(), matches.drop(1))
     }
 
     private fun findTargetChoiceConversion(

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/InstantiationContextImpl.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/InstantiationContextImpl.kt
@@ -152,18 +152,21 @@ class InstantiationContextImpl(
     override fun getIntervalConversionTargets(callType: DataType): List<IntervalType> {
         val results = ArrayList<IntervalType>()
         for (c in conversionMap.getConversions(callType)) {
-            if (c.toType is IntervalType) {
-                results.add(c.toType)
+            val targetType = c.toType
+            if (targetType is IntervalType) {
+                results.add(targetType)
                 conversionScore += ConversionMap.ConversionScore.ComplexConversion.score
             }
         }
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                if (c.operator != null && c.toType is IntervalType) {
+                val op = c.operator
+                val targetType = c.toType
+                if (op != null && targetType is IntervalType) {
                     // instantiate the generic...
                     val instantiationResult =
-                        (c.operator as GenericOperator).instantiate(
+                        (op as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,
@@ -175,7 +178,7 @@ class InstantiationContextImpl(
                     // score
                     if (operator != null) {
                         operatorMap.addOperator(operator)
-                        val conversion = Conversion(operator, true)
+                        val conversion = Conversion.OperatorConversion(operator, true)
                         conversionMap.add(conversion)
                         results.add(conversion.toType as IntervalType)
                     }
@@ -200,18 +203,21 @@ class InstantiationContextImpl(
     override fun getListConversionTargets(callType: DataType): List<ListType> {
         val results = ArrayList<ListType>()
         for (c in conversionMap.getConversions(callType)) {
-            if (c.toType is ListType) {
-                results.add(c.toType)
+            val targetType = c.toType
+            if (targetType is ListType) {
+                results.add(targetType)
                 conversionScore += ConversionMap.ConversionScore.ComplexConversion.score
             }
         }
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                if (c.operator != null && c.toType is ListType) {
+                val op = c.operator
+                val targetType = c.toType
+                if (op != null && targetType is ListType) {
                     // instantiate the generic...
                     val instantiationResult =
-                        (c.operator as GenericOperator).instantiate(
+                        (op as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,
@@ -223,7 +229,7 @@ class InstantiationContextImpl(
                     // score
                     if (operator != null) {
                         operatorMap.addOperator(operator)
-                        val conversion = Conversion(operator, true)
+                        val conversion = Conversion.OperatorConversion(operator, true)
                         conversionMap.add(conversion)
                         results.add(conversion.toType as ListType)
                     }
@@ -248,17 +254,20 @@ class InstantiationContextImpl(
     override fun getSimpleConversionTargets(callType: DataType): List<SimpleType> {
         val results = ArrayList<SimpleType>()
         for (c in conversionMap.getConversions(callType)) {
-            if (c.toType is SimpleType) {
-                results.add(c.toType)
+            val targetType = c.toType
+            if (targetType is SimpleType) {
+                results.add(targetType)
                 conversionScore += ConversionMap.ConversionScore.SimpleConversion.score
             }
         }
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                if (c.operator != null && c.toType is SimpleType) {
+                val op = c.operator
+                val targetType = c.toType
+                if (op != null && targetType is SimpleType) {
                     val instantiationResult =
-                        (c.operator as GenericOperator).instantiate(
+                        (op as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,
@@ -270,7 +279,7 @@ class InstantiationContextImpl(
                     // score
                     if (operator != null) {
                         operatorMap.addOperator(operator)
-                        val conversion = Conversion(operator, true)
+                        val conversion = Conversion.OperatorConversion(operator, true)
                         conversionMap.add(conversion)
                         results.add(conversion.toType as SimpleType)
                     }

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/InstantiationContextImpl.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/InstantiationContextImpl.kt
@@ -161,12 +161,11 @@ class InstantiationContextImpl(
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                val op = c.operator
                 val targetType = c.toType
-                if (op != null && targetType is IntervalType) {
+                if (targetType is IntervalType) {
                     // instantiate the generic...
                     val instantiationResult =
-                        (op as GenericOperator).instantiate(
+                        (c.operator as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,
@@ -212,12 +211,11 @@ class InstantiationContextImpl(
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                val op = c.operator
                 val targetType = c.toType
-                if (op != null && targetType is ListType) {
+                if (targetType is ListType) {
                     // instantiate the generic...
                     val instantiationResult =
-                        (op as GenericOperator).instantiate(
+                        (c.operator as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,
@@ -263,11 +261,10 @@ class InstantiationContextImpl(
 
         if (results.isEmpty()) {
             for (c in conversionMap.genericConversions) {
-                val op = c.operator
                 val targetType = c.toType
-                if (op != null && targetType is SimpleType) {
+                if (targetType is SimpleType) {
                     val instantiationResult =
-                        (op as GenericOperator).instantiate(
+                        (c.operator as GenericOperator).instantiate(
                             Signature(callType),
                             operatorMap,
                             conversionMap,

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
@@ -11,7 +11,7 @@ import org.hl7.elm_modelinfo.r1.ModelInfo
 open class Model(val modelInfo: ModelInfo, modelManager: ModelManager?) {
     private var index: Map<String, DataType> = HashMap()
     private val classIndex: MutableMap<String, ClassType> = HashMap()
-    private val conversions: MutableList<Conversion> = ArrayList()
+    private val conversions: MutableList<Conversion.OperatorConversion> = ArrayList()
     private val contexts: MutableList<ModelContext> = ArrayList()
 
     private val nameIndex: MutableMap<String, DataType> = HashMap()
@@ -42,7 +42,7 @@ open class Model(val modelInfo: ModelInfo, modelManager: ModelManager?) {
         }
     }
 
-    fun getConversions(): List<Conversion> {
+    fun getConversions(): List<Conversion.OperatorConversion> {
         return conversions
     }
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ModelImporter.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ModelImporter.kt
@@ -55,7 +55,7 @@ class ModelImporter(val modelInfo: ModelInfo, val modelManager: ModelManager?) {
     private val typeInfoIndex: MutableMap<String, TypeInfo> = HashMap()
     private val resolvedTypes: MutableMap<String, DataType> = HashMap()
     private val dataTypes: MutableList<DataType> = ArrayList()
-    val conversions: MutableList<Conversion> = ArrayList()
+    val conversions: MutableList<Conversion.OperatorConversion> = ArrayList()
     val contexts: MutableList<ModelContext> = ArrayList()
     private var defaultContext: ModelContext? = null
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ModelImporter.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/ModelImporter.kt
@@ -103,7 +103,7 @@ class ModelImporter(val modelInfo: ModelInfo, val modelManager: ModelManager?) {
             operator.libraryName = libraryName
 
             // All conversions loaded as part of a model are implicit
-            val conversion = Conversion(operator, true)
+            val conversion = Conversion.OperatorConversion(operator, true)
             conversions.add(conversion)
         }
 

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.kt
@@ -138,35 +138,35 @@ object SystemLibraryHelper {
         val booleanToString =
             Operator("ToString", Signature(systemModel.boolean), systemModel.string)
         add(system, tb, booleanToString)
-        add(system, tb, Conversion(booleanToString, false))
+        add(system, tb, Conversion.OperatorConversion(booleanToString, false))
         val integerToString =
             Operator("ToString", Signature(systemModel.integer), systemModel.string)
         add(system, tb, integerToString)
-        add(system, tb, Conversion(integerToString, false))
+        add(system, tb, Conversion.OperatorConversion(integerToString, false))
         val longToString = Operator("ToString", Signature(systemModel.long), systemModel.string)
         add(system, tb, longToString)
-        add(system, tb, Conversion(longToString, false))
+        add(system, tb, Conversion.OperatorConversion(longToString, false))
         val decimalToString =
             Operator("ToString", Signature(systemModel.decimal), systemModel.string)
         add(system, tb, decimalToString)
-        add(system, tb, Conversion(decimalToString, false))
+        add(system, tb, Conversion.OperatorConversion(decimalToString, false))
         val dateTimeToString =
             Operator("ToString", Signature(systemModel.dateTime), systemModel.string)
         add(system, tb, dateTimeToString)
-        add(system, tb, Conversion(dateTimeToString, false))
+        add(system, tb, Conversion.OperatorConversion(dateTimeToString, false))
         val dateToString = Operator("ToString", Signature(systemModel.date), systemModel.string)
         add(system, tb, dateToString)
-        add(system, tb, Conversion(dateToString, false))
+        add(system, tb, Conversion.OperatorConversion(dateToString, false))
         val timeToString = Operator("ToString", Signature(systemModel.time), systemModel.string)
         add(system, tb, timeToString)
-        add(system, tb, Conversion(timeToString, false))
+        add(system, tb, Conversion.OperatorConversion(timeToString, false))
         val quantityToString =
             Operator("ToString", Signature(systemModel.quantity), systemModel.string)
         add(system, tb, quantityToString)
-        add(system, tb, Conversion(quantityToString, false))
+        add(system, tb, Conversion.OperatorConversion(quantityToString, false))
         val ratioToString = Operator("ToString", Signature(systemModel.ratio), systemModel.string)
         add(system, tb, ratioToString)
-        add(system, tb, Conversion(ratioToString, false))
+        add(system, tb, Conversion.OperatorConversion(ratioToString, false))
 
         // Operator stringToString = new Operator("ToString", new
         // Signature(systemModel.getString()),
@@ -182,18 +182,18 @@ object SystemLibraryHelper {
         val stringToBoolean =
             Operator("ToBoolean", Signature(systemModel.string), systemModel.boolean)
         add(system, tb, stringToBoolean)
-        add(system, tb, Conversion(stringToBoolean, false))
+        add(system, tb, Conversion.OperatorConversion(stringToBoolean, false))
         val integerToBoolean =
             Operator("ToBoolean", Signature(systemModel.integer), systemModel.boolean)
         add(system, tb, integerToBoolean)
-        add(system, tb, Conversion(integerToBoolean, false))
+        add(system, tb, Conversion.OperatorConversion(integerToBoolean, false))
         val decimalToBoolean =
             Operator("ToBoolean", Signature(systemModel.decimal), systemModel.boolean)
         add(system, tb, decimalToBoolean)
-        add(system, tb, Conversion(decimalToBoolean, false))
+        add(system, tb, Conversion.OperatorConversion(decimalToBoolean, false))
         val longToBoolean = Operator("ToBoolean", Signature(systemModel.long), systemModel.boolean)
         add(system, tb, longToBoolean)
-        add(system, tb, Conversion(longToBoolean, false))
+        add(system, tb, Conversion.OperatorConversion(longToBoolean, false))
 
         // Operator booleanToBoolean = new Operator("ToBoolean", new
         // Signature(systemModel.getBoolean()),
@@ -205,7 +205,7 @@ object SystemLibraryHelper {
         val toChars =
             Operator("ToChars", Signature(systemModel.string), ListType(systemModel.string))
         add(system, tb, toChars)
-        add(system, tb, Conversion(toChars, false))
+        add(system, tb, Conversion.OperatorConversion(toChars, false))
 
         // ToInteger(String) : Integer
         // ToInteger(Boolean) : Integer
@@ -214,14 +214,14 @@ object SystemLibraryHelper {
         val stringToInteger =
             Operator("ToInteger", Signature(systemModel.string), systemModel.integer)
         add(system, tb, stringToInteger)
-        add(system, tb, Conversion(stringToInteger, false))
+        add(system, tb, Conversion.OperatorConversion(stringToInteger, false))
         val longToInteger = Operator("ToInteger", Signature(systemModel.long), systemModel.integer)
         add(system, tb, longToInteger)
-        add(system, tb, Conversion(longToInteger, false))
+        add(system, tb, Conversion.OperatorConversion(longToInteger, false))
         val booleanToInteger =
             Operator("ToInteger", Signature(systemModel.boolean), systemModel.integer)
         add(system, tb, booleanToInteger)
-        add(system, tb, Conversion(booleanToInteger, false))
+        add(system, tb, Conversion.OperatorConversion(booleanToInteger, false))
 
         // Operator integerToInteger = new Operator("ToInteger", new
         // Signature(systemModel.getInteger()),
@@ -235,17 +235,17 @@ object SystemLibraryHelper {
         // ToLong(Long) : Long
         val stringToLong = Operator("ToLong", Signature(systemModel.string), systemModel.long)
         add(system, tb, stringToLong)
-        add(system, tb, Conversion(stringToLong, false))
+        add(system, tb, Conversion.OperatorConversion(stringToLong, false))
         val integerToLong = Operator("ToLong", Signature(systemModel.integer), systemModel.long)
         add(system, tb, integerToLong)
-        add(system, tb, Conversion(integerToLong, true))
+        add(system, tb, Conversion.OperatorConversion(integerToLong, true))
         // Operator longToLong = new Operator("ToLong", new Signature(systemModel.getLong()),
         // systemModel.getLong());
         // add(system, tb, longToLong);
         // add(system, tb, new Conversion(longToLong, false));
         val booleanToLong = Operator("ToLong", Signature(systemModel.boolean), systemModel.long)
         add(system, tb, booleanToLong)
-        add(system, tb, Conversion(booleanToLong, false))
+        add(system, tb, Conversion.OperatorConversion(booleanToLong, false))
 
         // ToDecimal(Boolean) : Decimal
         // ToDecimal(String) : Decimal
@@ -255,14 +255,14 @@ object SystemLibraryHelper {
         val stringToDecimal =
             Operator("ToDecimal", Signature(systemModel.string), systemModel.decimal)
         add(system, tb, stringToDecimal)
-        add(system, tb, Conversion(stringToDecimal, false))
+        add(system, tb, Conversion.OperatorConversion(stringToDecimal, false))
         val integerToDecimal =
             Operator("ToDecimal", Signature(systemModel.integer), systemModel.decimal)
         add(system, tb, integerToDecimal)
-        add(system, tb, Conversion(integerToDecimal, true))
+        add(system, tb, Conversion.OperatorConversion(integerToDecimal, true))
         val longToDecimal = Operator("ToDecimal", Signature(systemModel.long), systemModel.decimal)
         add(system, tb, longToDecimal)
-        add(system, tb, Conversion(longToDecimal, true))
+        add(system, tb, Conversion.OperatorConversion(longToDecimal, true))
         // Operator decimalToDecimal = new Operator("ToDecimal", new
         // Signature(systemModel.getDecimal()),
         // systemModel.getDecimal());
@@ -271,7 +271,7 @@ object SystemLibraryHelper {
         val booleanToDecimal =
             Operator("ToDecimal", Signature(systemModel.boolean), systemModel.decimal)
         add(system, tb, booleanToDecimal)
-        add(system, tb, Conversion(booleanToDecimal, false))
+        add(system, tb, Conversion.OperatorConversion(booleanToDecimal, false))
 
         // ToDateTime(String) : DateTime
         // ToDateTime(Date) : DateTime
@@ -279,11 +279,11 @@ object SystemLibraryHelper {
         val stringToDateTime =
             Operator("ToDateTime", Signature(systemModel.string), systemModel.dateTime)
         add(system, tb, stringToDateTime)
-        add(system, tb, Conversion(stringToDateTime, false))
+        add(system, tb, Conversion.OperatorConversion(stringToDateTime, false))
         val dateToDateTime =
             Operator("ToDateTime", Signature(systemModel.date), systemModel.dateTime)
         add(system, tb, dateToDateTime)
-        add(system, tb, Conversion(dateToDateTime, true))
+        add(system, tb, Conversion.OperatorConversion(dateToDateTime, true))
 
         // Operator dateTimeToDateTime = new Operator("ToDateTime", new
         // Signature(systemModel.getDateTime()),
@@ -296,10 +296,10 @@ object SystemLibraryHelper {
         // ToDate(Date) : Date
         val stringToDate = Operator("ToDate", Signature(systemModel.string), systemModel.date)
         add(system, tb, stringToDate)
-        add(system, tb, Conversion(stringToDate, false))
+        add(system, tb, Conversion.OperatorConversion(stringToDate, false))
         val dateTimeToDate = Operator("ToDate", Signature(systemModel.dateTime), systemModel.date)
         add(system, tb, dateTimeToDate)
-        add(system, tb, Conversion(dateTimeToDate, false))
+        add(system, tb, Conversion.OperatorConversion(dateTimeToDate, false))
 
         // Operator dateToDate = new Operator("ToDate", new Signature(systemModel.getDate()),
         // systemModel.getDate());
@@ -310,7 +310,7 @@ object SystemLibraryHelper {
         // ToTime(Time) : Time
         val stringToTime = Operator("ToTime", Signature(systemModel.string), systemModel.time)
         add(system, tb, stringToTime)
-        add(system, tb, Conversion(stringToTime, false))
+        add(system, tb, Conversion.OperatorConversion(stringToTime, false))
 
         // Operator timeToTime = new Operator("ToTime", new Signature(systemModel.getTime()),
         // systemModel.getTime());
@@ -325,19 +325,19 @@ object SystemLibraryHelper {
         val stringToQuantity =
             Operator("ToQuantity", Signature(systemModel.string), systemModel.quantity)
         add(system, tb, stringToQuantity)
-        add(system, tb, Conversion(stringToQuantity, false))
+        add(system, tb, Conversion.OperatorConversion(stringToQuantity, false))
         val ratioToQuantity =
             Operator("ToQuantity", Signature(systemModel.ratio), systemModel.quantity)
         add(system, tb, ratioToQuantity)
-        add(system, tb, Conversion(ratioToQuantity, false))
+        add(system, tb, Conversion.OperatorConversion(ratioToQuantity, false))
         val integerToQuantity =
             Operator("ToQuantity", Signature(systemModel.integer), systemModel.quantity)
         add(system, tb, integerToQuantity)
-        add(system, tb, Conversion(integerToQuantity, true))
+        add(system, tb, Conversion.OperatorConversion(integerToQuantity, true))
         val decimalToQuantity =
             Operator("ToQuantity", Signature(systemModel.decimal), systemModel.quantity)
         add(system, tb, decimalToQuantity)
-        add(system, tb, Conversion(decimalToQuantity, true))
+        add(system, tb, Conversion.OperatorConversion(decimalToQuantity, true))
 
         // Operator quantityToQuantity = new Operator("ToQuantity", new
         // Signature(systemModel.getQuantity()),
@@ -349,7 +349,7 @@ object SystemLibraryHelper {
         // ToRatio(Ratio) : Ratio
         val stringToRatio = Operator("ToRatio", Signature(systemModel.string), systemModel.ratio)
         add(system, tb, stringToRatio)
-        add(system, tb, Conversion(stringToRatio, false))
+        add(system, tb, Conversion.OperatorConversion(stringToRatio, false))
 
         // Operator ratioToRatio = new Operator("ToRatio", new Signature(systemModel.getRatio()),
         // systemModel.getRatio());
@@ -2681,12 +2681,12 @@ object SystemLibraryHelper {
         // ToConcept(Code)
         val codeToConcept = Operator("ToConcept", Signature(systemModel.code), systemModel.concept)
         add(system, tb, codeToConcept)
-        add(system, tb, Conversion(codeToConcept, true))
+        add(system, tb, Conversion.OperatorConversion(codeToConcept, true))
         // ToConcept(list<Code>)
         val codesToConcept =
             Operator("ToConcept", Signature(ListType(systemModel.code)), systemModel.concept)
         add(system, tb, codesToConcept)
-        add(system, tb, Conversion(codesToConcept, false))
+        add(system, tb, Conversion.OperatorConversion(codesToConcept, false))
 
         // TODO: The result of CalculateAge and CalculateAgeAt may be an uncertainty over the range
         // of possible values (implemented as an interval in the engine).
@@ -2886,7 +2886,7 @@ object SystemLibraryHelper {
         val expandValueSet =
             Operator("ExpandValueSet", Signature(systemModel.valueSet), ListType(systemModel.code))
         add(system, tb, expandValueSet)
-        add(system, tb, Conversion(expandValueSet, true))
+        add(system, tb, Conversion.OperatorConversion(expandValueSet, true))
 
         add(
             system,

--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/SystemLibraryHelper.kt
@@ -2968,7 +2968,11 @@ object SystemLibraryHelper {
     }
 
     @Suppress("UnusedParameter")
-    private fun add(systemLibrary: CompiledLibrary, tb: TypeBuilder, conversion: Conversion) {
+    private fun add(
+        systemLibrary: CompiledLibrary,
+        tb: TypeBuilder,
+        conversion: Conversion.OperatorConversion,
+    ) {
         systemLibrary.add(conversion)
     }
 }


### PR DESCRIPTION
## Summary
- Replace the mutable-flag-based `Conversion` class with a sealed hierarchy of 10 subtypes, giving exhaustive `when`-dispatch with compile-time checking
- Eliminate 7 mutable boolean flags, 10 overload-dependent constructors, and ~70 lines of dead code in `convertExpression`
- Type all conversion storage (`ConversionMap`, `CompiledLibrary`, `Model`) as `OperatorConversion`, making the invariant that only operator conversions are registered explicit in the type system

## Test plan
- [x] Full `./gradlew build` passes (compile, spotless, detekt, all tests)
- [x] No test changes — all existing behavior preserved
- [x] Exhaustive `when` in `convertExpression` ensures new subtypes require handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)