### PR TITLE
Feature/add debugger support

### DIFF
--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointAction.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointAction.kt
@@ -1,0 +1,6 @@
+package org.opencds.cqf.cql.engine.debug
+
+enum class BreakpointAction {
+    CONTINUE,
+    PAUSE,
+}

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
@@ -6,8 +6,12 @@ import org.opencds.cqf.cql.engine.execution.State
 
 interface BreakpointHandler {
     fun onBeforeExpression(elm: Element, state: State): BreakpointAction
+
     fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+
     fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {}
+
     fun waitForResume() {}
+
     fun release() {}
 }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
@@ -1,0 +1,13 @@
+package org.opencds.cqf.cql.engine.debug
+
+import org.hl7.elm.r1.Element
+import org.hl7.elm.r1.ExpressionDef
+import org.opencds.cqf.cql.engine.execution.State
+
+interface BreakpointHandler {
+    fun onBeforeExpression(elm: Element, state: State): BreakpointAction
+    fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+    fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {}
+    fun waitForResume() {}
+    fun release() {}
+}

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/debug/BreakpointHandler.kt
@@ -11,6 +11,8 @@ interface BreakpointHandler {
 
     fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {}
 
+    fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {}
+
     fun waitForResume() {}
 
     fun release() {}

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluator.kt
@@ -24,6 +24,8 @@ object FunctionRefEvaluator {
             arguments.add(visitor.visitExpression(operand, state))
         }
 
+        state?.currentCallSite = functionRef
+
         val enteredLibrary = state!!.enterLibrary(functionRef.libraryName)
         try {
             val functionDef = resolveOrCacheFunctionDef(state, functionRef, arguments)
@@ -45,6 +47,8 @@ object FunctionRefEvaluator {
                 .getExternalFunctionProvider(state.getCurrentLibrary()!!.identifier)
                 .evaluate(functionDef.name, arguments)
         } else {
+            state.breakpointHandler?.onExpressionDefEntered(functionDef, state.currentCallSite, state)
+
             // Establish activation frame with the function
             // definition being evaluated.
             state.pushActivationFrame(functionDef, functionDef.context!!)
@@ -54,6 +58,7 @@ object FunctionRefEvaluator {
                 }
                 val result = visitor.visitExpression(functionDef.expression!!, state)
                 state.storeIntermediateResultForTracing(result)
+                state.breakpointHandler?.onExpressionDefEvaluated(functionDef, state, result)
                 return result
             } finally {
                 state.popActivationFrame()

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluator.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/FunctionRefEvaluator.kt
@@ -47,7 +47,11 @@ object FunctionRefEvaluator {
                 .getExternalFunctionProvider(state.getCurrentLibrary()!!.identifier)
                 .evaluate(functionDef.name, arguments)
         } else {
-            state.breakpointHandler?.onExpressionDefEntered(functionDef, state.currentCallSite, state)
+            state.breakpointHandler?.onExpressionDefEntered(
+                functionDef,
+                state.currentCallSite,
+                state,
+            )
 
             // Establish activation frame with the function
             // definition being evaluated.

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
@@ -241,12 +241,15 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Any?, State?>() {
     }
 
     override fun visitExpressionDef(elm: ExpressionDef, context: State?): Any? {
+        context?.breakpointHandler?.onExpressionDefEntered(elm, context?.currentCallSite, context)
+        context?.currentCallSite = null
         val value = internalEvaluate(elm, context, this)
         context?.breakpointHandler?.onExpressionDefEvaluated(elm, context, value)
         return value
     }
 
     override fun visitExpressionRef(elm: ExpressionRef, context: State?): Any? {
+        context?.currentCallSite = elm
         return ExpressionRefEvaluator.internalEvaluate(elm, context, this)
     }
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
@@ -8,7 +8,6 @@ import org.hl7.cql.model.ListType
 import org.hl7.elm.r1.*
 import org.hl7.elm.r1.List
 import org.opencds.cqf.cql.engine.debug.BreakpointAction
-import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.SourceLocator.Companion.fromNode
 import org.opencds.cqf.cql.engine.elm.executing.*
 import org.opencds.cqf.cql.engine.elm.executing.AbsEvaluator.abs
@@ -193,7 +192,8 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Any?, State?>() {
         }
 
         val action =
-            context?.breakpointHandler?.onBeforeExpression(elm, context) ?: BreakpointAction.CONTINUE
+            context?.breakpointHandler?.onBeforeExpression(elm, context)
+                ?: BreakpointAction.CONTINUE
         if (action == BreakpointAction.PAUSE) {
             context?.breakpointHandler?.waitForResume()
         }

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationVisitor.kt
@@ -7,6 +7,8 @@ import org.hl7.cql.model.IntervalType
 import org.hl7.cql.model.ListType
 import org.hl7.elm.r1.*
 import org.hl7.elm.r1.List
+import org.opencds.cqf.cql.engine.debug.BreakpointAction
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.SourceLocator.Companion.fromNode
 import org.opencds.cqf.cql.engine.elm.executing.*
 import org.opencds.cqf.cql.engine.elm.executing.AbsEvaluator.abs
@@ -190,9 +192,17 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Any?, State?>() {
             detailedState.pushSubExpressionFrame(elm)
         }
 
+        val action =
+            context?.breakpointHandler?.onBeforeExpression(elm, context) ?: BreakpointAction.CONTINUE
+        if (action == BreakpointAction.PAUSE) {
+            context?.breakpointHandler?.waitForResume()
+        }
+
         try {
             val value = super.visitExpression(elm, context)
             context?.checkType(elm, value)
+
+            context?.breakpointHandler?.onAfterExpression(elm, context, value)
 
             if (detailedState != null) {
                 detailedState.storeSubExpressionResult(value)
@@ -231,7 +241,9 @@ class EvaluationVisitor : BaseElmLibraryVisitor<Any?, State?>() {
     }
 
     override fun visitExpressionDef(elm: ExpressionDef, context: State?): Any? {
-        return internalEvaluate(elm, context, this)
+        val value = internalEvaluate(elm, context, this)
+        context?.breakpointHandler?.onExpressionDefEvaluated(elm, context, value)
+        return value
     }
 
     override fun visitExpressionRef(elm: ExpressionRef, context: State?): Any? {

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -132,8 +132,8 @@ constructor(
 
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Any?>>()
 
-    val parameters = mutableMapOf<kotlin.String, Value?>()
-    var contextValues = mutableMapOf<kotlin.String, kotlin.String?>()
+    val parameters = mutableMapOf<String, Any?>()
+    var contextValues = mutableMapOf<String, Any?>()
 
     var evaluationZonedDateTime: ZonedDateTime? = null
         private set

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -130,6 +130,14 @@ constructor(
 
     var breakpointHandler: BreakpointHandler? = null
 
+    /**
+     * Populated by EvaluationVisitor.visitExpressionRef or FunctionRefEvaluator.internalEvaluate
+     * before a define/function body is entered. Read by visitExpressionDef / evaluateFunctionDef to
+     * pass the calling ref to onExpressionDefEntered.
+     */
+    @Volatile
+    var currentCallSite: Element? = null
+
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Any?>>()
 
     val parameters = mutableMapOf<String, Any?>()

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -136,8 +136,7 @@ constructor(
      * before a define/function body is entered. Read by visitExpressionDef / evaluateFunctionDef to
      * pass the calling ref to onExpressionDefEntered.
      */
-    @Volatile
-    var currentCallSite: Element? = null
+    @Volatile var currentCallSite: Element? = null
 
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Any?>>()
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -132,8 +132,8 @@ constructor(
 
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Any?>>()
 
-    val parameters = mutableMapOf<String, Any?>()
-    var contextValues = mutableMapOf<String, Any?>()
+    val parameters = mutableMapOf<kotlin.String, Value?>()
+    var contextValues = mutableMapOf<kotlin.String, kotlin.String?>()
 
     var evaluationZonedDateTime: ZonedDateTime? = null
         private set

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -24,6 +24,7 @@ import org.hl7.elm.r1.QueryLetRef
 import org.hl7.elm.r1.Retrieve
 import org.hl7.elm.r1.Total
 import org.hl7.elm.r1.VersionedIdentifier
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.DebugAction
 import org.opencds.cqf.cql.engine.debug.DebugMap
 import org.opencds.cqf.cql.engine.debug.DebugResult
@@ -126,6 +127,8 @@ constructor(
      * `true` to filter (skip) an expression. When `null`, the [defaultTraceFilter] is used.
      */
     var traceExpressionFilter: ((Expression) -> Boolean)? = null
+
+    var breakpointHandler: BreakpointHandler? = null
 
     private val evaluatedResourceStack = ArrayDeque<MutableSet<Any?>>()
 

--- a/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/Src/java/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -6,6 +6,7 @@ import kotlin.IllegalStateException
 import kotlin.RuntimeException
 import kotlin.check
 import kotlin.checkNotNull
+import kotlin.concurrent.Volatile
 import kotlin.jvm.JvmOverloads
 import kotlin.text.StringBuilder
 import kotlin.time.Clock

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.debug.BreakpointAction
 import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.DebugMap
+import org.opencds.cqf.cql.engine.runtime.Integer
 
 internal class BreakpointHandlerTest : CqlTestBase() {
     companion object {
@@ -65,9 +66,9 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.state.breakpointHandler = handler
         val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
-        Assertions.assertEquals(3, results["X"]!!.value)
-        Assertions.assertEquals(12, results["Y"]!!.value)
-        Assertions.assertEquals(6, results["Z"]!!.value)
+        Assertions.assertEquals(Integer(3), results["X"]!!.value)
+        Assertions.assertEquals(Integer(12), results["Y"]!!.value)
+        Assertions.assertEquals(Integer(6), results["Z"]!!.value)
     }
 
     @Test
@@ -89,8 +90,8 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.state.breakpointHandler = handler
         engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
-        Assertions.assertTrue(addResults.contains(3))
-        Assertions.assertTrue(multiplyResults.contains(12))
+        Assertions.assertTrue(addResults.contains(Integer(3)))
+        Assertions.assertTrue(multiplyResults.contains(Integer(12)))
     }
 
     @Test
@@ -135,8 +136,8 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         val results = future.get(5, TimeUnit.SECONDS)
 
         Assertions.assertNotNull(results)
-        Assertions.assertEquals(3, results["X"]!!.value)
-        Assertions.assertEquals(12, results["Y"]!!.value)
+        Assertions.assertEquals(Integer(3), results["X"]!!.value)
+        Assertions.assertEquals(Integer(12), results["Y"]!!.value)
     }
 
     @Test
@@ -165,8 +166,7 @@ internal class BreakpointHandlerTest : CqlTestBase() {
 
         Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
 
-        val libraryDebug =
-            results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
+        val libraryDebug = results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
         Assertions.assertNotNull(libraryDebug)
         Assertions.assertTrue(libraryDebug.isNotEmpty())
     }

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -6,13 +6,15 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.hl7.elm.r1.Add
 import org.hl7.elm.r1.Element
+import org.hl7.elm.r1.ExpressionDef
+import org.hl7.elm.r1.ExpressionRef
+import org.hl7.elm.r1.FunctionRef
 import org.hl7.elm.r1.Multiply
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.debug.BreakpointAction
 import org.opencds.cqf.cql.engine.debug.BreakpointHandler
 import org.opencds.cqf.cql.engine.debug.DebugMap
-import org.opencds.cqf.cql.engine.runtime.Integer
 
 internal class BreakpointHandlerTest : CqlTestBase() {
     companion object {
@@ -169,6 +171,108 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         val libraryDebug = results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
         Assertions.assertNotNull(libraryDebug)
         Assertions.assertTrue(libraryDebug.isNotEmpty())
+    }
+
+    @Test
+    fun onExpressionDefEntered_firesForExpressionRef() {
+        val enteredDefs = mutableListOf<String>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                    elm.name?.let { enteredDefs.add(it) }
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue("X" in enteredDefs)
+        Assertions.assertTrue("Y" in enteredDefs)
+    }
+
+    @Test
+    fun onExpressionDefEntered_firesForFunctionRef() {
+        val enteredDefs = mutableListOf<String>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                    elm.name?.let { enteredDefs.add(it) }
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        // "F" is a function defined in the test CQL, and "Z" references F(5)
+        Assertions.assertTrue("F" in enteredDefs, "onExpressionDefEntered should fire for function F")
+    }
+
+    @Test
+    fun onExpressionDefEntered_receivesCorrectCallSite() {
+        val callSites = mutableListOf<Element?>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                    callSites.add(callSite)
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        // The first callSite is for define Z (referenced via ExpressionRef "Z")
+        // Since we don't know the exact order, just verify call sites exist and are
+        // either ExpressionRef or FunctionRef (never null when inside a ref)
+        for (cs in callSites) {
+            if (cs != null) {
+                Assertions.assertTrue(
+                    cs is ExpressionRef || cs is FunctionRef,
+                    "callSite should be an ExpressionRef or FunctionRef, got ${cs.javaClass.simpleName}",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun onExpressionDefEntered_andEvaluated_match() {
+        val entered = mutableListOf<ExpressionDef>()
+        val evaluated = mutableListOf<ExpressionDef>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                    entered.add(elm)
+                }
+
+                override fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {
+                    evaluated.add(elm)
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertEquals(entered.size, evaluated.size, "each entered define should be evaluated")
+        // Order may differ (nested function bodies are entered after the outer define
+        // but evaluated before it), so check set identity instead of sequential order.
+        val enteredSet = entered.toSet()
+        val evaluatedSet = evaluated.toSet()
+        Assertions.assertEquals(enteredSet, evaluatedSet, "entered and evaluated should contain the same elements")
     }
 
     @Test

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -1,0 +1,199 @@
+package org.opencds.cqf.cql.engine.execution
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.hl7.elm.r1.Add
+import org.hl7.elm.r1.Element
+import org.hl7.elm.r1.Multiply
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.opencds.cqf.cql.engine.debug.BreakpointAction
+import org.opencds.cqf.cql.engine.debug.BreakpointHandler
+import org.opencds.cqf.cql.engine.debug.DebugMap
+
+internal class BreakpointHandlerTest : CqlTestBase() {
+    companion object {
+        private const val NUMBER_OF_DEFINES = 4
+    }
+
+    @Test
+    fun onBeforeExpression_invokedForEveryExpression() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(
+            callCount.get() > NUMBER_OF_DEFINES,
+            "handler should be called for sub-expressions, not just ExpressionDefs",
+        )
+    }
+
+    @Test
+    fun onBeforeExpression_receivesLiveState() {
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    Assertions.assertNotNull(state)
+                    Assertions.assertTrue(state.stack.isNotEmpty())
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+    }
+
+    @Test
+    fun onBeforeExpression_returnsContinue_evaluationCompletes() {
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertEquals(3, results["X"]!!.value)
+        Assertions.assertEquals(12, results["Y"]!!.value)
+        Assertions.assertEquals(6, results["Z"]!!.value)
+    }
+
+    @Test
+    fun onAfterExpression_receivesCorrectValue() {
+        val addResults = mutableListOf<Any?>()
+        val multiplyResults = mutableListOf<Any?>()
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onAfterExpression(elm: Element, state: State, value: Any?) {
+                    if (elm is Add) addResults.add(value)
+                    if (elm is Multiply) multiplyResults.add(value)
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+        engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(addResults.contains(3))
+        Assertions.assertTrue(multiplyResults.contains(12))
+    }
+
+    @Test
+    fun onBeforeExpression_pauseBlocksAndReleaseResumes() {
+        val paused = CountDownLatch(1)
+        val resumeLatch = CountDownLatch(1)
+
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    if (elm is Add) {
+                        paused.countDown()
+                        return BreakpointAction.PAUSE
+                    }
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun waitForResume() {
+                    try {
+                        resumeLatch.await()
+                    } catch (e: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                }
+
+                override fun release() {
+                    resumeLatch.countDown()
+                }
+            }
+
+        engine.state.breakpointHandler = handler
+
+        val future =
+            CompletableFuture.supplyAsync {
+                engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+            }
+
+        Assertions.assertTrue(paused.await(5, TimeUnit.SECONDS))
+        Assertions.assertFalse(future.isDone)
+
+        handler.release()
+        val results = future.get(5, TimeUnit.SECONDS)
+
+        Assertions.assertNotNull(results)
+        Assertions.assertEquals(3, results["X"]!!.value)
+        Assertions.assertEquals(12, results["Y"]!!.value)
+    }
+
+    @Test
+    fun breakpointHandler_independentOfDebugMap() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+            }
+
+        val debugMap = DebugMap()
+        debugMap.isLoggingEnabled = true
+
+        engine.state.breakpointHandler = handler
+
+        val results =
+            engine
+                .evaluate {
+                    library("BreakpointHandlerTest")
+                    this@evaluate.debugMap = debugMap
+                }
+                .onlyResultOrThrow
+
+        Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
+
+        val libraryDebug =
+            results.debugResult!!.libraryResults["BreakpointHandlerTest"]!!.results
+        Assertions.assertNotNull(libraryDebug)
+        Assertions.assertTrue(libraryDebug.isNotEmpty())
+    }
+
+    @Test
+    fun breakpointHandler_worksWithDetailedTracing() {
+        val callCount = AtomicInteger(0)
+        val handler =
+            object : BreakpointHandler {
+                override fun onBeforeExpression(elm: Element, state: State): BreakpointAction {
+                    callCount.incrementAndGet()
+                    return BreakpointAction.CONTINUE
+                }
+
+                override fun onAfterExpression(elm: Element, state: State, value: Any?) {}
+            }
+
+        engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)
+        engine.state.breakpointHandler = handler
+
+        val results = engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
+
+        Assertions.assertTrue(callCount.get() > NUMBER_OF_DEFINES)
+
+        val traceEntry = results.trace
+        Assertions.assertNotNull(traceEntry)
+        Assertions.assertNotNull(traceEntry!!.frames)
+        Assertions.assertTrue(traceEntry.frames.isNotEmpty())
+    }
+}

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -181,7 +181,6 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onAfterExpression(elm: Element, state: State, value: Any?) {}
             }
 
         engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)

--- a/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
+++ b/Src/java/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.kt
@@ -182,7 +182,11 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                override fun onExpressionDefEntered(
+                    elm: ExpressionDef,
+                    callSite: Element?,
+                    state: State,
+                ) {
                     elm.name?.let { enteredDefs.add(it) }
                 }
             }
@@ -203,7 +207,11 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                override fun onExpressionDefEntered(
+                    elm: ExpressionDef,
+                    callSite: Element?,
+                    state: State,
+                ) {
                     elm.name?.let { enteredDefs.add(it) }
                 }
             }
@@ -212,7 +220,10 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
         // "F" is a function defined in the test CQL, and "Z" references F(5)
-        Assertions.assertTrue("F" in enteredDefs, "onExpressionDefEntered should fire for function F")
+        Assertions.assertTrue(
+            "F" in enteredDefs,
+            "onExpressionDefEntered should fire for function F",
+        )
     }
 
     @Test
@@ -224,7 +235,11 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                override fun onExpressionDefEntered(
+                    elm: ExpressionDef,
+                    callSite: Element?,
+                    state: State,
+                ) {
                     callSites.add(callSite)
                 }
             }
@@ -255,11 +270,19 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     return BreakpointAction.CONTINUE
                 }
 
-                override fun onExpressionDefEntered(elm: ExpressionDef, callSite: Element?, state: State) {
+                override fun onExpressionDefEntered(
+                    elm: ExpressionDef,
+                    callSite: Element?,
+                    state: State,
+                ) {
                     entered.add(elm)
                 }
 
-                override fun onExpressionDefEvaluated(elm: ExpressionDef, state: State, value: Any?) {
+                override fun onExpressionDefEvaluated(
+                    elm: ExpressionDef,
+                    state: State,
+                    value: Any?,
+                ) {
                     evaluated.add(elm)
                 }
             }
@@ -267,12 +290,20 @@ internal class BreakpointHandlerTest : CqlTestBase() {
         engine.state.breakpointHandler = handler
         engine.evaluate { library("BreakpointHandlerTest") }.onlyResultOrThrow
 
-        Assertions.assertEquals(entered.size, evaluated.size, "each entered define should be evaluated")
+        Assertions.assertEquals(
+            entered.size,
+            evaluated.size,
+            "each entered define should be evaluated",
+        )
         // Order may differ (nested function bodies are entered after the outer define
         // but evaluated before it), so check set identity instead of sequential order.
         val enteredSet = entered.toSet()
         val evaluatedSet = evaluated.toSet()
-        Assertions.assertEquals(enteredSet, evaluatedSet, "entered and evaluated should contain the same elements")
+        Assertions.assertEquals(
+            enteredSet,
+            evaluatedSet,
+            "entered and evaluated should contain the same elements",
+        )
     }
 
     @Test
@@ -284,7 +315,6 @@ internal class BreakpointHandlerTest : CqlTestBase() {
                     callCount.incrementAndGet()
                     return BreakpointAction.CONTINUE
                 }
-
             }
 
         engine.state.engineOptions.add(CqlEngine.Options.EnableDetailedTracing)

--- a/Src/java/engine/src/jvmTest/resources/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.cql
+++ b/Src/java/engine/src/jvmTest/resources/org/opencds/cqf/cql/engine/execution/BreakpointHandlerTest.cql
@@ -1,0 +1,5 @@
+library BreakpointHandlerTest
+define X: 1 + 2
+define Y: 3 * 4
+define function F(a Integer): a + 1
+define Z: F(5)


### PR DESCRIPTION
### Summary

Adds a `BreakpointHandler` interface to the CQL engine that enables external debugger
tooling (e.g., VS Code debug adapters) to observe and control CQL evaluation at runtime.
Callers implement the interface and attach it to `engine.state.breakpointHandler` before
evaluation.

closes https://github.com/cqframework/clinical_quality_language/issues/1783

### New API — `BreakpointHandler` interface (`engine/debug/`)

| Callback | When called |
|---|---|
| `onBeforeExpression(elm, state) -> BreakpointAction` | Before every ELM expression evaluates. Return `PAUSE` to suspend execution. |
| `onAfterExpression(elm, state, value)` | After every ELM expression evaluates, with the result value. |
| `onExpressionDefEntered(elm, callSite, state)` | When a `define` or function body is entered. `callSite` is the `ExpressionRef` or `FunctionRef` that triggered the entry (or `null` for top-level entries). |
| `onExpressionDefEvaluated(elm, state, value)` | When a `define` or function body evaluation completes. |
| `waitForResume()` / `release()` | Pause/resume flow control for stepping. |

A `BreakpointAction` enum (`CONTINUE`, `PAUSE`) controls whether execution proceeds
or blocks until `release()` is called.

### Implementation details

- **`EvaluationVisitor.kt`**: `onBeforeExpression`/`onAfterExpression` hooked into
  `internalEvaluate` (the central expression dispatch);
  `onExpressionDefEntered`/`onExpressionDefEvaluated` wired into `visitExpressionDef`
  and `visitExpressionRef`.
- **`FunctionRefEvaluator.kt`**: Callbacks added around function body evaluation, plus
  `currentCallSite` tracking so the caller can identify which `FunctionRef` caused the
  invocation.
- **`State.kt`**: New `breakpointHandler` property and `@Volatile var currentCallSite`
  field for cross-visitor call-site propagation.

### Additional fix

**`RetrieveEvaluator.kt`**: Filters out `null` elements when the `codes` argument is
`Iterable<*>`, preventing NPEs during data retrieval when a code list contains null
entries. Also handles mixed `String`/`Code` iterables by wrapping strings appropriately.
Addresses the spec at
https://cql.hl7.org/04-logicalspecification.html#retrieve.

### Tests

`BreakpointHandlerTest.kt` validates:

- `onBeforeExpression` fires for every expression (not just defines)
- Live `State` is accessible with a non-empty stack
- Evaluation completes correctly with `CONTINUE` and produces expected results
  (`X=3`, `Y=12`, `Z=6`)
- `onAfterExpression` receives correct intermediate values (Add → 3, Multiply → 12)
- Pause/resume flow control blocks and unblocks correctly via `CompletableFuture`
- Independence from the existing `DebugMap`/tracing system
- `onExpressionDefEntered` fires for both `ExpressionRef` and `FunctionRef` call sites
- `onExpressionDefEntered`/`onExpressionDefEvaluated` are balanced (same set of defs)
- Compatible with `EnableDetailedTracing`