### PR TITLE
Ignore "id" elements when checking FHIR complex types for equivalence

### DIFF
--- a/Src/java/engine-fhir/config/detekt-baseline.xml
+++ b/Src/java/engine-fhir/config/detekt-baseline.xml
@@ -10,7 +10,7 @@
     <ID>CyclomaticComplexMethod:BaseFhirTypeConverter.kt$BaseFhirTypeConverter$override fun toCqlType(value: Any?): Value?</ID>
     <ID>CyclomaticComplexMethod:BaseFhirTypeConverter.kt$BaseFhirTypeConverter$override fun toFhirType(value: Value?): IBase?</ID>
     <ID>CyclomaticComplexMethod:Dstu3FhirQueryGenerator.kt$Dstu3FhirQueryGenerator$override fun generateFhirQueries( dataRequirement: ICompositeType?, evaluationDateTime: DateTime?, contextValues: MutableMap&lt;String, String?>?, parameters: MutableMap&lt;String, Value?>?, capabilityStatement: IBaseConformance?, ): MutableList&lt;String></ID>
-    <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: Boolean = false, ): ClassInstance?</ID>
+    <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
     <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$open fun resolveType(typeName: String?): Class&lt;*>?</ID>
     <ID>CyclomaticComplexMethod:FhirModelResolverTest.kt$private fun validateCqlValueAgainstModel( fhirVersion: FhirVersionEnum, expectedFhirTypeName: String, cqlValue: Any?, )</ID>
     <ID>CyclomaticComplexMethod:R4FhirModelResolver.kt$R4FhirModelResolver$override fun resolveType(typeName: String?): Class&lt;*>?</ID>
@@ -72,7 +72,7 @@
     <ID>LongMethod:EvaluatedResourcesMultiLibLinearDepsTest.kt$EvaluatedResourcesMultiLibLinearDepsTest$@ParameterizedTest @MethodSource("multiLibEnsurePartialCacheAllowsUncachedLibsToBeCompiledParams") fun multiLibEnsurePartialCacheAllowsUncachedLibsToBeCompiled(expressionCaching: Boolean)</ID>
     <ID>LongMethod:EvaluatedResourcesMultiLibLinearDepsTest.kt$EvaluatedResourcesMultiLibLinearDepsTest.Companion$@JvmStatic private fun multiLibParams(): List&lt;Arguments></ID>
     <ID>LongMethod:EvaluatedResourcesMultiLibLinearDepsTest.kt$EvaluatedResourcesMultiLibLinearDepsTest.Companion$@JvmStatic private fun singleLibParams(): List&lt;Arguments></ID>
-    <ID>LongMethod:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: Boolean = false, ): ClassInstance?</ID>
+    <ID>LongMethod:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
     <ID>LongMethod:FhirModelResolver.kt$FhirModelResolver$protected fun toDateTime( value: BaseDateTimeType, calendarConstant: Int = this.getCalendarConstant(value), ): DateTime</ID>
     <ID>LongMethod:FhirModelResolverTest.kt$FhirModelResolverTest$@Test fun toCqlValueFhirPrimitiveWithValueAndExtension()</ID>
     <ID>LongMethod:FhirModelResolverTest.kt$fun validateCqlValueAgainstModelInner(cqlValue: Any?, modelType: DataType)</ID>
@@ -128,7 +128,7 @@
     <ID>NestedBlockDepth:EvaluatedResourceTestUtils.kt$EvaluatedResourceTestUtils$fun setupCql( classToUse: Class&lt;*>, librariesToPopulate: MutableList&lt;Library?>, libraryManagerToUse: LibraryManager, )</ID>
     <ID>NestedBlockDepth:FhirBundleCursor.kt$FhirBundleCursor.FhirBundleIterator$fun getTrustedEntries( entries: MutableList&lt;out IBaseResource>, templateId: String?, ): MutableList&lt;out IBaseResource></ID>
     <ID>NestedBlockDepth:FhirExecutionTestBase.kt$FhirExecutionTestBase$@BeforeEach @Throws(IOException::class, UcumException::class) fun beforeEachTestMethod()</ID>
-    <ID>NestedBlockDepth:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: Boolean = false, ): ClassInstance?</ID>
+    <ID>NestedBlockDepth:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
     <ID>NestedBlockDepth:FhirModelResolver.kt$FhirModelResolver$private fun resolveChildren( children: List&lt;BaseRuntimeChildDefinition>, childName: String, ): Class&lt;*>?</ID>
     <ID>NestedBlockDepth:R4FhirQueryGenerator.kt$R4FhirQueryGenerator$override fun generateFhirQueries( dataRequirement: ICompositeType?, evaluationDateTime: DateTime?, contextValues: MutableMap&lt;String, String?>?, parameters: MutableMap&lt;String, Value?>?, capabilityStatement: IBaseConformance?, ): MutableList&lt;String></ID>
     <ID>NestedBlockDepth:RestFhirRetrieveProvider.kt$RestFhirRetrieveProvider$private fun executeQuery(dataType: String?, map: SearchParameterMap): IBaseResource?</ID>
@@ -155,9 +155,9 @@
     <ID>ReturnCount:Dstu3FhirTypeConverter.kt$Dstu3FhirTypeConverter$override fun toCqlTemporal(value: IPrimitiveType&lt;Date>?): BaseTemporal?</ID>
     <ID>ReturnCount:Dstu3FhirTypeConverter.kt$Dstu3FhirTypeConverter$override fun toFhirPeriod(value: Interval?): ICompositeType?</ID>
     <ID>ReturnCount:Dstu3TypeConverterTests.kt$Dstu3TypeConverterTests$private fun compareObjects(left: Any?, right: Any?): Boolean</ID>
-    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: Boolean = false, ): ClassInstance?</ID>
+    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$open fun resolveType(typeName: String?): Class&lt;*>?</ID>
-    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun `is`(valueType: String, type: QName): Boolean?</ID>
+    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun `is`(valueType: String, type: QName): kotlin.Boolean?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun getContextPath( contextType: kotlin.String?, targetType: kotlin.String?, ): kotlin.String?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun resolveId(target: Value?): kotlin.String?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$protected fun innerGetContextPath( visitedElements: MutableSet&lt;String?>, child: BaseRuntimeChildDefinition, type: Class&lt;out IBase?>?, ): String?</ID>

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
@@ -10,11 +10,7 @@ import java.lang.reflect.InvocationTargetException
 import java.util.Calendar
 import java.util.GregorianCalendar
 import javax.xml.namespace.QName
-import kotlin.Any
-import kotlin.Boolean
-import kotlin.Exception
 import kotlin.IllegalArgumentException
-import kotlin.Int
 import org.hl7.fhir.instance.model.api.IAnyResource
 import org.hl7.fhir.instance.model.api.IBase
 import org.hl7.fhir.instance.model.api.IBaseBackboneElement
@@ -27,10 +23,12 @@ import org.hl7.fhir.instance.model.api.IBaseResource
 import org.hl7.fhir.instance.model.api.ICompositeType
 import org.hl7.fhir.instance.model.api.IIdType
 import org.hl7.fhir.instance.model.api.IPrimitiveType
+import org.opencds.cqf.cql.engine.elm.executing.EquivalentEvaluator
 import org.opencds.cqf.cql.engine.exception.InvalidPrecision
 import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
 import org.opencds.cqf.cql.engine.model.ModelResolver
 import org.opencds.cqf.cql.engine.runtime.BaseTemporal
+import org.opencds.cqf.cql.engine.runtime.Boolean
 import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.Date
 import org.opencds.cqf.cql.engine.runtime.DateTime
@@ -87,7 +85,7 @@ abstract class FhirModelResolver<
 
     protected abstract fun enumConstructor(factory: EnumFactoryType): EnumerationType
 
-    protected abstract fun enumChecker(`object`: Any): Boolean
+    protected abstract fun enumChecker(`object`: Any): kotlin.Boolean
 
     protected abstract fun enumFactoryTypeGetter(enumeration: EnumerationType): Class<*>
 
@@ -186,7 +184,7 @@ abstract class FhirModelResolver<
         return null
     }
 
-    override fun `is`(valueType: String, type: QName): Boolean? {
+    override fun `is`(valueType: String, type: QName): kotlin.Boolean? {
         // System.Any is a supertype of all types
         if (type == anyTypeName) {
             return true
@@ -201,6 +199,31 @@ abstract class FhirModelResolver<
         val typeClass = resolveType(type.localPart) ?: return null
 
         return typeClass.isAssignableFrom(valueTypeClass)
+    }
+
+    override fun objectEquivalent(
+        left: ClassInstance,
+        right: ClassInstance,
+        equivalent: (l: Value?, r: Value?) -> Boolean,
+    ): Boolean {
+        // "id" elements are excluded from equivalence checking for instances of FHIR.Resource and
+        // FHIR.Element (see https://hl7.org/fhir/fhirpath.html#changes)
+        if (
+            `is`(left.type.localPart, QName(fhirModelNamespaceUri, "Resource")) == true ||
+                `is`(left.type.localPart, QName(fhirModelNamespaceUri, "Element")) == true
+        ) {
+            return EquivalentEvaluator.structuredValueElementsEquivalent(
+                left.elements.filterKeys { it != "id" },
+                right.elements.filterKeys { it != "id" },
+                equivalent,
+            )
+        }
+
+        return EquivalentEvaluator.structuredValueElementsEquivalent(
+            left.elements,
+            right.elements,
+            equivalent,
+        )
     }
 
     override fun createInstance(typeName: String?): Value {
@@ -604,7 +627,7 @@ abstract class FhirModelResolver<
      */
     fun toCqlValue(
         target: Any?,
-        expandPrimitivesAndEnumerationsWithNoValues: Boolean = false,
+        expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false,
     ): ClassInstance? {
         if (target == null) {
             return null

--- a/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlComparisonOperatorsTest.xml
+++ b/Src/java/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlComparisonOperatorsTest.xml
@@ -798,6 +798,70 @@
 			<expression>@T10:00:00.000 ~ @T22:00:00.000</expression>
 			<output>false</output>
 		</test>
+		<test name="EquivFhirPatientSameNameId">
+			<expression>
+				FHIR.Patient {
+					id: FHIR.id { value: '123' },
+					name: {
+						FHIR.HumanName {
+							given: FHIR.string { value: 'John' }
+						}
+					}
+				} ~ FHIR.Patient {
+					id: FHIR.id { value: '123' },
+					name: {
+						FHIR.HumanName {
+							given: FHIR.string { value: 'John' }
+						}
+					}
+				}
+			</expression>
+			<output>true</output>
+		</test>
+		<test name="EquivFhirPatientSameNameDifferentId">
+			<expression>
+				FHIR.Patient {
+					id: FHIR.id { value: '123' },
+					name: {
+						FHIR.HumanName {
+							given: FHIR.string { value: 'John' }
+						}
+					}
+				} ~ FHIR.Patient {
+					id: FHIR.id { value: '456' },
+					name: {
+						FHIR.HumanName {
+							given: FHIR.string { value: 'John' }
+						}
+					}
+				}
+			</expression>
+			<output>true</output>
+		</test>
+		<test name="EquivFhirStringSameValueId">
+			<expression>
+				FHIR.string {
+					id: '123',
+					value: 'John'
+				} ~ FHIR.string {
+					id: '123',
+					value: 'John'
+				}
+			</expression>
+			<output>true</output>
+		</test>
+		<test name="EquivFhirStringSameValueDifferentId">
+			<expression>
+				FHIR.string {
+					id: '123',
+					value: 'John'
+				} ~ FHIR.string {
+					id: '456',
+					value: 'John'
+				}
+			</expression>
+			<output>true</output>
+		</test>
 	</group>
 	<group name="Not Equal">
 		<test name="SimpleNotEqTrueTrue">

--- a/Src/java/engine/detekt-baseline.xml
+++ b/Src/java/engine/detekt-baseline.xml
@@ -75,7 +75,7 @@
     <ID>FunctionNaming:AsEvaluator.kt$AsEvaluator$fun `as`( operand: Value?, type: TypeSpecifier, isStrict: kotlin.Boolean, state: State?, ): Value?</ID>
     <ID>FunctionNaming:InEvaluator.kt$InEvaluator$fun `in`(left: Value?, right: Value?, precision: kotlin.String?, state: State?): Boolean?</ID>
     <ID>FunctionNaming:IsEvaluator.kt$IsEvaluator$fun `is`(value: Value?, type: TypeSpecifier, state: State?): kotlin.Boolean?</ID>
-    <ID>FunctionNaming:ModelResolver.kt$ModelResolver$fun `is`(valueType: String, type: QName): Boolean?</ID>
+    <ID>FunctionNaming:ModelResolver.kt$ModelResolver$fun `is`(valueType: String, type: QName): kotlin.Boolean?</ID>
     <ID>FunctionNaming:TerminologyProvider.kt$TerminologyProvider$fun `in`(code: Code, valueSet: ValueSetInfo): Boolean</ID>
     <ID>FunctionOnlyReturningConstant:NullEvaluator.kt$NullEvaluator$@JvmStatic fun internalEvaluate(state: State?): Value?</ID>
     <ID>FunctionParameterNaming:AsEvaluator.kt$AsEvaluator$`as`: As</ID>
@@ -366,7 +366,7 @@
     <ID>ReturnCount:AnyInValueSetEvaluator.kt$AnyInValueSetEvaluator$@JvmStatic fun internalEvaluate( codes: Value?, valueSetRef: ValueSetRef?, valueset: Value?, state: State?, ): Boolean?</ID>
     <ID>ReturnCount:AnyTrueEvaluator.kt$AnyTrueEvaluator$@JvmStatic fun anyTrue(src: Value?): Boolean</ID>
     <ID>ReturnCount:BeforeEvaluator.kt$BeforeEvaluator$@JvmStatic fun before(left: Value?, right: Value?, precision: kotlin.String?, state: State?): Boolean?</ID>
-    <ID>ReturnCount:CachingModelResolverDecorator.kt$CachingModelResolverDecorator$override fun getContextPath(contextType: String?, targetType: String?): String?</ID>
+    <ID>ReturnCount:CachingModelResolverDecorator.kt$CachingModelResolverDecorator$override fun getContextPath(contextType: kotlin.String?, targetType: kotlin.String?): kotlin.String?</ID>
     <ID>ReturnCount:CeilingEvaluator.kt$CeilingEvaluator$@JvmStatic fun ceiling(operand: Value?): Integer?</ID>
     <ID>ReturnCount:CoalesceEvaluator.kt$CoalesceEvaluator$fun coalesce(operands: kotlin.collections.List&lt;Value?>): Value?</ID>
     <ID>ReturnCount:CollapseEvaluator.kt$CollapseEvaluator$private fun getIntervalWithPerApplied( interval: Interval, per: Quantity, state: State?, ): Interval</ID>

--- a/Src/java/engine/detekt-baseline.xml
+++ b/Src/java/engine/detekt-baseline.xml
@@ -366,7 +366,7 @@
     <ID>ReturnCount:AnyInValueSetEvaluator.kt$AnyInValueSetEvaluator$@JvmStatic fun internalEvaluate( codes: Value?, valueSetRef: ValueSetRef?, valueset: Value?, state: State?, ): Boolean?</ID>
     <ID>ReturnCount:AnyTrueEvaluator.kt$AnyTrueEvaluator$@JvmStatic fun anyTrue(src: Value?): Boolean</ID>
     <ID>ReturnCount:BeforeEvaluator.kt$BeforeEvaluator$@JvmStatic fun before(left: Value?, right: Value?, precision: kotlin.String?, state: State?): Boolean?</ID>
-    <ID>ReturnCount:CachingModelResolverDecorator.kt$CachingModelResolverDecorator$override fun getContextPath(contextType: kotlin.String?, targetType: kotlin.String?): kotlin.String?</ID>
+    <ID>ReturnCount:CachingModelResolverDecorator.kt$CachingModelResolverDecorator$override fun getContextPath( contextType: kotlin.String?, targetType: kotlin.String?, ): kotlin.String?</ID>
     <ID>ReturnCount:CeilingEvaluator.kt$CeilingEvaluator$@JvmStatic fun ceiling(operand: Value?): Integer?</ID>
     <ID>ReturnCount:CoalesceEvaluator.kt$CoalesceEvaluator$fun coalesce(operands: kotlin.collections.List&lt;Value?>): Value?</ID>
     <ID>ReturnCount:CollapseEvaluator.kt$CollapseEvaluator$private fun getIntervalWithPerApplied( interval: Interval, per: Quantity, state: State?, ): Interval</ID>

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/CompositeDataProvider.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/CompositeDataProvider.kt
@@ -3,6 +3,8 @@ package org.opencds.cqf.cql.engine.data
 import org.cqframework.cql.shared.QName
 import org.opencds.cqf.cql.engine.model.ModelResolver
 import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
+import org.opencds.cqf.cql.engine.runtime.Boolean
+import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.Code
 import org.opencds.cqf.cql.engine.runtime.Interval
 import org.opencds.cqf.cql.engine.runtime.Value
@@ -18,12 +20,20 @@ open class CompositeDataProvider(
         return this.modelResolver!!.getContextPath(contextType, targetType)
     }
 
-    override fun `is`(valueType: kotlin.String, type: QName): Boolean? {
+    override fun `is`(valueType: kotlin.String, type: QName): kotlin.Boolean? {
         return this.modelResolver!!.`is`(valueType, type)
     }
 
     override fun createInstance(typeName: kotlin.String?): Value? {
         return this.modelResolver!!.createInstance(typeName)
+    }
+
+    override fun objectEquivalent(
+        left: ClassInstance,
+        right: ClassInstance,
+        equivalent: (l: Value?, r: Value?) -> Boolean,
+    ): Boolean {
+        return this.modelResolver!!.objectEquivalent(left, right, equivalent)
     }
 
     override fun resolveId(target: Value?): kotlin.String? {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/EquivalentEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/EquivalentEvaluator.kt
@@ -153,12 +153,18 @@ object EquivalentEvaluator {
         }
 
         if (left is Tuple && right is Tuple) {
-            return structuredValueElementsEquivalent(left.elements, right.elements, state)
+            return structuredValueElementsEquivalent(left.elements, right.elements) { l, r ->
+                equivalent(l, r, state)
+            }
         }
 
         if (left is ClassInstance && right is ClassInstance) {
             if (left.type == right.type) {
-                return structuredValueElementsEquivalent(left.elements, right.elements, state)
+                val dataProvider =
+                    state!!.environment.resolveDataProviderByModelUri(left.type.getNamespaceURI())
+                return dataProvider.objectEquivalent(left, right) { l, r ->
+                    equivalent(l, r, state)
+                }
             }
             return Boolean.FALSE
         }
@@ -284,10 +290,19 @@ object EquivalentEvaluator {
         return (!rightIterator.hasNext()).toCqlBoolean()
     }
 
+    /**
+     * Compares the elements of structured values for equivalence using the tuple equivalence
+     * semantics.
+     *
+     * @param left Elements of the left hand operand
+     * @param right Elements of the right hand operand
+     * @param equivalent Used to compare the elements of the structured values for equivalence
+     * @return CQL Boolean indicating whether the structured values are equivalent
+     */
     fun structuredValueElementsEquivalent(
         left: Map<kotlin.String, Value?>,
         right: Map<kotlin.String, Value?>,
-        state: State?,
+        equivalent: (l: Value?, r: Value?) -> Boolean,
     ): Boolean {
         if (left.size != right.size) {
             return Boolean.FALSE
@@ -295,7 +310,7 @@ object EquivalentEvaluator {
 
         for (key in right.keys) {
             if (left.containsKey(key)) {
-                val areKeyValsSame = equivalent(right[key], left[key], state)
+                val areKeyValsSame = equivalent(right[key], left[key])
                 if (!areKeyValsSame.value) {
                     return Boolean.FALSE
                 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/CachingModelResolverDecorator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/CachingModelResolverDecorator.kt
@@ -1,12 +1,17 @@
 package org.opencds.cqf.cql.engine.model
 
 import org.cqframework.cql.shared.QName
+import org.opencds.cqf.cql.engine.runtime.Boolean
+import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.Value
 import org.opencds.cqf.cql.engine.util.createConcurrentHashMap
 
 open class CachingModelResolverDecorator(val innerResolver: ModelResolver) : ModelResolver {
 
-    override fun getContextPath(contextType: String?, targetType: String?): String? {
+    override fun getContextPath(
+        contextType: kotlin.String?,
+        targetType: kotlin.String?,
+    ): kotlin.String? {
         if (contextType == null) {
             return null
         }
@@ -28,20 +33,28 @@ open class CachingModelResolverDecorator(val innerResolver: ModelResolver) : Mod
         return null
     }
 
-    override fun createInstance(typeName: String?): Value? {
+    override fun createInstance(typeName: kotlin.String?): Value? {
         return this.innerResolver.createInstance(typeName)
     }
 
-    override fun resolveId(target: Value?): String? {
+    override fun objectEquivalent(
+        left: ClassInstance,
+        right: ClassInstance,
+        equivalent: (l: Value?, r: Value?) -> Boolean,
+    ): Boolean {
+        return this.innerResolver.objectEquivalent(left, right, equivalent)
+    }
+
+    override fun resolveId(target: Value?): kotlin.String? {
         return innerResolver.resolveId(target)
     }
 
-    override fun `is`(valueType: String, type: QName): Boolean? {
+    override fun `is`(valueType: kotlin.String, type: QName): kotlin.Boolean? {
         return this.innerResolver.`is`(valueType, type)
     }
 
     companion object {
         private val contextResolutions =
-            createConcurrentHashMap<String, MutableMap<String?, String?>>()
+            createConcurrentHashMap<kotlin.String, MutableMap<kotlin.String?, kotlin.String?>>()
     }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
@@ -3,6 +3,9 @@ package org.opencds.cqf.cql.engine.model
 import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
+import org.opencds.cqf.cql.engine.elm.executing.EquivalentEvaluator
+import org.opencds.cqf.cql.engine.runtime.Boolean
+import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.Value
 
 /**
@@ -30,7 +33,7 @@ interface ModelResolver {
      * @return `true` when `valueType` is a subtype of (or the same type as) the specified `type`,
      *   otherwise `false`.
      */
-    fun `is`(valueType: String, type: QName): Boolean?
+    fun `is`(valueType: String, type: QName): kotlin.Boolean?
 
     /**
      * Create an instance of the model object that corresponds to the specified type.
@@ -39,6 +42,27 @@ interface ModelResolver {
      * @return new instance of the specified model type
      */
     fun createInstance(typeName: String?): Value?
+
+    /**
+     * Compare two instances of the same class type for equivalence. The default implementation
+     * compares the elements of the structured values using the tuple equivalence semantics.
+     *
+     * @param left Left hand side of the equivalence expression
+     * @param right Right hand side of the equivalence expression
+     * @param equivalent Used to compare the elements of the structured values for equivalence
+     * @return CQL Boolean indicating whether the instances are equivalent
+     */
+    fun objectEquivalent(
+        left: ClassInstance,
+        right: ClassInstance,
+        equivalent: (l: Value?, r: Value?) -> Boolean,
+    ): Boolean {
+        return EquivalentEvaluator.structuredValueElementsEquivalent(
+            left.elements,
+            right.elements,
+            equivalent,
+        )
+    }
 
     /**
      * Ensure that for a given object each implementation can introspect that object in its own way


### PR DESCRIPTION
Closes #1778.

* Add back the `objectEquivalent()` method of the `ModelResolver` interface to allow implementations to override the default equivalent operation for class instances. The `objectEquivalent()` method provides the `equivalent(Value, Value) -> Boolean` parameter with the default implementation of the evaluator capturing the engine state in a closure.
* Override the `objectEquivalent()` method in `FhirModelResolver` to exclude "id" elements from equivalence checking for instances of FHIR.Resource and FHIR.Element.