### PR TITLE
Initial implementation of FHIR model resolver in JS

### DIFF
--- a/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
+++ b/Src/java/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
@@ -1,14 +1,21 @@
 package org.cqframework.cql.cql2elm.model
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import org.cqframework.cql.cql2elm.ModelManager
+import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.cql.model.ClassType
 import org.hl7.cql.model.DataType
 import org.hl7.cql.model.ModelContext
 import org.hl7.cql.model.NamedType
 import org.hl7.elm_modelinfo.r1.ModelInfo
 
-open class Model(val modelInfo: ModelInfo, modelManager: ModelManager?) {
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
+open class Model
+@JsExport.Ignore
+constructor(val modelInfo: ModelInfo, modelManager: ModelManager?) {
     private var index: Map<String, DataType> = HashMap()
     private val classIndex: MutableMap<String, ClassType> = HashMap()
     private val conversions: MutableList<Conversion.OperatorConversion> = ArrayList()
@@ -42,6 +49,7 @@ open class Model(val modelInfo: ModelInfo, modelManager: ModelManager?) {
         }
     }
 
+    @JsExport.Ignore
     fun getConversions(): List<Conversion.OperatorConversion> {
         return conversions
     }
@@ -52,6 +60,7 @@ open class Model(val modelInfo: ModelInfo, modelManager: ModelManager?) {
     }
 
     @Suppress("ReturnCount")
+    @JsExport.Ignore
     @JvmOverloads
     fun resolveContextName(contextName: String, mustResolve: Boolean = true): ModelContext? {
         for (context in contexts) {

--- a/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassType.kt
+++ b/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassType.kt
@@ -1,6 +1,12 @@
 package org.hl7.cql.model
 
-@Suppress("TooManyFunctions", "ComplexCondition")
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@Suppress("TooManyFunctions", "ComplexCondition", "NON_EXPORTABLE_TYPE")
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 open class ClassType(
     final override val name: String,
     baseType: DataType? = null,
@@ -16,7 +22,7 @@ open class ClassType(
 ) : BaseDataType(baseType), NamedType {
 
     // For Java compatibility. Can be deleted once tests are updated.
-    constructor(name: String) : this(name, null, mutableListOf(), mutableListOf())
+    @JsExport.Ignore constructor(name: String) : this(name, null, mutableListOf(), mutableListOf())
 
     init {
         require(name.isNotEmpty()) { "name can not be empty" }
@@ -51,34 +57,41 @@ open class ClassType(
 
     private val relationships: MutableList<Relationship> = ArrayList()
 
+    @JsExport.Ignore
     fun getRelationships(): List<Relationship> {
         return relationships
     }
 
+    @JsExport.Ignore
     fun addRelationship(relationship: Relationship) {
         relationships.add(relationship)
     }
 
     private val targetRelationships: MutableList<Relationship> = ArrayList()
 
+    @JsExport.Ignore
     fun getTargetRelationships(): List<Relationship> {
         return targetRelationships
     }
 
+    @JsExport.Ignore
     fun addTargetRelationship(relationship: Relationship) {
         targetRelationships.add(relationship)
     }
 
     private val searches: MutableList<SearchType> = ArrayList()
 
+    @JsExport.Ignore
     fun getSearches(): List<SearchType> {
         return searches
     }
 
+    @JsExport.Ignore
     fun addSearch(search: SearchType) {
         searches.add(search)
     }
 
+    @JsExport.Ignore
     fun findSearch(searchPath: String): SearchType? {
         return searches.firstOrNull { it.name == searchPath }
     }
@@ -88,6 +101,7 @@ open class ClassType(
      *
      * @param genericParameter
      */
+    @JsExport.Ignore
     fun addGenericParameter(genericParameter: TypeParameter) {
         genericParameters.add(genericParameter)
     }
@@ -97,6 +111,7 @@ open class ClassType(
      *
      * @param parameters
      */
+    @JsExport.Ignore
     fun addGenericParameter(parameters: Collection<TypeParameter>) {
         for (parameter in parameters) {
             internalAddParameter(parameter)
@@ -111,6 +126,7 @@ open class ClassType(
      * @return Generic parameter with the given name in the current class or in the base class. Null
      *   if none found.
      */
+    @JsExport.Ignore
     fun getGenericParameterByIdentifier(identifier: String): TypeParameter? {
         return getGenericParameterByIdentifier(identifier, false)
     }
@@ -124,6 +140,7 @@ open class ClassType(
      * @param inCurrentClassOnly
      * @return Class' generic parameter
      */
+    @JsExport.Ignore
     fun getGenericParameterByIdentifier(
         identifier: String,
         inCurrentClassOnly: Boolean,
@@ -230,7 +247,7 @@ open class ClassType(
 
     override fun toLabel(): String = label ?: name
 
-    val tupleType: TupleType by lazy { buildTupleType() }
+    @JsExport.Ignore val tupleType: TupleType by lazy { buildTupleType() }
 
     private fun addTupleElements(
         classType: ClassType,
@@ -273,6 +290,7 @@ open class ClassType(
     override val isGeneric: Boolean
         get() = genericParameters.isNotEmpty()
 
+    @JsExport.Ignore
     override fun isInstantiable(callType: DataType, context: InstantiationContext): Boolean {
         return if (callType is ClassType && callType.elements.size == elements.size) {
             sortedElements.zip(callType.sortedElements).all { (thisElement, thatElement) ->
@@ -281,6 +299,7 @@ open class ClassType(
         } else false
     }
 
+    @JsExport.Ignore
     override fun instantiate(context: InstantiationContext): DataType {
         if (!isGeneric) {
             return this

--- a/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassTypeElement.kt
+++ b/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassTypeElement.kt
@@ -1,5 +1,11 @@
 package org.hl7.cql.model
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 data class ClassTypeElement(
     val name: String,
     val type: DataType,
@@ -9,6 +15,7 @@ data class ClassTypeElement(
 ) {
 
     // For Java compatibility. Can be deleted once tests are updated.
+    @JsExport.Ignore
     constructor(name: String, type: DataType) : this(name, type, false, false, null)
 
     init {

--- a/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/DataType.kt
+++ b/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/DataType.kt
@@ -1,5 +1,11 @@
 package org.hl7.cql.model
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface DataType {
     val baseType: DataType
 
@@ -18,9 +24,9 @@ interface DataType {
 
     val isGeneric: Boolean
 
-    fun isInstantiable(callType: DataType, context: InstantiationContext): Boolean
+    @JsExport.Ignore fun isInstantiable(callType: DataType, context: InstantiationContext): Boolean
 
-    fun instantiate(context: InstantiationContext): DataType
+    @JsExport.Ignore fun instantiate(context: InstantiationContext): DataType
 
     companion object {
         val ANY: SimpleType = SimpleType("System.Any")

--- a/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/NamedType.kt
+++ b/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/NamedType.kt
@@ -1,5 +1,10 @@
 package org.hl7.cql.model
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface NamedType {
     val name: String
     val namespace: String

--- a/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/SimpleType.kt
+++ b/Src/java/cql/src/commonMain/kotlin/org/hl7/cql/model/SimpleType.kt
@@ -1,12 +1,18 @@
 package org.hl7.cql.model
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 data class SimpleType(
     override val name: String,
     val base: DataType? = null,
     override var target: String? = null,
 ) : BaseDataType(base), NamedType {
 
-    constructor(name: String) : this(name, null, null)
+    @JsExport.Ignore constructor(name: String) : this(name, null, null)
 
     init {
         require(name.isNotEmpty()) { "name can not be empty" }
@@ -37,6 +43,7 @@ data class SimpleType(
 
     override val isGeneric: Boolean = false
 
+    @JsExport.Ignore
     override fun isInstantiable(callType: DataType, context: InstantiationContext): Boolean {
         return when {
             this.isSuperTypeOf(callType) -> true
@@ -51,7 +58,7 @@ data class SimpleType(
         }
     }
 
-    override fun instantiate(context: InstantiationContext): DataType = this
+    @JsExport.Ignore override fun instantiate(context: InstantiationContext): DataType = this
 
     @Suppress("ForbiddenComment")
     // TODO: Remove hashCode and equals. Everything works without these methods but the compiled ELM

--- a/Src/java/engine/detekt-baseline.xml
+++ b/Src/java/engine/detekt-baseline.xml
@@ -317,9 +317,9 @@
     <ID>MaxLineLength:TodayEvaluator.kt$TodayEvaluator$/* Today() Date The Today operator returns the date (with no time component) of the start timestamp associated with the evaluation request. See the Now operator for more information on the rationale for defining the Today operator in this way. */</ID>
     <ID>MaxLineLength:TruncatedDivideEvaluator.kt$TruncatedDivideEvaluator$"TruncatedDivide(Integer, Integer), TruncatedDivide(Decimal, Decimal), TruncatedDivide(Quantity, Quantity)"</ID>
     <ID>MemberNameEqualsClassName:Code.kt$Code$var code: kotlin.String? = null</ID>
-    <ID>MemberNameEqualsClassName:Date.kt$Date$var date: LocalDate? = null set(date) { if (date!!.getYear() &lt; 1) { throw InvalidDate( "The year: ${date.getYear()} falls below the accepted bounds of 0001-9999." ) } if (date.getYear() > 9999) { throw InvalidDate( "The year: ${date.getYear()} falls above the accepted bounds of 0001-9999." ) } if (this.precision == null) { this.precision = Precision.DAY } field = date }</ID>
-    <ID>MemberNameEqualsClassName:DateTime.kt$DateTime$var dateTime: OffsetDateTime? = null set(dateTime) { if (dateTime!!.getYear() &lt; 1) { throw InvalidDateTime( "The year: ${dateTime.getYear()} falls below the accepted bounds of 0001-9999." ) } if (dateTime.getYear() > 9999) { throw InvalidDateTime( "The year: ${dateTime.getYear()} falls above the accepted bounds of 0001-9999." ) } field = dateTime }</ID>
-    <ID>MemberNameEqualsClassName:Time.kt$Time$var time: LocalTime private set</ID>
+    <ID>MemberNameEqualsClassName:Date.kt$Date$@JsExport.Ignore var date: LocalDate? = null set(date) { if (date!!.getYear() &lt; 1) { throw InvalidDate( "The year: ${date.getYear()} falls below the accepted bounds of 0001-9999." ) } if (date.getYear() > 9999) { throw InvalidDate( "The year: ${date.getYear()} falls above the accepted bounds of 0001-9999." ) } if (this.precision == null) { this.precision = Precision.DAY } field = date }</ID>
+    <ID>MemberNameEqualsClassName:DateTime.kt$DateTime$@JsExport.Ignore var dateTime: OffsetDateTime? = null set(dateTime) { if (dateTime!!.getYear() &lt; 1) { throw InvalidDateTime( "The year: ${dateTime.getYear()} falls below the accepted bounds of 0001-9999." ) } if (dateTime.getYear() > 9999) { throw InvalidDateTime( "The year: ${dateTime.getYear()} falls above the accepted bounds of 0001-9999." ) } field = dateTime }</ID>
+    <ID>MemberNameEqualsClassName:Time.kt$Time$@JsExport.Ignore var time: LocalTime private set</ID>
     <ID>NestedBlockDepth:AllTrueEvaluator.kt$AllTrueEvaluator$@JvmStatic fun allTrue(src: Value?): Boolean</ID>
     <ID>NestedBlockDepth:AnyTrueEvaluator.kt$AnyTrueEvaluator$@JvmStatic fun anyTrue(src: Value?): Boolean</ID>
     <ID>NestedBlockDepth:AvgEvaluator.kt$AvgEvaluator$@JvmStatic fun avg(source: Value?, state: State?): Value?</ID>
@@ -382,13 +382,13 @@
     <ID>ReturnCount:ConvertsToQuantityEvaluator.kt$ConvertsToQuantityEvaluator$@JvmStatic fun convertsToQuantity(argument: Value?, state: State?): Boolean?</ID>
     <ID>ReturnCount:ConvertsToTimeEvaluator.kt$ConvertsToTimeEvaluator$@JvmStatic fun convertsToTime(argument: Value?): Boolean?</ID>
     <ID>ReturnCount:CountEvaluator.kt$CountEvaluator$@JvmStatic fun count(source: Value?): Integer</ID>
+    <ID>ReturnCount:Date.kt$Date$@JsExport.Ignore override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
+    <ID>ReturnCount:Date.kt$Date$@JsExport.Ignore override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal</ID>
     <ID>ReturnCount:Date.kt$Date$override fun compare(other: BaseTemporal, forSort: kotlin.Boolean): Int?</ID>
-    <ID>ReturnCount:Date.kt$Date$override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
-    <ID>ReturnCount:Date.kt$Date$override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal</ID>
     <ID>ReturnCount:DateFromEvaluator.kt$DateFromEvaluator$@JvmStatic fun dateFrom(operand: Value?): Date?</ID>
+    <ID>ReturnCount:DateTime.kt$DateTime$@JsExport.Ignore override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
+    <ID>ReturnCount:DateTime.kt$DateTime$@JsExport.Ignore override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal</ID>
     <ID>ReturnCount:DateTime.kt$DateTime$override fun compare(other: BaseTemporal, forSort: kotlin.Boolean): Int?</ID>
-    <ID>ReturnCount:DateTime.kt$DateTime$override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
-    <ID>ReturnCount:DateTime.kt$DateTime$override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal</ID>
     <ID>ReturnCount:DateTime.kt$DateTime$override fun toString(): kotlin.String</ID>
     <ID>ReturnCount:DateTimeComponentFromEvaluator.kt$DateTimeComponentFromEvaluator$@JvmStatic fun dateTimeComponentFrom(operand: Value?, precision: kotlin.String?): Integer?</ID>
     <ID>ReturnCount:DecimalHelper.kt$DecimalHelper$fun validateDecimal(ret: BigDecimal, targetScale: Int?): BigDecimal?</ID>
@@ -477,8 +477,8 @@
     <ID>ReturnCount:SuccessorEvaluator.kt$SuccessorEvaluator$@JvmStatic fun successor(value: Value?): Value?</ID>
     <ID>ReturnCount:SuccessorEvaluator.kt$SuccessorEvaluator$@JvmStatic fun successor(value: Value?, quantity: Quantity?): Value?</ID>
     <ID>ReturnCount:TemporalHelper.kt$TemporalHelper$fun truncateValueToTargetPrecision( value: kotlin.Long, precision: Precision, targetPrecision: Precision?, ): kotlin.Long</ID>
+    <ID>ReturnCount:Time.kt$Time$@JsExport.Ignore override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
     <ID>ReturnCount:Time.kt$Time$override fun compare(other: BaseTemporal, forSort: kotlin.Boolean): Int?</ID>
-    <ID>ReturnCount:Time.kt$Time$override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
     <ID>ReturnCount:TimeFromEvaluator.kt$TimeFromEvaluator$@JvmStatic fun timeFrom(operand: Value?): Time?</ID>
     <ID>ReturnCount:TimeJs.kt$ChronoUnitJs$fun between(start: TemporalJs, end: TemporalJs): Long</ID>
     <ID>ReturnCount:ToBooleanEvaluator.kt$ToBooleanEvaluator$@JvmStatic fun toBoolean(operand: Value?): Boolean?</ID>
@@ -497,8 +497,8 @@
     <ID>ReturnCount:TruncatedDivideEvaluator.kt$TruncatedDivideEvaluator$@JvmStatic fun div(left: Value?, right: Value?, state: State?): Value?</ID>
     <ID>ReturnCount:UnionEvaluator.kt$UnionEvaluator$@JvmStatic fun unionInterval(left: Interval?, right: Interval?, state: State?): Interval?</ID>
     <ID>ReturnCount:UnionEvaluator.kt$UnionEvaluator$fun unionIterable(left: List?, right: List?, state: State?): List?</ID>
-    <ID>ReturnCount:ValueSet.kt$ValueSet$fun getCodeSystem(id: kotlin.String?): CodeSystem?</ID>
-    <ID>ReturnCount:ValueSet.kt$ValueSet$fun getCodeSystem(id: kotlin.String?, version: kotlin.String?): CodeSystem?</ID>
+    <ID>ReturnCount:ValueSet.kt$ValueSet$@JsName("getCodeSystemById") fun getCodeSystem(id: kotlin.String?): CodeSystem?</ID>
+    <ID>ReturnCount:ValueSet.kt$ValueSet$@JsName("getCodeSystemByIdAndVersion") fun getCodeSystem(id: kotlin.String?, version: kotlin.String?): CodeSystem?</ID>
     <ID>SpreadOperator:DateTime.kt$DateTime$(*dateElements)</ID>
     <ID>SpreadOperator:DateTimeEvaluator.kt$DateTimeEvaluator$( timeZoneOffset.value, *TemporalHelper.cleanArray( year.value, month?.value, day?.value, hour?.value, minute?.value, second?.value, milliSecond?.value, ), )</ID>
     <ID>SpreadOperator:IntervalHelper.kt$IntervalHelper.Companion$( *(intervals .filterNotNull() .flatMap { interval -> listOf( interval.start as BaseTemporal?, interval.end as BaseTemporal?, ) } .toTypedArray()) )</ID>

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/DataProvider.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/DataProvider.kt
@@ -1,10 +1,14 @@
 package org.opencds.cqf.cql.engine.data
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.elm.executing.obfuscate.NoOpPHIObfuscator
 import org.opencds.cqf.cql.engine.elm.executing.obfuscate.PHIObfuscator
 import org.opencds.cqf.cql.engine.model.ModelResolver
 import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface DataProvider : ModelResolver, RetrieveProvider {
     fun phiObfuscationSupplier(): () -> PHIObfuscator? {
         return { NoOpPHIObfuscator() }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/obfuscate/PHIObfuscator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/obfuscate/PHIObfuscator.kt
@@ -1,7 +1,11 @@
 package org.opencds.cqf.cql.engine.elm.executing.obfuscate
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Value
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface PHIObfuscator {
     fun obfuscate(source: Value?): String?
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.engine.model
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 import org.opencds.cqf.cql.engine.runtime.Value
 
@@ -9,6 +11,8 @@ import org.opencds.cqf.cql.engine.runtime.Value
  * implementation schemes with the simplest example being classes in different package names, but
  * also possibly with different property naming schemes, etc.
  */
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface ModelResolver {
     /**
      * Get the path expression that expresses the relationship between the `targetType` and the

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/retrieve/RetrieveProvider.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/retrieve/RetrieveProvider.kt
@@ -1,10 +1,15 @@
 package org.opencds.cqf.cql.engine.retrieve
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Code
 import org.opencds.cqf.cql.engine.runtime.Interval
 import org.opencds.cqf.cql.engine.runtime.Value
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 interface RetrieveProvider {
+    @Suppress("NON_EXPORTABLE_TYPE")
     fun retrieve(
         context: kotlin.String?,
         contextPath: kotlin.String?,

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
@@ -1,20 +1,27 @@
 package org.opencds.cqf.cql.engine.runtime
 
-sealed class BaseTemporal : SimpleValue, Comparable<BaseTemporal> {
-    var precision: Precision? = null
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import org.cqframework.cql.shared.JsOnlyExport
 
-    fun withPrecision(precision: Precision?): BaseTemporal {
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
+sealed class BaseTemporal : SimpleValue, Comparable<BaseTemporal> {
+    @JsExport.Ignore var precision: Precision? = null
+
+    @JsExport.Ignore
+    open fun withPrecision(precision: Precision?): BaseTemporal {
         this.precision = precision
         return this
     }
 
     abstract fun compare(other: BaseTemporal, forSort: kotlin.Boolean): Int?
 
-    abstract fun compareToPrecision(other: BaseTemporal, p: Precision): Int?
+    @JsExport.Ignore abstract fun compareToPrecision(other: BaseTemporal, p: Precision): Int?
 
-    abstract fun isUncertain(p: Precision): kotlin.Boolean
+    @JsExport.Ignore abstract fun isUncertain(p: Precision): kotlin.Boolean
 
-    abstract fun getUncertaintyInterval(p: Precision): Interval?
+    @JsExport.Ignore abstract fun getUncertaintyInterval(p: Precision): Interval?
 
     /**
      * Returns a copy of this temporal value rounded to the specified precision if the value has a
@@ -24,6 +31,7 @@ sealed class BaseTemporal : SimpleValue, Comparable<BaseTemporal> {
      * @param useCeiling whether to return the ceiling or floor value when rounding
      * @return the rounded copy
      */
+    @JsExport.Ignore
     abstract fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal?
 
     companion object {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
@@ -1,11 +1,15 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 
 /**
  * Represents an instance of a non-system-defined class (instance of a named structured type defined
  * outside the System model), e.g. a FHIR.Patient.
  */
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class ClassInstance(
     override val type: QName,
     override val elements: MutableMap<kotlin.String, Value?>,

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Code : StructuredValue(), NamedTypeValue {
     override val type = codeTypeName
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/CodeSystem.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/CodeSystem.kt
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class CodeSystem : Vocabulary() {
     override val type = codeSystemTypeName
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Concept : StructuredValue(), NamedTypeValue {
     override val type = conceptTypeName
 
@@ -23,6 +28,7 @@ class Concept : StructuredValue(), NamedTypeValue {
             }
         }
 
+    @Suppress("NON_EXPORTABLE_TYPE")
     fun withCodes(codes: Iterable<Code?>?): Concept {
         this.codes = codes?.toMutableList() ?: mutableListOf()
         return this

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
@@ -1,6 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import kotlin.jvm.JvmOverloads
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.exception.InvalidDate
 import org.opencds.cqf.cql.engine.execution.State
 import org.opencds.cqf.cql.engine.util.Date
@@ -14,9 +18,12 @@ import org.opencds.cqf.cql.engine.util.offsetDateTimeOfInstant
 import org.opencds.cqf.cql.engine.util.timeZoneGetDefault
 import org.opencds.cqf.cql.engine.util.toPaddedString
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Date : BaseTemporal {
     override val type = dateTypeName
 
+    @JsExport.Ignore
     var date: LocalDate? = null
         set(date) {
             if (date!!.getYear() < 1) {
@@ -35,25 +42,30 @@ class Date : BaseTemporal {
             field = date
         }
 
+    @JsName("fromYear")
     constructor(year: Int) {
         this.date = (localDateOf(year, 1, 1))
         this.precision = Precision.YEAR
     }
 
+    @JsName("fromYearMonth")
     constructor(year: Int, month: Int) {
         this.date = (localDateOf(year, month, 1))
         this.precision = Precision.MONTH
     }
 
+    @JsName("fromYearMonthDay")
     constructor(year: Int, month: Int, day: Int) {
         this.date = (localDateOf(year, month, day))
     }
 
+    @JsExport.Ignore
     constructor(date: LocalDate, precision: Precision) {
         this.date = date
         this.precision = precision
     }
 
+    @JsName("fromDateString")
     constructor(dateString: kotlin.String) {
         var dateString = dateString
         precision =
@@ -65,10 +77,12 @@ class Date : BaseTemporal {
         this.date = (localDateParse(dateString))
     }
 
+    @JsExport.Ignore
     constructor(date: LocalDate) {
         this.date = (date)
     }
 
+    @JsExport.Ignore
     fun expandPartialMinFromPrecision(
         precision: Precision
     ): org.opencds.cqf.cql.engine.runtime.Date {
@@ -85,6 +99,7 @@ class Date : BaseTemporal {
             .withPrecision(precision) as org.opencds.cqf.cql.engine.runtime.Date
     }
 
+    @JsExport.Ignore
     private fun expandPartialMin(precision: Precision?): org.opencds.cqf.cql.engine.runtime.Date {
         val ld = this.date!!.plusYears(0)
         return org.opencds.cqf.cql.engine.runtime
@@ -92,6 +107,7 @@ class Date : BaseTemporal {
             .withPrecision(precision) as org.opencds.cqf.cql.engine.runtime.Date
     }
 
+    @JsExport.Ignore
     fun expandPartialMax(precision: Precision): org.opencds.cqf.cql.engine.runtime.Date {
         var ld = this.date!!.plusYears(0)
         for (i in this.precision!!.toDateIndex() + 1..2) {
@@ -132,6 +148,7 @@ class Date : BaseTemporal {
         }
     }
 
+    @JsExport.Ignore
     override fun compareToPrecision(other: BaseTemporal, p: Precision): Int? {
         var precision = p
         val leftMeetsPrecisionRequirements =
@@ -163,6 +180,7 @@ class Date : BaseTemporal {
         return null
     }
 
+    @JsExport.Ignore
     override fun isUncertain(p: Precision): kotlin.Boolean {
         var precision = p
         if (precision == Precision.WEEK) {
@@ -172,12 +190,14 @@ class Date : BaseTemporal {
         return this.precision!!.toDateIndex() < precision.toDateIndex()
     }
 
+    @JsExport.Ignore
     override fun getUncertaintyInterval(p: Precision): Interval {
         val start = expandPartialMin(p)
         val end = expandPartialMax(p).expandPartialMinFromPrecision(p)
         return Interval(start, true, end, true)
     }
 
+    @JsExport.Ignore
     override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal {
         var precision = precision
         val originalPrecision = this.precision
@@ -224,6 +244,7 @@ class Date : BaseTemporal {
     }
 
     @JvmOverloads
+    @JsExport.Ignore
     fun toJavaDate(c: State? = null): Date {
         var zonedDateTime: ZonedDateTime? = null
         zonedDateTime =
@@ -238,6 +259,7 @@ class Date : BaseTemporal {
     }
 
     companion object {
+        @JsExport.Ignore
         fun fromJavaDate(date: Date): DateTime {
             val calendar = calendarGetInstance()
             calendar.setTime(date)

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
@@ -1,7 +1,11 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import kotlin.math.abs
 import org.cqframework.cql.shared.BigDecimal
+import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.ONE
 import org.opencds.cqf.cql.engine.exception.CqlException
 import org.opencds.cqf.cql.engine.exception.InvalidDateTime
@@ -14,11 +18,14 @@ import org.opencds.cqf.cql.engine.util.offsetDateTimeParse
 import org.opencds.cqf.cql.engine.util.toPaddedString
 import org.opencds.cqf.cql.engine.util.zoneOffsetOfHoursMinutes
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class DateTime : BaseTemporal {
     override val type = dateTimeTypeName
 
-    val zoneOffset: ZoneOffset
+    @JsExport.Ignore val zoneOffset: ZoneOffset
 
+    @JsExport.Ignore
     var dateTime: OffsetDateTime? = null
         set(dateTime) {
             if (dateTime!!.getYear() < 1) {
@@ -35,23 +42,27 @@ class DateTime : BaseTemporal {
             field = dateTime
         }
 
-    fun withPrecision(precision: Precision): DateTime {
+    @JsExport.Ignore
+    override fun withPrecision(precision: Precision?): DateTime {
         this.precision = precision
         return this
     }
 
+    @JsExport.Ignore
     constructor(dateTime: OffsetDateTime?) {
         this.dateTime = (dateTime)
         this.precision = Precision.MILLISECOND
         zoneOffset = toZoneOffset(dateTime)
     }
 
+    @JsExport.Ignore
     constructor(dateTime: OffsetDateTime, precision: Precision) {
         this.dateTime = (dateTime)
         this.precision = precision
         zoneOffset = toZoneOffset(dateTime)
     }
 
+    @JsExport.Ignore
     constructor(dateString: kotlin.String, offset: ZoneOffset?) {
         if (offset == null) {
             throw CqlException("Cannot pass a null offset")
@@ -104,6 +115,7 @@ class DateTime : BaseTemporal {
         this.dateTime = (offsetDateTimeParse(dateString))
     }
 
+    @JsName("fromDateElements")
     constructor(offset: BigDecimal?, vararg dateElements: Int) {
         if (offset == null) {
             throw CqlException("BigDecimal offset must be non-null")
@@ -144,6 +156,7 @@ class DateTime : BaseTemporal {
         this.dateTime = (offsetDateTimeParse(dateString.toString()))
     }
 
+    @JsExport.Ignore
     fun expandPartialMinFromPrecision(precision: Precision): DateTime {
         var odt = this.dateTime!!.plusYears(0)
         for (i in precision.toDateTimeIndex() + 1..6) {
@@ -156,11 +169,13 @@ class DateTime : BaseTemporal {
         return DateTime(odt, this.precision!!)
     }
 
+    @JsExport.Ignore
     fun expandPartialMin(precision: Precision?): DateTime {
         val odt = this.dateTime!!.plusYears(0)
         return DateTime(odt, if (precision == null) Precision.MILLISECOND else precision)
     }
 
+    @JsExport.Ignore
     fun expandPartialMax(precision: Precision?): DateTime {
         var odt = this.dateTime!!.plusYears(0)
         for (i in this.precision!!.toDateTimeIndex() + 1..6) {
@@ -181,6 +196,7 @@ class DateTime : BaseTemporal {
         return DateTime(odt, if (precision == null) Precision.MILLISECOND else precision)
     }
 
+    @JsExport.Ignore
     override fun isUncertain(p: Precision): kotlin.Boolean {
         var precision = p
         if (precision == Precision.WEEK) {
@@ -190,12 +206,14 @@ class DateTime : BaseTemporal {
         return this.precision!!.toDateTimeIndex() < precision.toDateTimeIndex()
     }
 
+    @JsExport.Ignore
     override fun getUncertaintyInterval(p: Precision): Interval {
         val start = expandPartialMin(p)
         val end = expandPartialMax(p).expandPartialMinFromPrecision(p)
         return Interval(start, true, end, true)
     }
 
+    @JsExport.Ignore
     override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal {
         var precision = precision
         val originalPrecision = this.precision
@@ -238,10 +256,12 @@ class DateTime : BaseTemporal {
         }
     }
 
+    @JsExport.Ignore
     fun getNormalized(precision: Precision): OffsetDateTime {
         return getNormalized(precision, zoneOffset)
     }
 
+    @JsExport.Ignore
     fun getNormalized(precision: Precision, nullableZoneOffset: ZoneOffset?): OffsetDateTime {
         if (precision.toDateTimeIndex() > Precision.DAY.toDateTimeIndex()) {
             if (nullableZoneOffset != null) {
@@ -254,6 +274,7 @@ class DateTime : BaseTemporal {
         return dateTime!!
     }
 
+    @JsExport.Ignore
     override fun compareToPrecision(other: BaseTemporal, p: Precision): Int? {
         var precision = p
         val leftMeetsPrecisionRequirements =
@@ -391,6 +412,7 @@ class DateTime : BaseTemporal {
     }
 
     // conversion functions
+    @JsExport.Ignore
     fun toJavaDate(): Date {
         return dateFrom(dateTime!!.toInstant())
     }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Interval.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Interval.kt
@@ -1,7 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlin.toString
+import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 import org.opencds.cqf.cql.engine.elm.executing.GreaterEvaluator.greater
 import org.opencds.cqf.cql.engine.elm.executing.MaxValueEvaluator.maxValue
@@ -13,8 +16,11 @@ import org.opencds.cqf.cql.engine.exception.InvalidInterval
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument
 import org.opencds.cqf.cql.engine.execution.State
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Interval
 @JvmOverloads
+@Suppress("NON_EXPORTABLE_TYPE")
 constructor(
     var low: Value?,
     val lowClosed: kotlin.Boolean,
@@ -128,6 +134,7 @@ constructor(
     }
 
     companion object {
+        @JsExport.Ignore
         fun getSize(start: Value?, end: Value?, state: State?): Value? {
             if (start == null || end == null) {
                 return null

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
@@ -1,5 +1,11 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
+@Suppress("NON_EXPORTABLE_TYPE")
 data class List(val value: Iterable<Value?>) : Value, Iterable<Value?> by value {
     override val typeAsString = "List"
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
@@ -1,5 +1,10 @@
+@file:OptIn(ExperimentalJsExport::class)
+@file:JsOnlyExport
+
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 
 sealed interface NamedTypeValue : Value {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
@@ -1,8 +1,12 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmStatic
 import org.cqframework.cql.shared.BigDecimal
+import org.cqframework.cql.shared.JsOnlyExport
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Quantity : StructuredValue(), NamedTypeValue, Comparable<Quantity> {
     override val type = quantityTypeName
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Ratio : StructuredValue(), NamedTypeValue {
     override val type = ratioTypeName
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
@@ -1,9 +1,14 @@
+@file:OptIn(ExperimentalJsExport::class)
+
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.BigDecimal
+import org.cqframework.cql.shared.JsOnlyExport
 
-sealed interface SimpleValue : NamedTypeValue
+@JsOnlyExport sealed interface SimpleValue : NamedTypeValue
 
+@JsOnlyExport
 data class Boolean(val value: kotlin.Boolean) : SimpleValue {
     override val type = booleanTypeName
 
@@ -15,6 +20,7 @@ data class Boolean(val value: kotlin.Boolean) : SimpleValue {
     }
 }
 
+@JsOnlyExport
 data class Integer(val value: Int) : SimpleValue {
     override val type = integerTypeName
 
@@ -26,18 +32,21 @@ data class Integer(val value: Int) : SimpleValue {
     }
 }
 
+@JsOnlyExport
 data class Long(val value: kotlin.Long) : SimpleValue {
     override val type = longTypeName
 
     override fun toString() = value.toString()
 }
 
+@JsOnlyExport
 data class Decimal(val value: BigDecimal) : SimpleValue {
     override val type = decimalTypeName
 
     override fun toString() = value.toString()
 }
 
+@JsOnlyExport
 data class String(val value: kotlin.String) : SimpleValue, CharSequence by value {
     override val type = stringTypeName
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
@@ -1,8 +1,12 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator.toString
 
 /** Represents a structured CQL value. */
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 sealed class StructuredValue : Value {
     abstract val elements: MutableMap<kotlin.String, Value?>
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
@@ -1,31 +1,42 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.exception.InvalidTime
 import org.opencds.cqf.cql.engine.util.LocalTime
 import org.opencds.cqf.cql.engine.util.localTimeParse
 import org.opencds.cqf.cql.engine.util.toPaddedString
 
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Time : BaseTemporal {
     override val type = timeTypeName
 
+    @JsExport.Ignore
     var time: LocalTime
         private set
 
+    @JsExport.Ignore
     fun withTime(time: LocalTime): Time {
         this.time = time
         return this
     }
 
-    fun withPrecision(precision: Precision): Time {
+    @JsExport.Ignore
+    override fun withPrecision(precision: Precision?): Time {
         this.precision = precision
         return this
     }
 
+    @JsExport.Ignore
     constructor(time: LocalTime, precision: Precision) {
         this.time = time
         this.precision = precision
     }
 
+    @JsName("fromDateString")
     constructor(dateString: kotlin.String) {
         var dateString = dateString
         var size = 0
@@ -46,6 +57,7 @@ class Time : BaseTemporal {
         time = localTimeParse(dateString)
     }
 
+    @JsName("fromTimeElements")
     constructor(vararg timeElements: Int) {
         if (timeElements.isEmpty()) {
             throw InvalidTime("Time must include an hour")
@@ -76,6 +88,7 @@ class Time : BaseTemporal {
         time = localTimeParse(timeString.toString())
     }
 
+    @JsExport.Ignore
     fun expandPartialMinFromPrecision(precision: Precision): Time {
         var ot = this.time.plusHours(0)
         for (i in precision.toTimeIndex() + 1..3) {
@@ -88,11 +101,13 @@ class Time : BaseTemporal {
         return Time(ot, this.precision!!)
     }
 
+    @JsExport.Ignore
     fun expandPartialMin(precision: Precision?): Time {
         val ot = this.time.plusHours(0)
         return Time(ot, precision ?: Precision.MILLISECOND)
     }
 
+    @JsExport.Ignore
     fun expandPartialMax(precision: Precision?): Time {
         var ot = this.time.plusHours(0)
         for (i in this.precision!!.toTimeIndex() + 1..3) {
@@ -112,16 +127,19 @@ class Time : BaseTemporal {
         return Time(ot, precision ?: Precision.MILLISECOND)
     }
 
+    @JsExport.Ignore
     override fun isUncertain(p: Precision): kotlin.Boolean {
         return this.precision!!.toTimeIndex() < p.toTimeIndex()
     }
 
+    @JsExport.Ignore
     override fun getUncertaintyInterval(p: Precision): Interval {
         val start = expandPartialMin(p)
         val end = expandPartialMax(p).expandPartialMinFromPrecision(p)
         return Interval(start, true, end, true)
     }
 
+    @JsExport.Ignore
     override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal? {
         val originalPrecision = this.precision
         val originalLocalTime = this.time.truncatedTo(originalPrecision!!.toChronoUnit())
@@ -163,6 +181,7 @@ class Time : BaseTemporal {
         }
     }
 
+    @JsExport.Ignore
     override fun compareToPrecision(other: BaseTemporal, p: Precision): Int? {
         var precision = p
         val leftMeetsPrecisionRequirements =

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
@@ -1,6 +1,11 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
 /** Represents a CQL Tuple value. */
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class Tuple : StructuredValue() {
     override val typeAsString = "Tuple"
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
@@ -1,5 +1,11 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsName
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 class ValueSet : Vocabulary() {
     override val type = valueSetTypeName
 
@@ -30,6 +36,7 @@ class ValueSet : Vocabulary() {
     var codeSystems = mutableListOf<CodeSystem>()
         private set
 
+    @Suppress("NON_EXPORTABLE_TYPE")
     fun setCodeSystems(codeSystems: Iterable<CodeSystem?>?) {
         this.codeSystems = mutableListOf()
         if (codeSystems != null) {
@@ -55,6 +62,7 @@ class ValueSet : Vocabulary() {
         return this
     }
 
+    @JsName("getCodeSystemById")
     fun getCodeSystem(id: kotlin.String?): CodeSystem? {
         if (id == null) {
             return null
@@ -69,6 +77,7 @@ class ValueSet : Vocabulary() {
         return null
     }
 
+    @JsName("getCodeSystemByIdAndVersion")
     fun getCodeSystem(id: kotlin.String?, version: kotlin.String?): CodeSystem? {
         if (id == null) {
             return null

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
+import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.shared.JsOnlyExport
+
+@OptIn(ExperimentalJsExport::class)
+@JsOnlyExport
 sealed class Vocabulary : StructuredValue(), NamedTypeValue {
     var id: kotlin.String? = null
 

--- a/Src/java/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/Iterable.kt
+++ b/Src/java/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/Iterable.kt
@@ -1,0 +1,6 @@
+package org.opencds.cqf.cql.engine.util
+
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@Suppress("NON_EXPORTABLE_TYPE")
+fun <T> iterableToList(iterable: Iterable<T>) = iterable.toList()

--- a/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
+++ b/Src/java/shared/src/commonMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
@@ -1,5 +1,8 @@
 package org.cqframework.cql.shared
 
+import kotlin.annotation.AnnotationTarget.*
 import kotlin.js.ExperimentalJsExport
 
-@OptIn(ExperimentalJsExport::class) expect annotation class JsOnlyExport()
+@OptIn(ExperimentalJsExport::class)
+@Target(CLASS, PROPERTY, FUNCTION, FILE)
+expect annotation class JsOnlyExport()

--- a/Src/java/shared/src/jvmMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
+++ b/Src/java/shared/src/jvmMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
@@ -1,3 +1,5 @@
 package org.cqframework.cql.shared
 
-actual annotation class JsOnlyExport
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(CLASS, PROPERTY, FUNCTION, FILE) actual annotation class JsOnlyExport

--- a/Src/java/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
+++ b/Src/java/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
@@ -1,3 +1,5 @@
 package org.cqframework.cql.shared
 
-actual annotation class JsOnlyExport
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(CLASS, PROPERTY, FUNCTION, FILE) actual annotation class JsOnlyExport

--- a/Src/js/cql-to-elm-ui/cql/cql-engine.ts
+++ b/Src/js/cql-to-elm-ui/cql/cql-engine.ts
@@ -13,6 +13,11 @@ import {
 } from "@/shared";
 import { getModelXml } from "@/cql/get-model-xml";
 import { getLibraryCql } from "@/cql/get-library-cql";
+import { toJsCqlValue } from "@/cql/cql-value";
+import {
+  createFhirDataProvider,
+  fhirModelNamespaceUri,
+} from "@/cql/fhir-data-provider";
 
 export function createStatefulEngine() {
   const ucumUtils = ucum.UcumLhcUtils.getInstance();
@@ -132,6 +137,11 @@ export function createStatefulEngine() {
         // @ts-expect-error TypeScript error
         const environment = new engineJs.Environment(libraryManager);
 
+        environment.registerDataProvider(
+          fhirModelNamespaceUri,
+          createFhirDataProvider(modelManager),
+        );
+
         const engine = new engineJs.CqlEngine(
           environment,
           kotlinStdlibJs.KtMutableSet.fromJsSet(
@@ -161,7 +171,7 @@ export function createStatefulEngine() {
             .entries(),
         ].map(([expressionName, expressionResult]) => ({
           expressionName,
-          expressionResult: prettyPrintValue(expressionResult.value),
+          expressionResult: toJsCqlValue(expressionResult.value),
         }));
 
         return {
@@ -191,9 +201,4 @@ export function createStatefulEngine() {
   return {
     runCql,
   };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function prettyPrintValue(value: Nullable<any>): string {
-  return String(value);
 }

--- a/Src/js/cql-to-elm-ui/cql/cql-value.ts
+++ b/Src/js/cql-to-elm-ui/cql/cql-value.ts
@@ -1,0 +1,118 @@
+import {
+  Value,
+  Boolean,
+  Integer,
+  Long,
+  Decimal,
+  String,
+  Date,
+  DateTime,
+  Time,
+  Interval,
+  List,
+  iterableToList,
+  StructuredValue,
+  getNamedTypeForCqlValue,
+} from "cql-js/kotlin/engine.mjs";
+import { Nullable, isKtNull, TJsCqlValue } from "@/shared";
+
+export function toJsCqlValue(ktCqlValue: Nullable<Value>): TJsCqlValue {
+  if (isKtNull(ktCqlValue)) {
+    return null;
+  }
+
+  if (ktCqlValue instanceof Boolean) {
+    return {
+      type: "Boolean",
+      value: ktCqlValue.value,
+    };
+  }
+
+  if (ktCqlValue instanceof Integer) {
+    return {
+      type: "Integer",
+      value: ktCqlValue.value,
+    };
+  }
+
+  if (ktCqlValue instanceof Long) {
+    return {
+      type: "Long",
+      value: ktCqlValue.value,
+    };
+  }
+
+  if (ktCqlValue instanceof Decimal) {
+    return {
+      type: "Decimal",
+      value: ktCqlValue.value.toString(),
+    };
+  }
+
+  if (ktCqlValue instanceof String) {
+    return {
+      type: "String",
+      value: ktCqlValue.value,
+    };
+  }
+
+  if (ktCqlValue instanceof Date) {
+    return {
+      type: "Date",
+      value: ktCqlValue.toString(),
+    };
+  }
+
+  if (ktCqlValue instanceof DateTime) {
+    return {
+      type: "DateTime",
+      value: ktCqlValue.toString(),
+    };
+  }
+
+  if (ktCqlValue instanceof Time) {
+    return {
+      type: "Time",
+      value: ktCqlValue.toString(),
+    };
+  }
+
+  if (ktCqlValue instanceof StructuredValue) {
+    return {
+      type: "Structured",
+      structuredTypeName: getNamedTypeForCqlValue(ktCqlValue)?.toString(),
+      elements: new Map(
+        [...ktCqlValue.elements.asJsReadonlyMapView().entries()].map(
+          ([k, v]) => [k, toJsCqlValue(v)],
+        ),
+      ),
+    };
+  }
+
+  if (ktCqlValue instanceof Interval) {
+    return {
+      type: "Interval",
+      // @ts-expect-error TypeScript error
+      pointTypeName: ktCqlValue.pointType.toString(),
+      // @ts-expect-error TypeScript error
+      low: toJsCqlValue(ktCqlValue.low),
+      // @ts-expect-error TypeScript error
+      high: toJsCqlValue(ktCqlValue.high),
+      // @ts-expect-error TypeScript error
+      lowClosed: ktCqlValue.lowClosed,
+      // @ts-expect-error TypeScript error
+      highClosed: ktCqlValue.highClosed,
+    };
+  }
+
+  if (ktCqlValue instanceof List) {
+    return {
+      type: "List",
+      value: iterableToList<Nullable<Value>>(ktCqlValue)
+        .asJsReadonlyArrayView()
+        .map((_) => toJsCqlValue(_)),
+    };
+  }
+
+  throw new Error(`Unsupported Kotlin CQL value type: ${ktCqlValue}`);
+}

--- a/Src/js/cql-to-elm-ui/cql/fhir-data-provider.ts
+++ b/Src/js/cql-to-elm-ui/cql/fhir-data-provider.ts
@@ -1,0 +1,104 @@
+import { QName } from "cql-js/kotlin/shared.mjs";
+import { DataType, ClassType } from "cql-js/kotlin/cql.mjs";
+import { ModelManager } from "cql-js/kotlin/cql-to-elm.mjs";
+import { DataProvider, ClassInstance } from "cql-js/kotlin/engine.mjs";
+import { unsupportedOperation } from "@/shared";
+import { KtMutableMap } from "cql-js/kotlin/kotlin-kotlin-stdlib.mjs";
+
+export const fhirModelNamespaceUri = "http://hl7.org/fhir";
+
+export function createFhirDataProvider(modelManager: ModelManager) {
+  const fhirDataProvider: Omit<DataProvider, "__doNotUseOrImplementIt"> = {
+    createInstance(typeName) {
+      // @ts-expect-error TypeScript error
+      const model = modelManager.resolveModelByUri(fhirModelNamespaceUri);
+
+      const dataType = model.resolveTypeName(typeName!);
+
+      if (dataType) {
+        if (dataType instanceof ClassType) {
+          return new ClassInstance(
+            // @ts-expect-error TypeScript error
+            new QName(
+              fhirModelNamespaceUri,
+              dataType.name.slice("FHIR.".length),
+              "",
+            ),
+            KtMutableMap.fromJsMap(
+              new Map(
+                getAllElements(dataType)
+                  .keys()
+                  .map((elementName) => [elementName, null]),
+              ),
+            ),
+          );
+        }
+
+        throw new Error(`Can't instantiate non-class type ${typeName}`);
+      }
+
+      throw new Error(`Unknown type ${typeName}`);
+    },
+    getContextPath(contextType, targetType) {
+      unsupportedOperation();
+    },
+    is(valueType, type) {
+      if (type.getNamespaceURI() === fhirModelNamespaceUri) {
+        // @ts-expect-error TypeScript error
+        const model = modelManager.resolveModelByUri(fhirModelNamespaceUri);
+
+        const valueDataType = model.resolveTypeName(valueType) as ClassType;
+
+        const targetDataType = model.resolveTypeName(
+          type.getLocalPart(),
+        ) as ClassType;
+
+        // @ts-expect-error TypeScript error
+        return valueDataType.isSubTypeOf(targetDataType);
+      }
+
+      return false;
+    },
+    phiObfuscationSupplier() {
+      return function () {
+        unsupportedOperation();
+      };
+    },
+    resolveId(target) {
+      unsupportedOperation();
+    },
+    retrieve(
+      context,
+      contextPath,
+      contextValue,
+      dataType,
+      templateId,
+      codePath,
+      codes,
+      valueSet,
+      datePath,
+      dateLowPath,
+      dateHighPath,
+      dateRange,
+    ) {
+      unsupportedOperation();
+    },
+  };
+
+  return fhirDataProvider as DataProvider;
+}
+
+// @ts-expect-error TypeScript error
+function getAllElements(classType: ClassType): Map<string, DataType> {
+  return new Map([
+    // @ts-expect-error TypeScript error
+    ...(classType.baseType instanceof ClassType
+      ? // @ts-expect-error TypeScript error
+        getAllElements(classType.baseType)
+      : []),
+    ...classType.elements
+      .asJsReadonlyArrayView()
+      // @ts-expect-error TypeScript error
+      .map((element) => [element.name, element.type] as const),
+  ]);
+}

--- a/Src/js/cql-to-elm-ui/shared.tsx
+++ b/Src/js/cql-to-elm-ui/shared.tsx
@@ -4,6 +4,10 @@ import * as cqlWasmJs from "cql-wasm-js";
 
 export type Nullable<T> = cqlJs.Nullable<T> | cqlWasmJs.Nullable<T>;
 
+export function isKtNull(ktValue: Nullable<unknown>) {
+  return ktValue === null || ktValue === undefined;
+}
+
 export type TElmContentType = "json" | "xml";
 
 export type TLibrarySource = "local" | "remote";
@@ -163,7 +167,7 @@ export type TCqlEngineOutput =
       type: "expressionResults";
       expressionResults: {
         expressionName: string;
-        expressionResult: string;
+        expressionResult: TJsCqlValue;
       }[];
     }
   | {
@@ -173,3 +177,43 @@ export type TCqlEngineOutput =
     };
 
 export const playgroundLibraryName = "Playground";
+
+export type TJsCqlValue =
+  | null
+  | {
+      type: "Boolean";
+      value: boolean;
+    }
+  | {
+      type: "Integer";
+      value: number;
+    }
+  | {
+      type: "Long";
+      value: bigint;
+    }
+  | { type: "Decimal"; value: string }
+  | {
+      type: "String";
+      value: string;
+    }
+  | { type: "Date"; value: string }
+  | { type: "DateTime"; value: string }
+  | { type: "Time"; value: string }
+  | {
+      type: "Structured";
+      structuredTypeName?: string;
+      elements: Map<string, TJsCqlValue>;
+    }
+  | {
+      type: "Interval";
+      pointTypeName: string;
+      low: TJsCqlValue;
+      high: TJsCqlValue;
+      lowClosed: boolean;
+      highClosed: boolean;
+    }
+  | {
+      type: "List";
+      value: TJsCqlValue[];
+    };

--- a/Src/js/cql-to-elm-ui/ui/cql-engine.tsx
+++ b/Src/js/cql-to-elm-ui/ui/cql-engine.tsx
@@ -3,6 +3,7 @@ import { TSetState, TState } from "@/state";
 import { Fragment, useEffect, useRef } from "react";
 import { Spinner } from "@/ui/spinner";
 import { Label } from "@/ui/label";
+import { CqlValue } from "@/ui/cql-value";
 
 export function CqlEngineResult({
   state,
@@ -204,7 +205,7 @@ function CqlEngineResultInner({ state }: { state: TState }) {
               ({ expressionName, expressionResult }, resultIndex) => (
                 <div key={resultIndex}>
                   <b style={{ color: "rgb(149, 56, 0)" }}>{expressionName}</b> ={" "}
-                  {expressionResult}
+                  <CqlValue value={expressionResult} />
                 </div>
               ),
             )}

--- a/Src/js/cql-to-elm-ui/ui/cql-value.tsx
+++ b/Src/js/cql-to-elm-ui/ui/cql-value.tsx
@@ -1,0 +1,171 @@
+import React, { Fragment } from "react";
+import { TJsCqlValue } from "@/shared";
+import {
+  quantityTypeName,
+  ratioTypeName,
+  codeTypeName,
+  codeSystemTypeName,
+  conceptTypeName,
+  valueSetTypeName,
+  systemModelNamespaceUri,
+} from "cql-js";
+
+export function CqlValue({ value }: { value: TJsCqlValue }) {
+  const typeHint = getTypeHint(value);
+  return (
+    <Fragment>
+      {formatCqlValue(value)}
+      {typeHint && (
+        <span
+          style={{
+            color: "#999",
+            fontSize: "80%",
+            margin: "0 0 0 4px",
+            padding: "0 3px",
+            background: "#f8f8f8",
+            borderRadius: 3,
+          }}
+        >
+          {typeHint}
+        </span>
+      )}
+    </Fragment>
+  );
+}
+
+function formatCqlValue(value: TJsCqlValue) {
+  if (value === null) {
+    return "null";
+  }
+
+  switch (value.type) {
+    case "Boolean":
+      return <span style={{ color: "#e36209" }}>{String(value.value)}</span>;
+    case "Integer":
+      return <span style={{ color: "#005cc5" }}>{value.value}</span>;
+    case "Long":
+      return <span style={{ color: "#005cc5" }}>{value.value}L</span>;
+    case "String":
+      return (
+        <span style={{ color: "#032f62" }}>
+          {"'"}
+          {value.value}
+          {"'"}
+        </span>
+      );
+    case "Decimal":
+      return <span style={{ color: "#005cc5" }}>{value.value}</span>;
+    case "Date":
+    case "DateTime":
+      return <span style={{ color: "#116329" }}>@{value.value}</span>;
+    case "Time":
+      return <span style={{ color: "#116329" }}>@T{value.value}</span>;
+    case "Structured":
+      switch (value.structuredTypeName) {
+        case quantityTypeName.get().toString():
+          return (
+            <Fragment>
+              {formatCqlValue(value.elements.get("value")!)}{" "}
+              {formatCqlValue(value.elements.get("unit")!)}
+            </Fragment>
+          );
+        case ratioTypeName.get().toString():
+          return (
+            <Fragment>
+              {formatCqlValue(value.elements.get("numerator")!)} :{" "}
+              {formatCqlValue(value.elements.get("denominator")!)}
+            </Fragment>
+          );
+        default:
+          return (
+            <Fragment>
+              {value.structuredTypeName ? (
+                formatTypeQName(value.structuredTypeName)
+              ) : (
+                <span style={{ color: "#005cc5" }}>Tuple</span>
+              )}
+              {" {"}
+              {value.elements.size ? (
+                <div style={{ padding: "0 0 0 2ch" }}>
+                  {[...value.elements.entries()].map(
+                    ([elementName, elementValue], elementIndex, elements) => (
+                      <div key={elementIndex}>
+                        {elementName}: <CqlValue value={elementValue} />
+                        {elementIndex < elements.length - 1 ? "," : ""}
+                      </div>
+                    ),
+                  )}
+                </div>
+              ) : (
+                " : "
+              )}
+              {"}"}
+            </Fragment>
+          );
+      }
+    case "Interval":
+      return (
+        <Fragment>
+          <span style={{ color: "#005cc5" }}>Interval</span>
+          {value.lowClosed ? "[" : "("}
+          {formatCqlValue(value.low)}, {formatCqlValue(value.high)}
+          {value.highClosed ? "]" : ")"}
+        </Fragment>
+      );
+    case "List":
+      return (
+        <Fragment>
+          {"{"}
+          {value.value.length > 0 && (
+            <div style={{ padding: "0 0 0 2ch" }}>
+              {value.value.map((item, itemIndex) => (
+                <div key={itemIndex}>
+                  <CqlValue value={item} />
+                  {itemIndex < value.value.length - 1 ? "," : ""}
+                </div>
+              ))}
+            </div>
+          )}
+          {"}"}
+        </Fragment>
+      );
+  }
+}
+
+function getTypeHint(value: TJsCqlValue) {
+  if (value === null) {
+    return "Any";
+  }
+
+  switch (value.type) {
+    case "Boolean":
+    case "Integer":
+    case "Long":
+    case "Decimal":
+    case "String":
+    case "Date":
+    case "DateTime":
+    case "Time":
+      return value.type;
+    case "Interval":
+      return `Interval<${formatTypeQName(value.pointTypeName)}>`;
+    case "Structured":
+      switch (value.structuredTypeName) {
+        case quantityTypeName.get().toString():
+          return "Quantity";
+        case ratioTypeName.get().toString():
+          return "Ratio";
+        default:
+          return "";
+      }
+    case "List":
+      return "";
+  }
+}
+
+function formatTypeQName(typeQName: string) {
+  if (typeQName.startsWith(`{${systemModelNamespaceUri.get()}}`)) {
+    return typeQName.slice(`{${systemModelNamespaceUri.get()}}`.length);
+  }
+  return typeQName;
+}


### PR DESCRIPTION
* Initial implementation of FHIR model resolver in JS with support for `createInstance()` and `is()` methods.
* JS-export CQL value classes, CQL type classes.
* Add type hints for expression results in the online playground.

This builds on top of the changes planned for v5.

<img width="1536" height="872" alt="image" src="https://github.com/user-attachments/assets/8775e847-425a-4bd3-8c3c-e75b7a57c52a" />
