### PR TITLE
Fix multi-level sort. Report test coverage for KMP projects. 

### DIFF
--- a/Src/java/build-logic/build.gradle.kts
+++ b/Src/java/build-logic/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     )
     implementation("org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin:7.26.0")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.8")
 }
 
 kotlin { jvmToolchain(17) }

--- a/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 plugins {
     kotlin("multiplatform")
     id("cql.maven-publishing-conventions")
+    id("org.jetbrains.kotlinx.kover")
     id("io.gitlab.arturbosch.detekt")
     id("org.jetbrains.dokka")
     id("com.github.gmazzo.buildconfig")

--- a/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -110,3 +110,13 @@ afterEvaluate {
 // JAR manifests aren't available in Kotlin/JS, so to access Package.implementationVersion, a build
 // config is needed.
 buildConfig { buildConfigField("IMPLEMENTATION_VERSION", project.version.toString()) }
+
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
+        }
+    }
+}

--- a/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/Src/java/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -111,12 +111,4 @@ afterEvaluate {
 // config is needed.
 buildConfig { buildConfigField("IMPLEMENTATION_VERSION", project.version.toString()) }
 
-kover {
-    reports {
-        total {
-            xml {
-                onCheck = true
-            }
-        }
-    }
-}
+kover { reports { total { xml { onCheck = true } } } }

--- a/Src/java/build.gradle.kts
+++ b/Src/java/build.gradle.kts
@@ -12,6 +12,10 @@ sonar {
         property("sonar.projectKey", "cqframework_clinical_quality_language")
         property("sonar.organization", "cqframework")
         property("sonar.host.url", "https://sonarcloud.io")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            "**/build/reports/kover/report.xml,**/build/reports/jacoco/test/jacocoTestReport.xml",
+        )
     }
 }
 

--- a/Src/java/cql-to-elm/build.gradle.kts
+++ b/Src/java/cql-to-elm/build.gradle.kts
@@ -36,3 +36,8 @@ kotlin {
         }
     }
 }
+
+dependencies {
+    kover(project(":cql"))
+    kover(project(":elm"))
+}

--- a/Src/java/cql/build.gradle.kts
+++ b/Src/java/cql/build.gradle.kts
@@ -95,3 +95,5 @@ tasks.named("dokkaGeneratePublicationHtml") {
     dependsOn(generateKotlinGrammarSource)
     dependsOn(inlineModelInfoXmlsTask)
 }
+
+dependencies { kover(project(":shared")) }

--- a/Src/java/elm/build.gradle.kts
+++ b/Src/java/elm/build.gradle.kts
@@ -22,3 +22,5 @@ kotlin {
         }
     }
 }
+
+dependencies { kover(project(":shared")) }

--- a/Src/java/engine/build.gradle.kts
+++ b/Src/java/engine/build.gradle.kts
@@ -25,3 +25,5 @@ kotlin {
         }
     }
 }
+
+dependencies { kover(project(":cql-to-elm")) }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluator.kt
@@ -116,23 +116,27 @@ object QueryEvaluator {
         val sortClause = elm.sort
 
         if (sortClause != null) {
-            for (byItem in sortClause.by) {
-                when (byItem) {
-                    is ByExpression ->
-                        result.sortWith(
-                            CqlList(state, visitor, "\$this", byItem.expression!!).expressionSort
-                        )
+            val comparator =
+                sortClause.by
+                    .map { byItem ->
+                        val baseComparator =
+                            when (byItem) {
+                                is ByExpression ->
+                                    CqlList(state, visitor, "\$this", byItem.expression!!)
+                                        .expressionSort
+                                is ByColumn -> CqlList(state, byItem.path).columnSort
+                                else -> CqlList(state).valueSort
+                            }
 
-                    is ByColumn -> result.sortWith(CqlList(state, byItem.path).columnSort)
+                        val direction = byItem.direction
+                        val isDesc =
+                            direction == SortDirection.DESC || direction == SortDirection.DESCENDING
 
-                    else -> result.sortWith(CqlList(state).valueSort)
-                }
+                        if (isDesc) baseComparator.reversed() else baseComparator
+                    }
+                    .reduceOrNull { acc, comp -> acc.then(comp) }
 
-                val direction = byItem.direction!!.value()
-                if (direction == "desc" || direction == "descending") {
-                    result.reverse()
-                }
-            }
+            comparator?.let { result.sortWith(it) }
         }
     }
 

--- a/Src/java/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluatorTest.kt
+++ b/Src/java/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/QueryEvaluatorTest.kt
@@ -1,0 +1,55 @@
+package org.opencds.cqf.cql.engine.elm.executing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hl7.elm.r1.ByColumn
+import org.hl7.elm.r1.Query
+import org.hl7.elm.r1.SortClause
+import org.hl7.elm.r1.SortDirection
+import org.opencds.cqf.cql.engine.execution.Environment
+import org.opencds.cqf.cql.engine.execution.EvaluationVisitor
+import org.opencds.cqf.cql.engine.execution.State
+import org.opencds.cqf.cql.engine.runtime.Tuple
+
+class QueryEvaluatorTest {
+    /**
+     * [#1745](https://github.com/cqframework/clinical_quality_language/issues/1745): A secondary
+     * sort in the opposite direction shouldn't reverse the primary sort
+     */
+    @Test
+    fun sortResultTest() {
+        val query =
+            Query()
+                .withSort(
+                    SortClause()
+                        .withBy(
+                            listOf(
+                                ByColumn().withPath("field1").withDirection(SortDirection.ASC),
+                                ByColumn().withPath("field2").withDirection(SortDirection.DESC),
+                            )
+                        )
+                )
+
+        val list =
+            mutableListOf<Any?>(
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 2)),
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 1)),
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 3)),
+                Tuple().withElements(mutableMapOf("field1" to 1, "field2" to 2)),
+                Tuple().withElements(mutableMapOf("field1" to 1, "field2" to 3)),
+            )
+
+        QueryEvaluator.sortResult(query, list, State(Environment(null)), EvaluationVisitor())
+
+        val expected =
+            listOf<Any?>(
+                Tuple().withElements(mutableMapOf("field1" to 1, "field2" to 3)),
+                Tuple().withElements(mutableMapOf("field1" to 1, "field2" to 2)),
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 3)),
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 2)),
+                Tuple().withElements(mutableMapOf("field1" to 2, "field2" to 1)),
+            )
+
+        assertEquals(true, EqualEvaluator.equal(expected, list))
+    }
+}


### PR DESCRIPTION
Closes #1745.

A secondary sort in the opposite direction shouldn't reverse the primary sort. E.g. in `sort by field1 asc, field2 desc`, `field1` values should be sorted in the ascending order. The latter sort should only be applied when `field1` values are equal.

Also includes a fix for code coverage reporting. Uses [Kover](https://github.com/Kotlin/kotlinx-kover) to collect test coverage for KMP projects which is picked up by Codecov and SonarQube.