### PR TITLE
Feature/cql debug

### DIFF
--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointAction.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointAction.kt
@@ -1,0 +1,6 @@
+package org.opencds.cqf.cql.engine.debug
+
+enum class BreakpointAction {
+    CONTINUE,
+    PAUSE,
+}

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
@@ -6,8 +6,12 @@ import org.opencds.cqf.cql.engine.execution.State
 
 interface BreakpointHandler {
     fun onBeforeExpression(elm: Element, state: State): BreakpointAction
+
     fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+
     fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {}
+
     fun waitForResume() {}
+
     fun release() {}
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
@@ -1,0 +1,13 @@
+package org.opencds.cqf.cql.engine.debug
+
+import org.hl7.elm.r1.Element
+import org.hl7.elm.r1.ExpressionDef
+import org.opencds.cqf.cql.engine.execution.State
+
+interface BreakpointHandler {
+    fun onBeforeExpression(elm: Element, state: State): BreakpointAction
+    fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+    fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {}
+    fun waitForResume() {}
+    fun release() {}
+}

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
@@ -6,7 +6,6 @@ import org.hl7.cql.model.IntervalType
 import org.hl7.cql.model.ListType
 import org.hl7.elm.r1.*
 import org.opencds.cqf.cql.engine.debug.BreakpointAction
-import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.SourceLocator.Companion.fromNode
 import org.opencds.cqf.cql.engine.elm.executing.*
 import org.opencds.cqf.cql.engine.elm.executing.AbsEvaluator.abs
@@ -196,7 +195,8 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Value?, State?>() {
         }
 
         val action =
-            context?.breakpointHandler?.onBeforeExpression(elm, context) ?: BreakpointAction.CONTINUE
+            context?.breakpointHandler?.onBeforeExpression(elm, context)
+                ?: BreakpointAction.CONTINUE
         if (action == BreakpointAction.PAUSE) {
             context?.breakpointHandler?.waitForResume()
         }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
@@ -5,6 +5,8 @@ import org.cqframework.cql.elm.visiting.BaseElmLibraryVisitor
 import org.hl7.cql.model.IntervalType
 import org.hl7.cql.model.ListType
 import org.hl7.elm.r1.*
+import org.opencds.cqf.cql.engine.debug.BreakpointAction
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.SourceLocator.Companion.fromNode
 import org.opencds.cqf.cql.engine.elm.executing.*
 import org.opencds.cqf.cql.engine.elm.executing.AbsEvaluator.abs
@@ -193,9 +195,17 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Value?, State?>() {
             detailedState.pushSubExpressionFrame(elm)
         }
 
+        val action =
+            context?.breakpointHandler?.onBeforeExpression(elm, context) ?: BreakpointAction.CONTINUE
+        if (action == BreakpointAction.PAUSE) {
+            context?.breakpointHandler?.waitForResume()
+        }
+
         try {
             val value = super.visitExpression(elm, context)
             context?.checkType(elm, value)
+
+            context?.breakpointHandler?.onAfterExpression(elm, context, value)
 
             if (detailedState != null) {
                 detailedState.storeSubExpressionResult(value)
@@ -234,7 +244,9 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Value?, State?>() {
     }
 
     override fun visitExpressionDef(elm: ExpressionDef, context: State?): Value? {
-        return internalEvaluate(elm, context, this)
+        val value = internalEvaluate(elm, context, this)
+        context?.breakpointHandler?.onExpressionDefEvaluated(elm, context, value)
+        return value
     }
 
     override fun visitExpressionRef(elm: ExpressionRef, context: State?): Value? {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -134,8 +134,8 @@ constructor(
 
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Value?>>()
 
-    val parameters = mutableMapOf<String, Any?>()
-    var contextValues = mutableMapOf<String, Any?>()
+    val parameters = mutableMapOf<kotlin.String, Value?>()
+    var contextValues = mutableMapOf<kotlin.String, kotlin.String?>()
 
     var evaluationZonedDateTime: ZonedDateTime? = null
         private set

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -24,6 +24,7 @@ import org.hl7.elm.r1.QueryLetRef
 import org.hl7.elm.r1.Retrieve
 import org.hl7.elm.r1.Total
 import org.hl7.elm.r1.VersionedIdentifier
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.DebugAction
 import org.opencds.cqf.cql.engine.debug.DebugMap
 import org.opencds.cqf.cql.engine.debug.DebugResult
@@ -129,10 +130,12 @@ constructor(
      */
     var traceExpressionFilter: ((Expression) -> Boolean)? = null
 
+    var breakpointHandler: BreakpointHandler? = null
+
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Value?>>()
 
-    val parameters = mutableMapOf<kotlin.String, Value?>()
-    var contextValues = mutableMapOf<kotlin.String, kotlin.String?>()
+    val parameters = mutableMapOf<String, Any?>()
+    var contextValues = mutableMapOf<String, Any?>()
 
     var evaluationZonedDateTime: ZonedDateTime? = null
         private set

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.debug.BreakpointAction
 import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.DebugMap
+import org.opencds.cqf.cql.engine.runtime.Integer
 
 internal class BreakpointHandlerTest : CqlTestBase() {
     companion object {
@@ -65,9 +66,9 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.state.breakpointHandler = handler
         val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
-        Assertions.assertEquals(3, results["X"]!!.value)
-        Assertions.assertEquals(12, results["Y"]!!.value)
-        Assertions.assertEquals(6, results["Z"]!!.value)
+        Assertions.assertEquals(Integer(3), results["X"]!!.value)
+        Assertions.assertEquals(Integer(12), results["Y"]!!.value)
+        Assertions.assertEquals(Integer(6), results["Z"]!!.value)
     }
 
     @Test
@@ -89,8 +90,8 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.state.breakpointHandler = handler
         engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
-        Assertions.assertTrue(addResults.contains(3))
-        Assertions.assertTrue(multiplyResults.contains(12))
+        Assertions.assertTrue(addResults.contains(Integer(3)))
+        Assertions.assertTrue(multiplyResults.contains(Integer(12)))
     }
 
     @Test
@@ -135,8 +136,8 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         val results = future.get(5, TimeUnit.SECONDS)
 
         Assertions.assertNotNull(results)
-        Assertions.assertEquals(3, results["X"]!!.value)
-        Assertions.assertEquals(12, results["Y"]!!.value)
+        Assertions.assertEquals(Integer(3), results["X"]!!.value)
+        Assertions.assertEquals(Integer(12), results["Y"]!!.value)
     }
 
     @Test
@@ -165,8 +166,7 @@ internal class BreakpointHandlerTest : CqlTestBase() {
 
         Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
 
-        val libraryDebug =
-            results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
+        val libraryDebug = results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
         Assertions.assertNotNull(libraryDebug)
         Assertions.assertTrue(libraryDebug.isNotEmpty())
     }

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -180,7 +180,6 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     callCount.incrementAndGet()
                     return BreakpointAction.CONTINUE
                 }
-
             }
 
         engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -1,0 +1,199 @@
+package org.opencds.cqf.cql.engine.execution
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.hl7.elm.r1.Add
+import org.hl7.elm.r1.Element
+import org.hl7.elm.r1.Multiply
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.opencds.cqf.cql.engine.debug.BreakpointAction
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
+import org.opencds.cqf.cql.engine.debug.DebugMap
+
+internal class BreakpointHandlerTest : CqlTestBase() {
+    companion object {
+        private const val NUMBER_OF_DEFINES = 4
+    }
+
+    @Test
+    fun onBeforeExpression_invokedForEveryExpression() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(
+            callCount.get() > NUMBER_OF_DEFINES,
+            "handler should be called for sub-expressions, not just ExpressionDefs",
+        )
+    }
+
+    @Test
+    fun onBeforeExpression_receivesLiveState() {
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    Assertions.assertNotNull(state)
+                    Assertions.assertTrue(state.stack.isNotEmpty())
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+    }
+
+    @Test
+    fun onBeforeExpression_returnsContinue_evaluationCompletes() {
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertEquals(3, results["X"]!!.value)
+        Assertions.assertEquals(12, results["Y"]!!.value)
+        Assertions.assertEquals(6, results["Z"]!!.value)
+    }
+
+    @Test
+    fun onAfterExpression_receivesCorrectValue() {
+        val addResults = mutableListOf<Any?>()
+        val multiplyResults = mutableListOf<Any?>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onAfterExpression(elm: Element, state: State, value: Any?) {
+                    if (elm is Add) addResults.add(value)
+                    if (elm is Multiply) multiplyResults.add(value)
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(addResults.contains(3))
+        Assertions.assertTrue(multiplyResults.contains(12))
+    }
+
+    @Test
+    fun onBeforeExpression_pauseBlocksAndReleaseResumes() {
+        val paused = CountDownLatch(1)
+        val resumeLatch = CountDownLatch(1)
+
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    if (elm is Add) {
+                        paused.countDown()
+                        return BreakpointAction.PAUSE
+                    }
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun waitForResume() {
+                    try {
+                        resumeLatch.await()
+                    } catch (e: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                }
+
+                override fun release() {
+                    resumeLatch.countDown()
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+
+        val future =
+            CompletableFuture.supplyAsync {
+                engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+            }
+
+        Assertions.assertTrue(paused.await(5, TimeUnit.SECONDS))
+        Assertions.assertFalse(future.isDone)
+
+        handler.release()
+        val results = future.get(5, TimeUnit.SECONDS)
+
+        Assertions.assertNotNull(results)
+        Assertions.assertEquals(3, results["X"]!!.value)
+        Assertions.assertEquals(12, results["Y"]!!.value)
+    }
+
+    @Test
+    fun breakpointHandler_independentOfDebugMap() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        val debugMap = DebugMap()
+        debugMap.isLoggingEnabled = true
+
+        engine.state.breakpointHandler = handler
+
+        val results =
+            engine
+                .evaluate {
+                    library("BreakpointHandlerTest")
+                    this@evaluate.debugMap = debugMap
+                }
+                .onlyResultOrThrow
+
+        Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
+
+        val libraryDebug =
+            results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
+        Assertions.assertNotNull(libraryDebug)
+        Assertions.assertTrue(libraryDebug.isNotEmpty())
+    }
+
+    @Test
+    fun breakpointHandler_worksWithDetailedTracing() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+            }
+
+        engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)
+        engine.state.breakpointHandler = handler
+
+        val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
+
+        val traceEntry = results.trace
+        Assertions.assertNotNull(traceEntry)
+        Assertions.assertNotNull(traceEntry!!.frames)
+        Assertions.assertTrue(traceEntry.frames.isNotEmpty())
+    }
+}

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -181,7 +181,6 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onAfterExpression(elm: Element, state: State, value: Any?) {}
             }
 
         engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)

--- a/Src/java/engine/src/jvmTest/resources/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.cql
+++ b/Src/java/engine/src/jvmTest/resources/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.cql
@@ -1,0 +1,5 @@
+library BreakpointHandlerTest
+define X: 1 + 2
+define Y: 3 * 4
+define function F(a Integer): a + 1
+define Z: F(5)


### PR DESCRIPTION
## Summary

Adds a `BreakpointHandler` interface to the CQL engine for step-through debugging. External callers set `State.breakpointHandler` to observe expression evaluation and optionally pause execution.

## New files

| File | Purpose |
|------|---------|
| `BreakpointAction.kt` | `enum { CONTINUE, PAUSE }` |
| `BreakpointHandler.kt` | Interface with 5 callbacks (all default no-op) |
| `BreakpointHandlerTest.kt` | 7 tests covering all callback paths |
| `BreakpointHandlerTest.cql` | Test fixture |

## Modified files

- **EvaluationVisitor.kt** — `onBeforeExpression`/`onAfterExpression` fire on every ELM node; `onExpressionDefEvaluated` fires on the define after its expression completes
- **State.kt** — `var breakpointHandler: BreakpointHandler?`

## Key fix

`onExpressionDefEvaluated` solves the define-value tracking gap: `onAfterExpression` fires on intermediate child nodes (Property, Equal, etc.), never on the `ExpressionDef` itself. The new callback always fires on the define with its final value.
