### PR TITLE
`Value.toString()` returns the CVL representation of the CQL value

### DIFF
--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/Dstu2FhirTypeConverter.kt
@@ -102,7 +102,7 @@ internal class Dstu2FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return DateType(value.toString())
+        return DateType(value.toStringInner())
     }
 
     override fun toFhirDateTime(value: DateTime?): IPrimitiveType<Date>? {
@@ -120,7 +120,7 @@ internal class Dstu2FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return TimeType(value.toString())
+        return TimeType(value.toStringInner())
     }
 
     override fun toFhirString(value: String?): IPrimitiveType<kotlin.String>? {

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/Dstu3FhirTypeConverter.kt
@@ -102,7 +102,7 @@ internal class Dstu3FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return DateType(value.toString())
+        return DateType(value.toStringInner())
     }
 
     override fun toFhirDateTime(value: DateTime?): IPrimitiveType<Date>? {
@@ -120,7 +120,7 @@ internal class Dstu3FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return TimeType(value.toString())
+        return TimeType(value.toStringInner())
     }
 
     override fun toFhirString(value: String?): IPrimitiveType<kotlin.String>? {

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/R4FhirTypeConverter.kt
@@ -102,7 +102,7 @@ internal class R4FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return DateType(value.toString())
+        return DateType(value.toStringInner())
     }
 
     override fun toFhirDateTime(value: DateTime?): IPrimitiveType<Date>? {
@@ -120,7 +120,7 @@ internal class R4FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return TimeType(value.toString())
+        return TimeType(value.toStringInner())
     }
 
     override fun toFhirString(value: String?): IPrimitiveType<kotlin.String>? {

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/converter/R5FhirTypeConverter.kt
@@ -107,7 +107,7 @@ internal class R5FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return DateType(value.toString())
+        return DateType(value.toStringInner())
     }
 
     override fun toFhirDateTime(value: DateTime?): IPrimitiveType<Date>? {
@@ -125,7 +125,7 @@ internal class R5FhirTypeConverter : BaseFhirTypeConverter() {
             return null
         }
 
-        return TimeType(value.toString())
+        return TimeType(value.toStringInner())
     }
 
     override fun toFhirString(value: String?): IPrimitiveType<kotlin.String>? {

--- a/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
+++ b/Src/java/engine-fhir/src/main/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
@@ -678,7 +678,7 @@ abstract class FhirModelResolver<
 
             elements["value"] = target.valueAsString?.toCqlString()
 
-            return ClassInstance(QName(fhirModelNamespaceUri, typeName), elements)
+            return ClassInstance(QName(fhirModelNamespaceUri, typeName, fhirModelId), elements)
         }
 
         if (target is IPrimitiveType<*>) {
@@ -696,7 +696,10 @@ abstract class FhirModelResolver<
 
             elements["value"] = toSimpleCqlType(target)
 
-            return ClassInstance(QName(fhirModelNamespaceUri, elementDefinition.name), elements)
+            return ClassInstance(
+                QName(fhirModelNamespaceUri, elementDefinition.name, fhirModelId),
+                elements,
+            )
         }
 
         val definition = resolveRuntimeDefinition(target)
@@ -715,10 +718,11 @@ abstract class FhirModelResolver<
                     }
         }
 
-        return ClassInstance(QName(fhirModelNamespaceUri, definition.name), elements)
+        return ClassInstance(QName(fhirModelNamespaceUri, definition.name, fhirModelId), elements)
     }
 
     companion object {
         const val fhirModelNamespaceUri = "http://hl7.org/fhir"
+        const val fhirModelId = "FHIR"
     }
 }

--- a/Src/java/engine-fhir/src/test/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolverTest.kt
+++ b/Src/java/engine-fhir/src/test/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolverTest.kt
@@ -28,6 +28,7 @@ import org.hl7.fhir.r4.model.StringType as R4StringType
 import org.hl7.fhir.r5.model.HumanName as R5HumanName
 import org.hl7.fhir.r5.model.Patient as R5Patient
 import org.hl7.fhir.r5.model.StringType as R5StringType
+import org.opencds.cqf.cql.engine.fhir.model.FhirModelResolver.Companion.fhirModelId
 import org.opencds.cqf.cql.engine.fhir.model.FhirModelResolver.Companion.fhirModelNamespaceUri
 import org.opencds.cqf.cql.engine.runtime.Boolean
 import org.opencds.cqf.cql.engine.runtime.ClassInstance
@@ -241,19 +242,23 @@ class FhirModelResolverTest {
 
             assertEquals(
                 ClassInstance(
-                    QName(fhirModelNamespaceUri, "string"),
+                    QName(fhirModelNamespaceUri, "string", fhirModelId),
                     mutableMapOf(
                         "id" to null,
                         "extension" to
                             listOf(
                                     ClassInstance(
-                                        QName(fhirModelNamespaceUri, "Extension"),
+                                        QName(fhirModelNamespaceUri, "Extension", fhirModelId),
                                         mutableMapOf(
                                             "id" to null,
                                             "extension" to null,
                                             "value" to
                                                 ClassInstance(
-                                                    QName(fhirModelNamespaceUri, "string"),
+                                                    QName(
+                                                        fhirModelNamespaceUri,
+                                                        "string",
+                                                        fhirModelId,
+                                                    ),
                                                     mutableMapOf(
                                                         "id" to null,
                                                         "extension" to null,
@@ -262,7 +267,11 @@ class FhirModelResolverTest {
                                                 ),
                                             "url" to
                                                 ClassInstance(
-                                                    QName(fhirModelNamespaceUri, "uri"),
+                                                    QName(
+                                                        fhirModelNamespaceUri,
+                                                        "uri",
+                                                        fhirModelId,
+                                                    ),
                                                     mutableMapOf(
                                                         "id" to null,
                                                         "extension" to null,
@@ -318,7 +327,7 @@ class FhirModelResolverTest {
 
             assertEquals(
                 ClassInstance(
-                    QName(fhirModelNamespaceUri, "string"),
+                    QName(fhirModelNamespaceUri, "string", fhirModelId),
                     mutableMapOf(
                         "id" to stringId.toCqlString(),
                         "extension" to null,
@@ -351,7 +360,7 @@ class FhirModelResolverTest {
 
             assertEquals(
                 ClassInstance(
-                    QName(fhirModelNamespaceUri, "NameUse"),
+                    QName(fhirModelNamespaceUri, "NameUse", fhirModelId),
                     mutableMapOf(
                         "id" to null,
                         "extension" to null,
@@ -399,7 +408,7 @@ class FhirModelResolverTest {
 
             assertEquals(
                 ClassInstance(
-                    QName(fhirModelNamespaceUri, "NameUse"),
+                    QName(fhirModelNamespaceUri, "NameUse", fhirModelId),
                     mutableMapOf(
                         "id" to elementId.toCqlString(),
                         "extension" to null,

--- a/Src/java/engine/detekt-baseline.xml
+++ b/Src/java/engine/detekt-baseline.xml
@@ -106,7 +106,7 @@
     <ID>LongMethod:CqlTypesOperatorsTest.kt$CqlTypesOperatorsTest$@ParameterizedTest @MethodSource("timezones") fun all_types_operators(timezone: String?)</ID>
     <ID>LongMethod:CqlTypesTest.kt$CqlTypesTest$@Test fun all_types()</ID>
     <ID>LongMethod:CqlValueLiteralsAndSelectorsTest.kt$CqlValueLiteralsAndSelectorsTest$@Test fun all_value_literals_and_selectors()</ID>
-    <ID>LongMethod:DateTime.kt$DateTime$override fun toString(): kotlin.String</ID>
+    <ID>LongMethod:DateTime.kt$DateTime$override fun toStringInner(): kotlin.String</ID>
     <ID>LongMethod:DateTimeTest.kt$DateTimeTest$@Test fun bigDecimal()</ID>
     <ID>LongMethod:DateTimeTest.kt$DateTimeTest$@Test fun dateStringsOtherZoneIdTest()</ID>
     <ID>LongMethod:DateTimeTest.kt$DateTimeTest$@Test fun dateStringsTest()</ID>
@@ -135,6 +135,7 @@
     <ID>LongMethod:SameAsEvaluator.kt$SameAsEvaluator$@JvmStatic fun sameAs(left: Value?, right: Value?, precision: kotlin.String?, state: State?): Boolean?</ID>
     <ID>LongMethod:SuccessorEvaluator.kt$SuccessorEvaluator$@JvmStatic fun successor(value: Value?): Value?</ID>
     <ID>LongMethod:TemporalHelper.kt$TemporalHelper$fun truncateValueToTargetPrecision( value: kotlin.Long, precision: Precision, targetPrecision: Precision?, ): kotlin.Long</ID>
+    <ID>LongMethod:ToCvlTest.kt$ToCvlTest$@Test fun systemStructuredValueToCvlTest()</ID>
     <ID>LongParameterList:DateTimeEvaluator.kt$DateTimeEvaluator$( year: Value?, month: Value?, day: Value?, hour: Value?, minute: Value?, second: Value?, milliSecond: Value?, timeZoneOffset: Value?, )</ID>
     <ID>LongParameterList:MessageEvaluator.kt$MessageEvaluator$( state: State?, sourceLocator: SourceLocator?, source: Value?, condition: Boolean?, code: String?, severity: String?, message: String?, )</ID>
     <ID>LongParameterList:Profile.kt$Profile.Node$( sink: Sink, i: Int, x: Double, depth: Int, scaleX: Double, scaleY: Double, )</ID>
@@ -244,7 +245,6 @@
     <ID>MaxLineLength:FirstEvaluator.kt$FirstEvaluator$/* First(argument List&lt;T>) T The First operator returns the first element in a list. The operator is equivalent to invoking the indexer with an index of 0. If the argument is null, the result is null. */</ID>
     <ID>MaxLineLength:FunctionRefEvaluator.kt$FunctionRefEvaluator$"Ambiguous call to operator '${name}(${types})' in library '${state!!.getCurrentLibrary()!!.identifier!!.id}'."</ID>
     <ID>MaxLineLength:FunctionRefEvaluator.kt$FunctionRefEvaluator$"Could not resolve call to operator '${name}(${types})' in library '${state!!.getCurrentLibrary()!!.identifier!!.id}'."</ID>
-    <ID>MaxLineLength:FunctionRefEvaluatorTest.kt$FunctionRefEvaluatorTest$"Could not resolve call to operator 'func({urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}Integer)' in library 'lib'."</ID>
     <ID>MaxLineLength:GreaterEvaluator.kt$GreaterEvaluator$"Greater(Integer, Integer), Greater(Long, Long), Greater(Decimal, Decimal), Greater(Quantity, Quantity), Greater(Date, Date), Greater(DateTime, DateTime), Greater(Time, Time) or Greater(String, String)"</ID>
     <ID>MaxLineLength:GreaterEvaluator.kt$GreaterEvaluator$/* >(left Integer, right Integer) Boolean >(left Long, right Long) Boolean >(left Decimal, right Decimal) Boolean >(left Quantity, right Quantity) Boolean >(left Date, right Date) Boolean >(left DateTime, right DateTime) Boolean >(left Time, right Time) Boolean >(left String, right String) Boolean The greater (>) operator returns true if the first argument is greater than the second argument. String comparisons are strictly lexical based on the Unicode value of the individual characters in the string. For comparisons involving quantities, the dimensions of each quantity must be the same, but not necessarily the unit. For example, units of 'cm' and 'm' are comparable, but units of 'cm2' and 'cm' are not. Attempting to operate on quantities with invalid units will result in a null. When a quantity has no units specified, it is treated as a quantity with the default unit ('1'). For date/time values, the comparison is performed by considering each precision in order, beginning with years (or hours for time values). If the values are the same, comparison proceeds to the next precision; if the first value is greater than the second, the result is true; if the first value is less than the second, the result is false; if one input has a value for the precision and the other does not, the comparison stops and the result is null; if neither input has a value for the precision or the last precision has been reached, the comparison stops and the result is false. For example: define DateTimeGreaterIsNull: @2012-01-01 > @2012-01-01T12 If either argument is null, the result is null. */</ID>
     <ID>MaxLineLength:GreaterOrEqualEvaluator.kt$GreaterOrEqualEvaluator$"GreaterOrEqual(Integer, Integer), GreaterOrEqual(Long, Long), GreaterOrEqual(Decimal, Decimal), GreaterOrEqual(Quantity, Quantity), GreaterOrEqual(Date, Date), GreaterOrEqual(DateTime, DateTime), GreaterOrEqual(Time, Time) or GreaterOrEqual(String, String)"</ID>
@@ -357,6 +357,7 @@
     <ID>ObjectPropertyNaming:CqlEngineMultipleLibrariesTest.kt$CqlEngineMultipleLibrariesTest.Companion$private val _2031_01_01 = DateTime("2031-01-01", ZoneOffset.UTC)</ID>
     <ID>ObjectPropertyNaming:CqlEngineMultipleLibrariesTest.kt$CqlEngineMultipleLibrariesTest.Companion$private val _2031_01_01_TO_2032_01_01 = Interval(_2031_01_01, true, _2032_01_01, false)</ID>
     <ID>ObjectPropertyNaming:CqlEngineMultipleLibrariesTest.kt$CqlEngineMultipleLibrariesTest.Companion$private val _2032_01_01 = DateTime("2032-01-01", ZoneOffset.UTC)</ID>
+    <ID>OptionalAbstractKeyword:Value.kt$Value$abstract</ID>
     <ID>ProtectedMemberInFinalClass:Cache.kt$Cache$protected fun constructLibraryExpressionHashMap(): MutableMap&lt;String?, ExpressionResult?></ID>
     <ID>ProtectedMemberInFinalClass:Cache.kt$Cache$protected fun getExpressionCache( libraryId: VersionedIdentifier? ): MutableMap&lt;String?, ExpressionResult?>?</ID>
     <ID>ReturnCount:AfterEvaluator.kt$AfterEvaluator$@JvmStatic fun after(left: Value?, right: Value?, precision: String?, state: State?): Boolean?</ID>
@@ -389,7 +390,7 @@
     <ID>ReturnCount:DateTime.kt$DateTime$@JsExport.Ignore override fun compareToPrecision(other: BaseTemporal, p: Precision): Int?</ID>
     <ID>ReturnCount:DateTime.kt$DateTime$@JsExport.Ignore override fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal</ID>
     <ID>ReturnCount:DateTime.kt$DateTime$override fun compare(other: BaseTemporal, forSort: kotlin.Boolean): Int?</ID>
-    <ID>ReturnCount:DateTime.kt$DateTime$override fun toString(): kotlin.String</ID>
+    <ID>ReturnCount:DateTime.kt$DateTime$override fun toStringInner(): kotlin.String</ID>
     <ID>ReturnCount:DateTimeComponentFromEvaluator.kt$DateTimeComponentFromEvaluator$@JvmStatic fun dateTimeComponentFrom(operand: Value?, precision: kotlin.String?): Integer?</ID>
     <ID>ReturnCount:DecimalHelper.kt$DecimalHelper$fun validateDecimal(ret: BigDecimal, targetScale: Int?): BigDecimal?</ID>
     <ID>ReturnCount:DifferenceBetweenEvaluator.kt$DifferenceBetweenEvaluator$@JvmStatic fun difference(left: Value?, right: Value?, precision: Precision): Value?</ID>
@@ -491,7 +492,6 @@
     <ID>ReturnCount:ToQuantityEvaluator.kt$ToQuantityEvaluator$@JvmStatic fun toQuantity(operand: Value?, state: State?): Quantity?</ID>
     <ID>ReturnCount:ToQuantityEvaluator.kt$ToQuantityEvaluator$private fun setValue(quantity: Quantity, str: kotlin.String): Quantity?</ID>
     <ID>ReturnCount:ToRatioEvaluator.kt$ToRatioEvaluator$@JvmStatic fun toRatio(operand: Value?): Ratio?</ID>
-    <ID>ReturnCount:ToStringEvaluator.kt$ToStringEvaluator$@JvmStatic fun toString(operand: Value?): String?</ID>
     <ID>ReturnCount:ToTimeEvaluator.kt$ToTimeEvaluator$@JvmStatic fun toTime(operand: Value?): Time?</ID>
     <ID>ReturnCount:TruncateEvaluator.kt$TruncateEvaluator$@JvmStatic fun truncate(operand: Value?): Integer?</ID>
     <ID>ReturnCount:TruncatedDivideEvaluator.kt$TruncatedDivideEvaluator$@JvmStatic fun div(left: Value?, right: Value?, state: State?): Value?</ID>
@@ -567,6 +567,7 @@
     <ID>TooManyFunctions:TimeJs.kt$OffsetDateTimeJs : TemporalJs</ID>
     <ID>TooManyFunctions:TimeJs.kt$org.opencds.cqf.cql.engine.util.TimeJs.kt</ID>
     <ID>TooManyFunctions:TimeJvm.kt$org.opencds.cqf.cql.engine.util.TimeJvm.kt</ID>
+    <ID>TopLevelPropertyNaming:NamedTypeValue.kt$const val systemModelId = "System"</ID>
     <ID>TopLevelPropertyNaming:NamedTypeValue.kt$const val systemModelNamespaceUri = "urn:hl7-org:elm-types:r1"</ID>
     <ID>UnusedParameter:LengthEvaluator.kt$LengthEvaluator$state: State?</ID>
     <ID>UnusedParameter:NullEvaluator.kt$NullEvaluator$state: State?</ID>

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/PrecisionEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/PrecisionEvaluator.kt
@@ -44,15 +44,15 @@ object PrecisionEvaluator {
             val index = string.indexOf(".")
             return (if (index < 0) 0 else string.length - index - 1).toCqlInteger()
         } else if (argument is Date) {
-            return argument.toString().replace("-".toRegex(), "").length.toCqlInteger()
+            return argument.toStringInner().replace("-".toRegex(), "").length.toCqlInteger()
         } else if (argument is DateTime) {
             return argument
-                .toString()
+                .toStringInner()
                 .replace("(:?[+-][0-9]{2}:[0-9]{2}$|[T.:-]|)".toRegex(), "")
                 .length
                 .toCqlInteger()
         } else if (argument is Time) {
-            return argument.toString().replace("[T.:]".toRegex(), "").length.toCqlInteger()
+            return argument.toStringInner().replace("[T.:]".toRegex(), "").length.toCqlInteger()
         }
 
         throw InvalidOperatorArgument(

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ToStringEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ToStringEvaluator.kt
@@ -30,7 +30,7 @@ The ToString operator converts the value of its argument to a String value.
 The operator uses the following string representations for each type:
 Boolean	true|false
 Integer	    (-)?#0
-Long	    (-)?#0L
+Long	    (-)?#0
 Decimal	    (-)?#0.0#
 Quantity    (-)?#0.0# '<unit>'
 Ratio       <quantity>:<quantity>
@@ -43,34 +43,19 @@ If the argument is null, the result is null.
 object ToStringEvaluator {
     @JvmStatic
     fun toString(operand: Value?): String? {
-        if (operand == null) {
-            return null
-        }
-
-        if (operand is String) {
-            return operand
-        }
-
-        if (operand is Integer) {
-            return operand.value.toString().toCqlString()
-        } else if (operand is Long) {
-            return operand.value.toString().toCqlString()
-        } else if (operand is Decimal) {
-            return operand.value.toString().toCqlString()
-        } else if (operand is Quantity) {
-            return operand.toString().toCqlString()
-        } else if (operand is Ratio) {
-            return operand.toString().toCqlString()
-        } else if (operand is Boolean) {
-            return operand.value.toString().toCqlString()
-        } else if (operand is Date) {
-            return operand.toString().toCqlString()
-        } else if (operand is DateTime) {
-            return operand.toString().toCqlString()
-        } else if (operand is Time) {
-            return operand.toString().toCqlString()
-        } else {
-            return operand.toString().toCqlString()
+        return when (operand) {
+            null -> null
+            is Boolean -> operand.value.toString().toCqlString()
+            is Integer -> operand.value.toString().toCqlString()
+            is Long -> operand.value.toString().toCqlString()
+            is Decimal -> operand.value.toPlainString().toCqlString()
+            is Quantity,
+            is Ratio -> operand.toString().toCqlString()
+            is Date,
+            is DateTime,
+            is Time -> operand.toStringInner().toCqlString()
+            is String -> operand
+            else -> operand.toString().toCqlString()
         }
     }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
@@ -36,7 +36,10 @@ interface ModelResolver {
     fun `is`(valueType: String, type: QName): kotlin.Boolean?
 
     /**
-     * Create an instance of the model object that corresponds to the specified type.
+     * Create an instance of the model object that corresponds to the specified type. If the result
+     * is a [ClassInstance], the model URI (e.g. "http://hl7.org/fhir") and identifier (model
+     * qualifier, e.g. "FHIR") must be included in the `namespaceURI` and `prefix` of the type
+     * [QName] respectively.
      *
      * @param typeName Model type to create
      * @return new instance of the specified model type

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
@@ -34,6 +34,9 @@ sealed class BaseTemporal : SimpleValue, Comparable<BaseTemporal> {
     @JsExport.Ignore
     abstract fun roundToPrecision(precision: Precision, useCeiling: kotlin.Boolean): BaseTemporal?
 
+    /** Returns the string representation of the temporal value without the leading `@` or `@T`. */
+    abstract fun toStringInner(): kotlin.String
+
     companion object {
         fun getHighestPrecision(vararg values: BaseTemporal?): kotlin.String {
             var max = -1

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
@@ -13,8 +13,4 @@ import org.cqframework.cql.shared.QName
 class ClassInstance(
     override val type: QName,
     override val elements: MutableMap<kotlin.String, Value?>,
-) : StructuredValue(), NamedTypeValue {
-    override fun toString(): kotlin.String {
-        return toPrettyString(type.toString())
-    }
-}
+) : StructuredValue(), NamedTypeValue

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
@@ -44,8 +44,4 @@ class Code : StructuredValue(), NamedTypeValue {
         this.version = version
         return this
     }
-
-    override fun toString(): kotlin.String {
-        return "Code { code: ${this.code}, system: ${this.system}, version: ${this.version}, display: ${this.display} }"
-    }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
@@ -38,8 +38,4 @@ class Concept : StructuredValue(), NamedTypeValue {
         codes!!.add(code!!)
         return this
     }
-
-    override fun toString(): kotlin.String {
-        return toPrettyString("Concept")
-    }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
@@ -229,18 +229,22 @@ class Date : BaseTemporal {
         return this.compare(other, true)!!
     }
 
-    override fun toString(): kotlin.String {
+    override fun toStringInner(): kotlin.String {
         return when (precision) {
             Precision.YEAR -> date!!.getYear().toPaddedString(4)
             Precision.MONTH ->
                 "${date!!.getYear().toPaddedString(4)}-${date!!.getMonthValue().toPaddedString(2)}"
             else ->
                 "${
-                date!!.getYear().toPaddedString(4)
-            }-${
-                date!!.getMonthValue().toPaddedString(2)
-            }-${date!!.getDayOfMonth().toPaddedString(2)}"
+                    date!!.getYear().toPaddedString(4)
+                }-${
+                    date!!.getMonthValue().toPaddedString(2)
+                }-${date!!.getDayOfMonth().toPaddedString(2)}"
         }
+    }
+
+    override fun toString(): kotlin.String {
+        return "@${toStringInner()}"
     }
 
     @JvmOverloads

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
@@ -333,7 +333,7 @@ class DateTime : BaseTemporal {
         return result
     }
 
-    override fun toString(): kotlin.String {
+    override fun toStringInner(): kotlin.String {
         when (precision) {
             Precision.YEAR -> return dateTime!!.getYear().toPaddedString(4)
             Precision.MONTH ->
@@ -409,6 +409,10 @@ class DateTime : BaseTemporal {
                 }"
             }
         }
+    }
+
+    override fun toString(): kotlin.String {
+        return "@${toStringInner()}"
     }
 
     // conversion functions

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
@@ -12,6 +12,14 @@ data class List(val value: Iterable<Value?>) : Value, Iterable<Value?> by value 
     companion object {
         val EMPTY_LIST = List(emptyList())
     }
+
+    override fun toString(): kotlin.String {
+        if (value.count() == 0) {
+            return "{}"
+        }
+
+        return "{\n" + value.joinToString(",\n") { "$it".prependIndent("  ") } + "\n}"
+    }
 }
 
 fun Iterable<Value?>.toCqlList() = List(this)

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
@@ -9,29 +9,32 @@ import org.cqframework.cql.shared.QName
 
 sealed interface NamedTypeValue : Value {
     override val typeAsString: kotlin.String
-        get() = type.toString()
+        get() =
+            if (type.getNamespaceURI() == systemModelNamespaceUri) type.getLocalPart()
+            else "${type.getPrefix()}.${type.getLocalPart()}"
 
     val type: QName
 }
 
 const val systemModelNamespaceUri = "urn:hl7-org:elm-types:r1"
+const val systemModelId = "System"
 
-val anyTypeName = QName(systemModelNamespaceUri, "Any")
-val booleanTypeName = QName(systemModelNamespaceUri, "Boolean")
-val integerTypeName = QName(systemModelNamespaceUri, "Integer")
-val longTypeName = QName(systemModelNamespaceUri, "Long")
-val decimalTypeName = QName(systemModelNamespaceUri, "Decimal")
-val stringTypeName = QName(systemModelNamespaceUri, "String")
-val dateTypeName = QName(systemModelNamespaceUri, "Date")
-val dateTimeTypeName = QName(systemModelNamespaceUri, "DateTime")
-val timeTypeName = QName(systemModelNamespaceUri, "Time")
-val quantityTypeName = QName(systemModelNamespaceUri, "Quantity")
-val ratioTypeName = QName(systemModelNamespaceUri, "Ratio")
-val codeTypeName = QName(systemModelNamespaceUri, "Code")
-val conceptTypeName = QName(systemModelNamespaceUri, "Concept")
-val codeSystemTypeName = QName(systemModelNamespaceUri, "CodeSystem")
-val valueSetTypeName = QName(systemModelNamespaceUri, "ValueSet")
-val vocabularyTypeName = QName(systemModelNamespaceUri, "Vocabulary")
+val anyTypeName = QName(systemModelNamespaceUri, "Any", systemModelId)
+val booleanTypeName = QName(systemModelNamespaceUri, "Boolean", systemModelId)
+val integerTypeName = QName(systemModelNamespaceUri, "Integer", systemModelId)
+val longTypeName = QName(systemModelNamespaceUri, "Long", systemModelId)
+val decimalTypeName = QName(systemModelNamespaceUri, "Decimal", systemModelId)
+val stringTypeName = QName(systemModelNamespaceUri, "String", systemModelId)
+val dateTypeName = QName(systemModelNamespaceUri, "Date", systemModelId)
+val dateTimeTypeName = QName(systemModelNamespaceUri, "DateTime", systemModelId)
+val timeTypeName = QName(systemModelNamespaceUri, "Time", systemModelId)
+val quantityTypeName = QName(systemModelNamespaceUri, "Quantity", systemModelId)
+val ratioTypeName = QName(systemModelNamespaceUri, "Ratio", systemModelId)
+val codeTypeName = QName(systemModelNamespaceUri, "Code", systemModelId)
+val conceptTypeName = QName(systemModelNamespaceUri, "Concept", systemModelId)
+val codeSystemTypeName = QName(systemModelNamespaceUri, "CodeSystem", systemModelId)
+val valueSetTypeName = QName(systemModelNamespaceUri, "ValueSet", systemModelId)
+val vocabularyTypeName = QName(systemModelNamespaceUri, "Vocabulary", systemModelId)
 
 /**
  * Returns the type as a `QName` for instances of named types. Returns null for intervals, lists,

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
@@ -2,6 +2,7 @@ package org.opencds.cqf.cql.engine.runtime
 
 import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmStatic
+import org.cqframework.cql.cql2elm.StringEscapeUtils.escapeCql
 import org.cqframework.cql.shared.BigDecimal
 import org.cqframework.cql.shared.JsOnlyExport
 
@@ -47,7 +48,7 @@ class Quantity : StructuredValue(), NamedTypeValue, Comparable<Quantity> {
     }
 
     override fun toString(): kotlin.String {
-        return "${this.value} '${this.unit}'"
+        return this.value?.toPlainString() + " " + this.unit?.let { "'${escapeCql(it)}'" }
     }
 
     companion object {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
@@ -26,6 +26,6 @@ class Ratio : StructuredValue(), NamedTypeValue {
     }
 
     override fun toString(): kotlin.String {
-        return "${this.numerator.toString()}:${this.denominator.toString()}"
+        return "${this.numerator}:${this.denominator}"
     }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
@@ -3,6 +3,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
 import kotlin.js.ExperimentalJsExport
+import org.cqframework.cql.cql2elm.StringEscapeUtils.escapeCql
 import org.cqframework.cql.shared.BigDecimal
 import org.cqframework.cql.shared.JsOnlyExport
 
@@ -36,21 +37,21 @@ data class Integer(val value: Int) : SimpleValue {
 data class Long(val value: kotlin.Long) : SimpleValue {
     override val type = longTypeName
 
-    override fun toString() = value.toString()
+    override fun toString() = "${value}L"
 }
 
 @JsOnlyExport
 data class Decimal(val value: BigDecimal) : SimpleValue {
     override val type = decimalTypeName
 
-    override fun toString() = value.toString()
+    override fun toString() = value.toPlainString()
 }
 
 @JsOnlyExport
 data class String(val value: kotlin.String) : SimpleValue, CharSequence by value {
     override val type = stringTypeName
 
-    override fun toString() = value
+    override fun toString() = "'${escapeCql(value)}'"
 
     companion object {
         val EMPTY_STRING = String("")

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
@@ -2,7 +2,6 @@ package org.opencds.cqf.cql.engine.runtime
 
 import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
-import org.opencds.cqf.cql.engine.elm.executing.ToStringEvaluator.toString
 
 /** Represents a structured CQL value. */
 @OptIn(ExperimentalJsExport::class)
@@ -25,22 +24,6 @@ sealed class StructuredValue : Value {
         return elements[elementName]
     }
 
-    /** Returns a string representation of the elements of the structured value. */
-    protected fun toPrettyString(label: kotlin.String): kotlin.String {
-        if (elements.isEmpty()) {
-            return "$label {}"
-        }
-
-        return buildString {
-            appendLine("$label {")
-            for ((key, value) in elements) {
-                // append valueString and indent its every line
-                appendLine("$key: ${toString(value)}".prependIndent("  "))
-            }
-            append("}")
-        }
-    }
-
     override fun equals(other: Any?): kotlin.Boolean {
         if (this === other) return true
         if (other !is StructuredValue) return false
@@ -59,5 +42,15 @@ sealed class StructuredValue : Value {
         var result = if (this is NamedTypeValue) type.hashCode() else 0
         result = 31 * result + elements.hashCode()
         return result
+    }
+
+    override fun toString(): kotlin.String {
+        if (elements.isEmpty()) {
+            return "$typeAsString { : }"
+        }
+
+        return "$typeAsString {\n" +
+            elements.entries.joinToString(",\n") { "${it.key}: ${it.value}".prependIndent("  ") } +
+            "\n}"
     }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
@@ -218,7 +218,7 @@ class Time : BaseTemporal {
         return this.compare(other, true)!!
     }
 
-    override fun toString(): kotlin.String {
+    override fun toStringInner(): kotlin.String {
         return when (precision) {
             Precision.HOUR -> time.getHour().toPaddedString(2)
             Precision.MINUTE ->
@@ -232,5 +232,9 @@ class Time : BaseTemporal {
                 time.getSecond().toPaddedString(2)
                 }.${time.get(precision!!.toChronoField()).toPaddedString(3)}"
         }
+    }
+
+    override fun toString(): kotlin.String {
+        return "@T${toStringInner()}"
     }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
@@ -16,8 +16,4 @@ class Tuple : StructuredValue() {
         this.elements.putAll(elements)
         return this
     }
-
-    override fun toString(): kotlin.String {
-        return toPrettyString("Tuple")
-    }
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Value.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Value.kt
@@ -3,8 +3,12 @@ package org.opencds.cqf.cql.engine.runtime
 import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
+/** Represents a non-null CQL value. */
 @OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 sealed interface Value {
     val typeAsString: kotlin.String
+
+    /** Returns the CVL representation of the CQL value. */
+    abstract override fun toString(): kotlin.String
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
@@ -34,18 +34,10 @@ class ValueSet : Vocabulary() {
     }
 
     var codeSystems = mutableListOf<CodeSystem>()
-        private set
 
     @Suppress("NON_EXPORTABLE_TYPE")
     fun setCodeSystems(codeSystems: Iterable<CodeSystem?>?) {
-        this.codeSystems = mutableListOf()
-        if (codeSystems != null) {
-            for (cs in codeSystems) {
-                if (cs != null) {
-                    addCodeSystem(cs)
-                }
-            }
-        }
+        this.codeSystems = codeSystems?.filterNotNull()?.toMutableList() ?: mutableListOf()
     }
 
     fun withCodeSystems(codeSystems: MutableList<CodeSystem?>?): ValueSet {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
@@ -11,8 +11,4 @@ sealed class Vocabulary : StructuredValue(), NamedTypeValue {
     var version: kotlin.String? = null
 
     var name: kotlin.String? = null
-
-    override fun toString(): kotlin.String {
-        return toPrettyString(type.getLocalPart())
-    }
 }

--- a/Src/java/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/runtime/ToCvlTest.kt
+++ b/Src/java/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/runtime/ToCvlTest.kt
@@ -1,0 +1,186 @@
+package org.opencds.cqf.cql.engine.runtime
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.cqframework.cql.shared.BigDecimal
+import org.cqframework.cql.shared.QName
+
+class ToCvlTest {
+    @Test
+    fun simpleValueToCvlTest() {
+        assertEquals("true", Boolean.TRUE.toString())
+        assertEquals("123", 123.toCqlInteger().toString())
+        assertEquals("123L", 123L.toCqlLong().toString())
+        assertEquals("1.0", BigDecimal("1.0").toCqlDecimal().toString())
+    }
+
+    @Test
+    fun stringToCvlTest() {
+        assertEquals("'abc'", "abc".toCqlString().toString())
+        assertEquals("'abc\\'def'", "abc'def".toCqlString().toString())
+    }
+
+    @Test
+    fun dateTimeToCvlTest() {
+        assertEquals("@2012-06-01", Date(2012, 6, 1).toString())
+        assertEquals(
+            "@2012-06-01T12:34:56.789+00:00",
+            DateTime(BigDecimal("0.0"), 2012, 6, 1, 12, 34, 56, 789).toString(),
+        )
+        assertEquals("@T12:34:56.789", Time(12, 34, 56, 789).toString())
+    }
+
+    @Test
+    fun systemStructuredValueToCvlTest() {
+        assertEquals(
+            "5.0 'g'",
+            Quantity()
+                .apply {
+                    value = BigDecimal("5.0")
+                    unit = "g"
+                }
+                .toString(),
+        )
+        assertEquals(
+            "1.0 'mg':2.0 'mg'",
+            Ratio()
+                .apply {
+                    numerator =
+                        Quantity().apply {
+                            value = BigDecimal("1.0")
+                            unit = "mg"
+                        }
+                    denominator =
+                        Quantity().apply {
+                            value = BigDecimal("2.0")
+                            unit = "mg"
+                        }
+                }
+                .toString(),
+        )
+        assertEquals(
+            """
+            ValueSet {
+              id: 'exampleVsId',
+              version: '1.0.0',
+              name: 'exampleVsName',
+              codesystems: {
+                CodeSystem {
+                  id: 'exampleCsId',
+                  version: '2.0.0',
+                  name: 'exampleCsName'
+                }
+              }
+            }
+        """
+                .trimIndent(),
+            ValueSet()
+                .apply {
+                    id = "exampleVsId"
+                    version = "1.0.0"
+                    name = "exampleVsName"
+                    codeSystems =
+                        mutableListOf(
+                            CodeSystem().apply {
+                                id = "exampleCsId"
+                                version = "2.0.0"
+                                name = "exampleCsName"
+                            }
+                        )
+                }
+                .toString(),
+        )
+    }
+
+    @Test
+    fun classInstanceToCvlTest() {
+        assertEquals(
+            "ExampleModel.ExampleClass { : }",
+            ClassInstance(
+                    QName("http://example.org", "ExampleClass", "ExampleModel"),
+                    mutableMapOf(),
+                )
+                .toString(),
+        )
+        assertEquals(
+            """
+            ExampleModel.ExampleClass {
+              field1: 123,
+              field2: 'abc',
+              field3: null
+            }
+        """
+                .trimIndent(),
+            ClassInstance(
+                    QName("http://example.org", "ExampleClass", "ExampleModel"),
+                    mutableMapOf(
+                        "field1" to 123.toCqlInteger(),
+                        "field2" to "abc".toCqlString(),
+                        "field3" to null,
+                    ),
+                )
+                .toString(),
+        )
+    }
+
+    @Test
+    fun tupleToCvlTest() {
+        assertEquals("Tuple { : }", Tuple().toString())
+        assertEquals(
+            """
+            Tuple {
+              field1: 123,
+              field2: 'abc',
+              field3: null
+            }
+        """
+                .trimIndent(),
+            Tuple()
+                .withElements(
+                    mutableMapOf(
+                        "field1" to 123.toCqlInteger(),
+                        "field2" to "abc".toCqlString(),
+                        "field3" to null,
+                    )
+                )
+                .toString(),
+        )
+    }
+
+    @Test
+    fun listToCvlTest() {
+        assertEquals("{}", List.EMPTY_LIST.toString())
+        assertEquals(
+            """
+            {
+              123,
+              'abc',
+              null
+            }
+        """
+                .trimIndent(),
+            listOf(123.toCqlInteger(), "abc".toCqlString(), null).toCqlList().toString(),
+        )
+    }
+
+    @Test
+    fun intervalToCvlTest() {
+        assertEquals(
+            "Interval[1, 2)",
+            Interval(1.toCqlInteger(), true, 2.toCqlInteger(), false).toString(),
+        )
+        assertEquals(
+            "Interval[5.0 'g', null)",
+            Interval(
+                    Quantity().apply {
+                        value = BigDecimal("5.0")
+                        unit = "g"
+                    },
+                    true,
+                    null,
+                    false,
+                )
+                .toString(),
+        )
+    }
+}

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluatorTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluatorTest.kt
@@ -33,7 +33,7 @@ internal class FunctionRefEvaluatorTest {
                 )
             }
         Assertions.assertEquals(
-            "Could not resolve call to operator 'func({urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}Integer)' in library 'lib'.",
+            "Could not resolve call to operator 'func(Integer, Integer, Integer)' in library 'lib'.",
             cqlException.message,
         )
     }

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BacktraceTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BacktraceTest.kt
@@ -89,7 +89,7 @@ class BacktraceTest : CqlTestBase() {
         assertEquals(
             """
             BacktraceTest.E2
-              BacktraceTest.G(Y = 2, Z = hi)
+              BacktraceTest.G(Y = 2, Z = 'hi')
                 BacktraceTest.F(X = 3)
                   Message
 

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/RuntimeTests.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/RuntimeTests.kt
@@ -11,25 +11,8 @@ import org.opencds.cqf.cql.engine.elm.executing.EqualEvaluator
 import org.opencds.cqf.cql.engine.elm.executing.WidthEvaluator
 import org.opencds.cqf.cql.engine.runtime.Interval
 import org.opencds.cqf.cql.engine.runtime.Quantity
-import org.opencds.cqf.cql.engine.runtime.Tuple
-import org.opencds.cqf.cql.engine.runtime.toCqlInteger
 
 internal class RuntimeTests {
-    @Test
-    fun quantityToString() {
-        var q = Quantity().withValue(null).withUnit(null)
-        assertEquals("null 'null'", q.toString())
-
-        q = Quantity()
-        assertEquals("0.0 '1'", q.toString())
-
-        q = Quantity().withValue(BigDecimal("1.0")).withUnit("g")
-        assertEquals("1.0 'g'", q.toString())
-
-        q = Quantity().withValue(BigDecimal("0.05")).withUnit("mg")
-        assertEquals("0.05 'mg'", q.toString())
-    }
-
     @Test
     fun intervalOfQuantityWithDifferentUOM() {
         val modelManager = ModelManager()
@@ -53,17 +36,6 @@ internal class RuntimeTests {
                 )
                 ?.value,
         )
-    }
-
-    @Test
-    fun tupleToString() {
-        var t = Tuple()
-        assertEquals("Tuple {}", t.toString())
-
-        t = Tuple()
-        t.elements["id"] = 1.toCqlInteger()
-        t.elements["value"] = Quantity().withValue(BigDecimal("1.0")).withUnit("g")
-        assertEquals("Tuple {\n  id: 1\n  value: 1.0 'g'\n}", t.toString())
     }
 
     @Test


### PR DESCRIPTION
Closes #1781.

* `Value.toString()` returns the CVL representation of the CQL value.
* CQL strings are escaped and wrapped in single quotes to output proper CVL, e.g. `'abc\'abc'`.
* Dates and times are prepended with `@` and `@T`, respectively.
* CQL decimals are stringified as plain values (without using scientific or exponential notation) which is consistent with the CVL syntax.
* For class instances, the type label includes the model identifier (model qualifier), e.g. `FHIR.Patient { : }`.