### PR TITLE
Update version of HAPI FHIR dependency to 8.10.0

### DIFF
--- a/Src/java/gradle.properties
+++ b/Src/java/gradle.properties
@@ -9,5 +9,5 @@ systemProp.sonar.gradle.skipCompile=true
 
 group=org.cqframework
 specification.version=1.5.3
-hapi.version=8.8.1
+hapi.version=8.10.0
 android.api.level=34


### PR DESCRIPTION
HAPI FHIR 8.10.0 includes updating FHIR Core to 6.9.4.1, which ultimately addresses the "dueling npm package caches" issue by ensuring that the NPM Package Cache management logic in the CQF stack is using the same logic as the publisher