### PR TITLE
Fix Successor/Predecessor of Date, DateTime, and Time to return null on overflow/underflow (#1734, #1733)

### DIFF
--- a/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlArithmeticFunctionsTest.xml
+++ b/engine-fhir/src/test/resources/org/hl7/fhirpath/cql/CqlArithmeticFunctionsTest.xml
@@ -602,12 +602,12 @@
 			<output>@T11:59:59.999</output>
 		</test>
 		<test name="PredecessorUnderflowDt">
-			<expression invalid="true">predecessor of DateTime(0001, 1, 1, 0, 0, 0, 0)</expression>
-			<!-- EXPECT: The result of the predecessor operation precedes the minimum value allowed for the type -->
+			<expression>predecessor of DateTime(0001, 1, 1, 0, 0, 0, 0)</expression>
+			<output>null</output>
 		</test>
 		<test name="PredecessorUnderflowT">
-			<expression invalid="true">predecessor of @T00:00:00.000</expression>
-			<!-- EXPECT: The result of the predecessor operation precedes the minimum value allowed for the type -->
+			<expression>predecessor of @T00:00:00.000</expression>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="Power">
@@ -778,12 +778,12 @@
 			<output>@T12:00:00.001</output>
 		</test>
 		<test name="SuccessorOverflowDt">
-			<expression invalid="true">successor of DateTime(9999, 12, 31, 23, 59, 59, 999)</expression>
-			<!-- EXPECT: The result of the successor operation exceeds the maximum value allowed for the type -->
+			<expression>successor of DateTime(9999, 12, 31, 23, 59, 59, 999)</expression>
+			<output>null</output>
 		</test>
 		<test name="SuccessorOverflowT">
-			<expression invalid="true">successor of @T23:59:59.999</expression>
-			<!-- EXPECT: The result of the successor operation exceeds the maximum value allowed for the type -->
+			<expression>successor of @T23:59:59.999</expression>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="Truncate">

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/PredecessorEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/PredecessorEvaluator.kt
@@ -24,16 +24,22 @@ import org.opencds.cqf.cql.engine.runtime.toCqlLong
 predecessor of<T>(argument T) T
 
 The predecessor operator returns the predecessor of the argument.
-  For example, the predecessor of 2 is 1. If the argument is already the minimum value for the type, a run-time error is thrown.
+  For example, the predecessor of 2 is 1. If the argument is already the minimum value for the type,
+  or the result cannot otherwise be represented (i.e. would result in underflow), the result is null.
 The predecessor operator is defined for the Integer, Long, Decimal, DateTime, and Time types.
 For Integer, Long predecessor is equivalent to subtracting 1.
 For Decimal, predecessor is equivalent to subtracting the minimum precision value for the Decimal type, or 10^-08.
-For DateTime and Time values, predecessor is equivalent to subtracting a time-unit quantity for the lowest specified precision of the value.
+For DateTime and Time values, predecessor is equivalent to subtracting a time-unit quantity for
+  the lowest specified precision of the value.
   For example, if the DateTime is fully specified, predecessor is equivalent to subtracting 1 millisecond;
     if the DateTime is specified to the second, predecessor is equivalent to subtracting one second, etc.
 If the argument is null, the result is null.
 */
 object PredecessorEvaluator {
+    // The minimum representable year for Date/DateTime values (see the bounds enforced by the
+    // Date and DateTime types).
+    private const val MIN_YEAR = 1
+
     /**
      * Checks if the given BigDecimal value is less than the minimum allowed value for Decimal type.
      *
@@ -83,51 +89,35 @@ object PredecessorEvaluator {
                 .withValue((predecessor(quantity.value?.toCqlDecimal()) as Decimal).value)
                 .withUnit(quantity.unit)
         } else if (value is Date) {
-            val dt = value
-            return Date(dt.date!!.minus(1, dt.precision!!.toChronoUnit()), dt.precision!!)
+            val prev = value.date!!.minus(1, value.precision!!.toChronoUnit())
+            // If decrementing underflows the representable year range, the result is null.
+            return if (prev.getYear() < MIN_YEAR) null else Date(prev, value.precision!!)
         } else if (value is DateTime) {
-            val dt = value
-            return DateTime(dt.dateTime!!.minus(1, dt.precision!!.toChronoUnit()), dt.precision!!)
+            val prev = value.dateTime!!.minus(1, value.precision!!.toChronoUnit())
+            // If decrementing underflows the representable year range, the result is null.
+            return if (prev.getYear() < MIN_YEAR) null else DateTime(prev, value.precision!!)
         } else if (value is Time) {
             val t = value
-            when (t.precision!!) {
-                Precision.HOUR ->
-                    if (t.time.getHour() == 0) {
-                        throw TypeUnderflow(
-                            "The result of the successor operation precedes the minimum value allowed for the Time type"
-                        )
-                    }
-                Precision.MINUTE ->
-                    if (t.time.getHour() == 0 && t.time.getMinute() == 0) {
-                        throw TypeUnderflow(
-                            "The result of the successor operation precedes the minimum value allowed for the Time type"
-                        )
-                    }
-                Precision.SECOND ->
-                    if (
+            // If the value is already the minimum for its precision, decrementing underflows the
+            // representable range and the result is null.
+            val underflow =
+                when (t.precision!!) {
+                    Precision.HOUR -> t.time.getHour() == 0
+                    Precision.MINUTE -> t.time.getHour() == 0 && t.time.getMinute() == 0
+                    Precision.SECOND ->
                         t.time.getHour() == 0 && t.time.getMinute() == 0 && t.time.getSecond() == 0
-                    ) {
-                        throw TypeUnderflow(
-                            "The result of the successor operation precedes the minimum value allowed for the Time type"
-                        )
-                    }
-                Precision.MILLISECOND ->
-                    if (
+                    Precision.MILLISECOND ->
                         t.time.getHour() == 0 &&
                             t.time.getMinute() == 0 &&
                             t.time.getSecond() == 0 &&
                             t.time.get(Precision.MILLISECOND.toChronoField()) == 0
-                    ) {
-                        throw TypeUnderflow(
-                            "The result of the successor operation precedes the minimum value allowed for the Time type"
-                        )
-                    }
-                Precision.DAY,
-                Precision.MONTH,
-                Precision.WEEK,
-                Precision.YEAR -> {}
-            }
-            return Time(t.time.minus(1, t.precision!!.toChronoUnit()), t.precision!!)
+                    Precision.DAY,
+                    Precision.MONTH,
+                    Precision.WEEK,
+                    Precision.YEAR -> false
+                }
+            return if (underflow) null
+            else Time(t.time.minus(1, t.precision!!.toChronoUnit()), t.precision!!)
         }
 
         throw InvalidOperatorArgument(

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/SuccessorEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/SuccessorEvaluator.kt
@@ -23,16 +23,22 @@ import org.opencds.cqf.cql.engine.runtime.toCqlLong
 successor of<T>(argument T) T
 
 The successor operator returns the successor of the argument. For example, the successor of 1 is 2.
-  If the argument is already the maximum value for the type, a run-time error is thrown.
+  If the argument is already the maximum value for the type, or the result cannot otherwise be
+  represented (i.e. would result in overflow), the result is null.
 The successor operator is defined for the Integer, Long, Decimal, DateTime, and Time types.
 For Integer, Long successor is equivalent to adding 1.
 For Decimal, successor is equivalent to adding the minimum precision value for the Decimal type, or 10^-08.
-For DateTime and Time values, successor is equivalent to adding a time-unit quantity for the lowest specified precision of the value.
+For DateTime and Time values, successor is equivalent to adding a time-unit quantity for the
+  lowest specified precision of the value.
   For example, if the DateTime is fully specified, successor is equivalent to adding 1 millisecond;
     if the DateTime is specified to the second, successor is equivalent to adding one second, etc.
 If the argument is null, the result is null.
 */
 object SuccessorEvaluator {
+    // The maximum representable year for Date/DateTime values (see the bounds enforced by the
+    // Date and DateTime types).
+    private const val MAX_YEAR = 9999
+
     /**
      * Checks if the given BigDecimal value exceeds the maximum allowed value for Decimal type.
      *
@@ -82,53 +88,37 @@ object SuccessorEvaluator {
                 .withValue((successor(quantity.value?.toCqlDecimal()) as Decimal).value)
                 .withUnit(quantity.unit)
         } else if (value is Date) {
-            val dt = value
-            return Date(dt.date!!.plus(1, dt.precision!!.toChronoUnit()), dt.precision!!)
+            val next = value.date!!.plus(1, value.precision!!.toChronoUnit())
+            // If incrementing overflows the representable year range, the result is null.
+            return if (next.getYear() > MAX_YEAR) null else Date(next, value.precision!!)
         } else if (value is DateTime) {
-            val dt = value
-            return DateTime(dt.dateTime!!.plus(1, dt.precision!!.toChronoUnit()), dt.precision!!)
+            val next = value.dateTime!!.plus(1, value.precision!!.toChronoUnit())
+            // If incrementing overflows the representable year range, the result is null.
+            return if (next.getYear() > MAX_YEAR) null else DateTime(next, value.precision!!)
         } else if (value is Time) {
             val t = value
-            when (t.precision!!) {
-                Precision.HOUR ->
-                    if (t.time.getHour() == 23) {
-                        throw TypeOverflow(
-                            "The result of the successor operation exceeds the maximum value allowed for the Time type"
-                        )
-                    }
-                Precision.MINUTE ->
-                    if (t.time.getHour() == 23 && t.time.getMinute() == 23) {
-                        throw TypeOverflow(
-                            "The result of the successor operation exceeds the maximum value allowed for the Time type"
-                        )
-                    }
-                Precision.SECOND ->
-                    if (
+            // If the value is already the maximum for its precision, incrementing overflows the
+            // representable range and the result is null.
+            val overflow =
+                when (t.precision!!) {
+                    Precision.HOUR -> t.time.getHour() == 23
+                    Precision.MINUTE -> t.time.getHour() == 23 && t.time.getMinute() == 59
+                    Precision.SECOND ->
                         t.time.getHour() == 23 &&
-                            t.time.getMinute() == 23 &&
+                            t.time.getMinute() == 59 &&
                             t.time.getSecond() == 59
-                    ) {
-                        throw TypeOverflow(
-                            "The result of the successor operation exceeds the maximum value allowed for the Time type"
-                        )
-                    }
-                Precision.MILLISECOND ->
-                    if (
+                    Precision.MILLISECOND ->
                         t.time.getHour() == 23 &&
                             t.time.getMinute() == 59 &&
                             t.time.getSecond() == 59 &&
                             t.time.get(Precision.MILLISECOND.toChronoField()) == 999
-                    ) {
-                        throw TypeOverflow(
-                            "The result of the successor operation exceeds the maximum value allowed for the Time type"
-                        )
-                    }
-                Precision.DAY,
-                Precision.MONTH,
-                Precision.WEEK,
-                Precision.YEAR -> {}
-            }
-            return Time(t.time.plus(1, t.precision!!.toChronoUnit()), t.precision!!)
+                    Precision.DAY,
+                    Precision.MONTH,
+                    Precision.WEEK,
+                    Precision.YEAR -> false
+                }
+            return if (overflow) null
+            else Time(t.time.plus(1, t.precision!!.toChronoUnit()), t.precision!!)
         }
 
         throw InvalidOperatorArgument(


### PR DESCRIPTION
## Problem

successor of DateTime(9999,12,31,23,59,59,999) and successor of `@T23:59:59.999` threw an EvaluationError (TypeOverflow / "year 10000 falls above the accepted bounds") instead of returning null. Same for predecessor of the minimum DateTime/Time (TypeUnderflow). The current CQL reference is explicit:

> "If the argument is already the maximum value for the type, a null is returned. If the result of the operation cannot be represented (i.e. would result in an overflow), the result is null."

The engine's own doc comments still said "a run-time error is thrown" - a leftover from an earlier version of the spec.

## Fix

SuccessorEvaluator and PredecessorEvaluator now return null when a Date, DateTime, or Time overflows/underflows the representable range:

- Date/DateTime: compute the shifted temporal, then a getYear() bounds check against a named MAX_YEAR/MIN_YEAR constant is null if out of [1, 9999] (no exception-driven control flow).
- Time: the precision-based boundary checks return null instead of throwing.
- Updated the stale doc comments to match the current spec.

Also fixes a latent bug in SuccessorEvaluator's Time overflow detection: the MINUTE and SECOND checks compared getMinute() == 23 instead of == 59, so successor of `@T23:59` wrapped to `@T00:00` instead of overflowing, while `@T23:23` was wrongly treated as overflow.

### Scope

Limited to the temporal types (Date, DateTime, Time), which is what #1734/#1733 and the conformance tests cover. Numeric types (Integer/Long/Decimal/Quantity) still throw on overflow; per the current spec they should also return null, but that requires reworking the checkMaxDecimal/checkMinDecimal helpers and the internal (value, quantity) overloads (used by interval-boundary computation) to propagate null, and there are no conformance tests for it. Left as a separate, carefully-scoped follow-up.

### Tests

Un-doctored the vendored engine-fhir copy of CqlArithmeticFunctionsTest.xml - these had been marked invalid="true" to match the old throwing behavior:

| Test                   | Expression                                     | Before  | After |
|------------------------|------------------------------------------------|---------|-------|
| SuccessorOverflowDt    | successor of DateTime(9999,12,31,23,59,59,999) | invalid | null  |
| SuccessorOverflowT     | successor of `@T23:59:59.999`                    | invalid | null  |
| PredecessorUnderflowDt | predecessor of DateTime(0001,1,1,0,0,0,0)      | invalid | null  |
| PredecessorUnderflowT  | predecessor of `@T00:00:00.000`                  | invalid | null  |

Validated: spotlessApply, :engine:detekt, engine arithmetic + Successor/Predecessor evaluator unit tests, and both vendored suites (R4 + DSTU3) — all green. Full :engine:jvmTest + :engine-fhir:test run completing.

## Upstream follow-up

The canonical cql-tests (https://github.com/cqframework/cql-tests) suite still marks these four invalid="true", which now contradicts the current spec. A companion cql-tests PR is needed to change them to expect null; until then the conformance dashboard will report them as failing (same situation as the Exp/Ln fix, #1716).

Fixes #1734 
Fixes #1733.