### PR TITLE
Add experimental JS opt-ins as Kotlin compiler options

### DIFF
--- a/build-logic/src/main/kotlin/XsdKotlinGenTask.kt
+++ b/build-logic/src/main/kotlin/XsdKotlinGenTask.kt
@@ -1135,11 +1135,6 @@ fun FileSpec.Builder.addSerializers(
 
 // Adds `@JsOnlyExport`
 fun TypeSpec.Builder.addJsExport(): TypeSpec.Builder {
-    addAnnotation(
-        AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
-            .addMember("%T::class", ClassName("kotlin.js", "ExperimentalJsExport"))
-            .build()
-    )
     addAnnotation(ClassName("org.cqframework.cql.shared", "JsOnlyExport"))
 
     return this

--- a/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
         freeCompilerArgs.add("-Xwarning-level=DEPRECATION:disabled")
 
         optIn.add("kotlin.js.ExperimentalJsExport")
+        optIn.add("kotlin.js.ExperimentalJsStatic")
     }
     jvmToolchain(17)
     jvm()

--- a/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/cql.kotlin-multiplatform-conventions.gradle.kts
@@ -41,6 +41,8 @@ kotlin {
         // we'll need to refactor the code to use interfaces.
         freeCompilerArgs.add("-Xexpect-actual-classes")
         freeCompilerArgs.add("-Xwarning-level=DEPRECATION:disabled")
+
+        optIn.add("kotlin.js.ExperimentalJsExport")
     }
     jvmToolchain(17)
     jvm()
@@ -59,6 +61,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
+        compilerOptions { optIn.add("kotlin.js.ExperimentalWasmJsInterop") }
         browser { testTask { enabled = false } }
         nodejs { testTask { enabled = false } }
         binaries.library()

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerException.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerException.kt
@@ -1,11 +1,9 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmStatic
 import org.cqframework.cql.cql2elm.tracking.TrackBack
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 abstract class CqlCompilerException(

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerOptions.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerOptions.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsExport
 import kotlin.js.JsStatic
 import kotlin.jvm.JvmStatic
@@ -305,7 +304,6 @@ class CqlCompilerOptions() {
          *
          * @return
          */
-        @OptIn(ExperimentalJsStatic::class)
         @JvmStatic
         @JsStatic
         fun defaultOptions(): CqlCompilerOptions {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerOptions.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlCompilerOptions.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsExport
 import kotlin.js.JsStatic
@@ -10,7 +9,6 @@ import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel
 import org.cqframework.cql.shared.JsOnlyExport
 
 /** Translation options for CQL source files */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE", "TooManyFunctions")
 @Serializable

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
@@ -2,7 +2,6 @@
 
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsExport
 import kotlin.js.JsStatic
@@ -28,7 +27,6 @@ import org.hl7.elm.r1.VersionedIdentifier
  * Wraps [CqlCompiler] and produces ELM outputs in different formats. Exposes compilation exceptions
  * and filtered views for errors, warnings, and messages.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class CqlTranslator

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalJsStatic::class)
-
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsExport
 import kotlin.js.JsStatic
 import kotlin.jvm.JvmOverloads

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslatorOptions.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslatorOptions.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsStatic
 import kotlin.jvm.JvmStatic
@@ -12,7 +11,7 @@ import kotlinx.io.files.SystemFileSystem
 import kotlinx.serialization.Serializable
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class, ExperimentalJsStatic::class)
+@OptIn(ExperimentalJsStatic::class)
 @JsOnlyExport
 @Serializable
 @Suppress("NON_EXPORTABLE_TYPE")

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslatorOptions.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslatorOptions.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsStatic
 import kotlin.js.JsStatic
 import kotlin.jvm.JvmStatic
 import kotlinx.io.Sink
@@ -11,7 +10,6 @@ import kotlinx.io.files.SystemFileSystem
 import kotlinx.serialization.Serializable
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsStatic::class)
 @JsOnlyExport
 @Serializable
 @Suppress("NON_EXPORTABLE_TYPE")

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/DefaultLibrarySourceProvider.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/DefaultLibrarySourceProvider.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.files.FileNotFoundException
@@ -16,7 +15,6 @@ import org.hl7.elm.r1.VersionedIdentifier
 // form
 // <major>[.<minor>[.<patch>]]
 // Usage outside these boundaries will result in errors or incorrect behavior.
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class DefaultLibrarySourceProvider(path: Path) : LibrarySourceProvider, PathAware {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/DefaultModelInfoProvider.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlinx.io.IOException
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -17,7 +16,6 @@ import org.hl7.elm_modelinfo.r1.serializing.parseModelInfoXml
 // And further that <modelname> will never contain dashes, and that <version> will always be of the
 // form <major>[.<minor>[.<patch>]]
 // Usage outside these boundaries will result in errors or incorrect behavior.
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class DefaultModelInfoProvider(path: Path) : ModelInfoProvider, PathAware {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryBuilder.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlin.reflect.KClass

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
@@ -1,11 +1,8 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm
 
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.collections.HashSet
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlinx.io.Source

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceLoader.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceLoader.kt
@@ -1,11 +1,9 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlinx.io.Source
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm.r1.VersionedIdentifier
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 interface LibrarySourceLoader {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceProvider.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceProvider.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlinx.io.Source
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm.r1.VersionedIdentifier

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoLoader.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoLoader.kt
@@ -1,7 +1,6 @@
 package org.cqframework.cql.cql2elm
 
 import kotlin.collections.ArrayList
-import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmOverloads
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -12,7 +11,6 @@ import org.hl7.cql.model.NamespaceAware
 import org.hl7.cql.model.NamespaceManager
 import org.hl7.elm_modelinfo.r1.ModelInfo
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class ModelInfoLoader : NamespaceAware, PathAware {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoProvider.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoProvider.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlinx.io.Source
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.cql.model.ModelIdentifier
@@ -10,7 +9,6 @@ import org.hl7.elm_modelinfo.r1.serializing.parseModelInfoXml
 
 expect fun getModelInfoProviders(refresh: Boolean): Iterator<ModelInfoProvider>
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 fun createModelInfoProvider(

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelManager.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ModelManager.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlinx.io.files.Path

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/model/Model.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm.model
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import org.cqframework.cql.cql2elm.ModelManager
@@ -11,7 +10,6 @@ import org.hl7.cql.model.ModelContext
 import org.hl7.cql.model.NamedType
 import org.hl7.elm_modelinfo.r1.ModelInfo
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 open class Model
 @JsExport.Ignore

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ucum/UcumService.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/ucum/UcumService.kt
@@ -1,6 +1,5 @@
 package org.cqframework.cql.cql2elm.ucum
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.BigDecimal
 import org.cqframework.cql.shared.JsOnlyExport
 
@@ -44,7 +43,6 @@ expect val defaultLazyUcumService: Lazy<UcumService>
  *   null, otherwise it should return an error message.
  * @return a lazy UCUM service
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 fun createUcumService(

--- a/cql-to-elm/src/jsMain/kotlin/org/cqframework/cql/cql2elm/utils/Path.kt
+++ b/cql-to-elm/src/jsMain/kotlin/org/cqframework/cql/cql2elm/utils/Path.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm.utils
 
 import kotlinx.io.files.Path

--- a/cql-to-elm/src/jsMain/kotlin/org/cqframework/cql/cql2elm/utils/Source.kt
+++ b/cql-to-elm/src/jsMain/kotlin/org/cqframework/cql/cql2elm/utils/Source.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.cql2elm.utils
 
 import kotlinx.io.Source

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/CqlTranslator.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm
 
 @JsExport

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm
 
 import org.cqframework.cql.cql2elm.ucum.UcumService

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceProviderWasmJs.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/LibrarySourceProviderWasmJs.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm
 
 import kotlinx.io.Source

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoProviderWasmJs.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ModelInfoProviderWasmJs.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm
 
 import kotlinx.io.Source

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ModelManager.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ModelManager.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm
 
 import org.hl7.cql.model.ModelInfoProvider

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ucum/UcumServiceWasmJs.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/ucum/UcumServiceWasmJs.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm.ucum
 
 import org.cqframework.cql.shared.BigDecimal

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/IdentityHashMap.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/IdentityHashMap.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm.utils
 
 @JsName("Map")

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/Path.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/Path.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm.utils
 
 import kotlinx.io.files.Path

--- a/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/Source.kt
+++ b/cql-to-elm/src/wasmJsMain/kotlin/org/cqframework/cql/cql2elm/utils/Source.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJsExport::class, ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.cql2elm.utils
 
 import kotlinx.io.Source

--- a/cql/src/commonMain/kotlin/org/hl7/cql/ast/Builder.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/ast/Builder.kt
@@ -1,6 +1,5 @@
 package org.hl7.cql.ast
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlinx.serialization.json.Json
 import org.antlr.v4.kotlinruntime.BaseErrorListener
@@ -1719,7 +1718,6 @@ class Builder(private val sourceId: String? = null) {
 }
 
 /** Generates the AST for the given CQL in the JSON format. */
-@OptIn(ExperimentalJsExport::class)
 @JsExport
 fun inspectCqlAst(text: String): String {
     val builder = Builder()

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassType.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassType.kt
@@ -1,11 +1,9 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
 @Suppress("TooManyFunctions", "ComplexCondition", "NON_EXPORTABLE_TYPE")
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 open class ClassType(
     final override val name: String,

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassTypeElement.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/ClassTypeElement.kt
@@ -1,10 +1,8 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 data class ClassTypeElement(
     val name: String,

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/DataType.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/DataType.kt
@@ -1,10 +1,8 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface DataType {
     val baseType: DataType

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/ModelInfoProvider.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/ModelInfoProvider.kt
@@ -1,10 +1,8 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm_modelinfo.r1.ModelInfo
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 interface ModelInfoProvider {

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/NamedType.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/NamedType.kt
@@ -1,9 +1,7 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface NamedType {
     val name: String

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/NamespaceManager.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/NamespaceManager.kt
@@ -1,11 +1,9 @@
 package org.hl7.cql.model
 
 import kotlin.collections.HashMap
-import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmStatic
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class NamespaceManager {

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/SimpleType.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/SimpleType.kt
@@ -1,10 +1,8 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 data class SimpleType(
     override val name: String,

--- a/cql/src/commonMain/kotlin/org/hl7/cql/model/SystemModelInfoProvider.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/model/SystemModelInfoProvider.kt
@@ -1,11 +1,9 @@
 package org.hl7.cql.model
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm_modelinfo.r1.ModelInfo
 import org.hl7.elm_modelinfo.r1.serializing.parseModelInfoXml
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class SystemModelInfoProvider : ModelInfoProvider {

--- a/cql/src/commonMain/kotlin/org/hl7/cql/parsetree/ParseTree.kt
+++ b/cql/src/commonMain/kotlin/org/hl7/cql/parsetree/ParseTree.kt
@@ -1,6 +1,5 @@
 package org.hl7.cql.parsetree
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.antlr.v4.kotlinruntime.CharStreams
 import org.antlr.v4.kotlinruntime.CommonTokenStream
@@ -17,7 +16,6 @@ fun createParser(text: String): cqlParser {
 }
 
 /** Generates the parse tree for the given CQL. */
-@OptIn(ExperimentalJsExport::class)
 @JsExport
 fun inspectCqlParseTree(text: String): String {
     val parser = createParser(text)

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/DataProvider.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/data/DataProvider.kt
@@ -1,13 +1,11 @@
 package org.opencds.cqf.cql.engine.data
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.elm.executing.obfuscate.NoOpPHIObfuscator
 import org.opencds.cqf.cql.engine.elm.executing.obfuscate.PHIObfuscator
 import org.opencds.cqf.cql.engine.model.ModelResolver
 import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface DataProvider : ModelResolver, RetrieveProvider {
     fun phiObfuscationSupplier(): () -> PHIObfuscator? {

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/obfuscate/PHIObfuscator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/obfuscate/PHIObfuscator.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.elm.executing.obfuscate
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Value
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface PHIObfuscator {
     fun obfuscate(source: Value?): String?

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/CqlEngine.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/CqlEngine.kt
@@ -1,7 +1,6 @@
 package org.opencds.cqf.cql.engine.execution
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import org.cqframework.cql.cql2elm.CompiledLibraryResult
@@ -31,7 +30,6 @@ import org.opencds.cqf.cql.engine.util.zonedDateTimeNow
  * Visitor pattern reduces the process to convert EML Tree to Executable ELM tree and thus reduces a
  * potential maintenance issue.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class CqlEngine
 @JvmOverloads

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/Environment.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/Environment.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsName
 import kotlin.jvm.JvmOverloads
 import org.cqframework.cql.cql2elm.LibraryManager
@@ -19,7 +18,6 @@ import org.opencds.cqf.cql.engine.terminology.TerminologyProvider
  * The Environment class represents the current CQL execution environment. Meaning, things that are
  * set up outside of the CQL engine
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class Environment

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationExpressionRef.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationExpressionRef.kt
@@ -1,20 +1,16 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm.r1.TypeSpecifier
 import org.opencds.cqf.cql.engine.runtime.Value
 
 /** Represents a reference to an expression or function to be evaluated. */
-@OptIn(ExperimentalJsExport::class)
-@JsOnlyExport
-open class EvaluationExpressionRef(val name: String)
+@JsOnlyExport open class EvaluationExpressionRef(val name: String)
 
 /**
  * Represents a reference to a function to be evaluated, including its signature and arguments.
  * Signature is only required when there are multiple overloads of the function.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class EvaluationFunctionRef(

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationParams.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationParams.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import org.cqframework.cql.shared.JsOnlyExport
@@ -20,7 +19,6 @@ import org.opencds.cqf.cql.engine.util.ZonedDateTime
  * @property debugMap Captures debug information during evaluation.
  * @property evaluationDateTime Represents the evaluation date and time.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class EvaluationParams(

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResult.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResult.kt
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsName
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.debug.DebugResult
 import org.opencds.cqf.cql.engine.execution.trace.Trace
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class EvaluationResult {

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResults.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResults.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.hl7.elm.r1.VersionedIdentifier
 
@@ -8,7 +7,6 @@ import org.hl7.elm.r1.VersionedIdentifier
  * Track evaluation results and exceptions for multiple libraries in a single evaluation, to support
  * partial successes and partial failures across libraries.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 class EvaluationResults private constructor(builder: Builder) {

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/ExpressionResult.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/ExpressionResult.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.execution
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Value
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class ExpressionResult(val value: Value?, val evaluatedResources: MutableSet<Value?>?)

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/model/ModelResolver.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.model
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 import org.opencds.cqf.cql.engine.elm.executing.EquivalentEvaluator
@@ -14,7 +13,6 @@ import org.opencds.cqf.cql.engine.runtime.Value
  * implementation schemes with the simplest example being classes in different package names, but
  * also possibly with different property naming schemes, etc.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface ModelResolver {
     /**

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/retrieve/RetrieveProvider.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/retrieve/RetrieveProvider.kt
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.engine.retrieve
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Code
 import org.opencds.cqf.cql.engine.runtime.Interval
 import org.opencds.cqf.cql.engine.runtime.Value
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 interface RetrieveProvider {
     @Suppress("NON_EXPORTABLE_TYPE")

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/BaseTemporal.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 sealed class BaseTemporal : SimpleValue, Comparable<BaseTemporal> {
     @JsExport.Ignore var precision: Precision? = null

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ClassInstance.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 
@@ -8,7 +7,6 @@ import org.cqframework.cql.shared.QName
  * Represents an instance of a non-system-defined class (instance of a named structured type defined
  * outside the System model), e.g. a FHIR.Patient.
  */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class ClassInstance(
     override val type: QName,

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Code.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Code : StructuredValue(), NamedTypeValue {
     override val type = codeTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/CodeSystem.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/CodeSystem.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class CodeSystem : Vocabulary() {
     override val type = codeSystemTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Concept.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Concept : StructuredValue(), NamedTypeValue {
     override val type = conceptTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Date.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.jvm.JvmOverloads
@@ -18,7 +17,6 @@ import org.opencds.cqf.cql.engine.util.offsetDateTimeOfInstant
 import org.opencds.cqf.cql.engine.util.timeZoneGetDefault
 import org.opencds.cqf.cql.engine.util.toPaddedString
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Date : BaseTemporal {
     override val type = dateTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/DateTime.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.math.abs
@@ -18,7 +17,6 @@ import org.opencds.cqf.cql.engine.util.offsetDateTimeParse
 import org.opencds.cqf.cql.engine.util.toPaddedString
 import org.opencds.cqf.cql.engine.util.zoneOffsetOfHoursMinutes
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class DateTime : BaseTemporal {
     override val type = dateTimeTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Interval.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Interval.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.jvm.JvmOverloads
 import kotlin.toString
@@ -16,7 +15,6 @@ import org.opencds.cqf.cql.engine.exception.InvalidInterval
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument
 import org.opencds.cqf.cql.engine.execution.State
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Interval
 @JvmOverloads

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/List.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @Suppress("NON_EXPORTABLE_TYPE")
 data class List(val value: Iterable<Value?>) : Value, Iterable<Value?> by value {

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/NamedTypeValue.kt
@@ -1,9 +1,7 @@
-@file:OptIn(ExperimentalJsExport::class)
 @file:JsOnlyExport
 
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 import org.cqframework.cql.shared.QName
 

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.jvm.JvmStatic
 import org.cqframework.cql.cql2elm.StringEscapeUtils.escapeCql
 import org.cqframework.cql.shared.BigDecimal
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Quantity : StructuredValue(), NamedTypeValue, Comparable<Quantity> {
     override val type = quantityTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Ratio.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Ratio : StructuredValue(), NamedTypeValue {
     override val type = ratioTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/SimpleValue.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.cql2elm.StringEscapeUtils.escapeCql
 import org.cqframework.cql.shared.BigDecimal
 import org.cqframework.cql.shared.JsOnlyExport

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/StructuredValue.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
 /** Represents a structured CQL value. */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 sealed class StructuredValue : Value {
     abstract val elements: MutableMap<kotlin.String, Value?>

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Time.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import org.cqframework.cql.shared.JsOnlyExport
@@ -9,7 +8,6 @@ import org.opencds.cqf.cql.engine.util.LocalTime
 import org.opencds.cqf.cql.engine.util.localTimeParse
 import org.opencds.cqf.cql.engine.util.toPaddedString
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Time : BaseTemporal {
     override val type = timeTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Tuple.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
 /** Represents a CQL Tuple value. */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class Tuple : StructuredValue() {
     override val typeAsString = "Tuple"

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Value.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Value.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
 /** Represents a non-null CQL value. */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 sealed interface Value {
     val typeAsString: kotlin.String

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/ValueSet.kt
@@ -1,10 +1,8 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsName
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 class ValueSet : Vocabulary() {
     override val type = valueSetTypeName

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Vocabulary.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.runtime
 
-import kotlin.js.ExperimentalJsExport
 import org.cqframework.cql.shared.JsOnlyExport
 
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 sealed class Vocabulary : StructuredValue(), NamedTypeValue {
     var id: kotlin.String? = null

--- a/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/Iterable.kt
+++ b/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/Iterable.kt
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.util
 
-@OptIn(ExperimentalJsExport::class)
 @JsExport
 @Suppress("NON_EXPORTABLE_TYPE")
 fun <T> iterableToList(iterable: Iterable<T>) = iterable.toList()

--- a/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/TimeJs.kt
+++ b/engine/src/jsMain/kotlin/org/opencds/cqf/cql/engine/util/TimeJs.kt
@@ -3,7 +3,7 @@ package org.opencds.cqf.cql.engine.util
 // https://github.com/Kotlin/kotlinx-datetime#note-about-time-zones-in-js
 @JsModule("@js-joda/timezone") @JsNonModule external object JsJodaTimeZoneModule
 
-@OptIn(ExperimentalJsExport::class) @JsExport val jsJodaTz = JsJodaTimeZoneModule
+@JsExport val jsJodaTz = JsJodaTimeZoneModule
 
 actual typealias Date = DateJs
 

--- a/engine/src/wasmJsMain/kotlin/org/opencds/cqf/cql/engine/util/TimeWasmJs.kt
+++ b/engine/src/wasmJsMain/kotlin/org/opencds/cqf/cql/engine/util/TimeWasmJs.kt
@@ -1,9 +1,7 @@
 package org.opencds.cqf.cql.engine.util
 
 // https://github.com/Kotlin/kotlinx-datetime#note-about-time-zones-in-wasmjs
-@OptIn(ExperimentalWasmJsInterop::class)
-@JsModule("@js-joda/timezone")
-external object JsJodaTimeZoneModule
+@JsModule("@js-joda/timezone") external object JsJodaTimeZoneModule
 
 private val jsJodaTz = JsJodaTimeZoneModule
 

--- a/shared/src/commonMain/kotlin/org/cqframework/cql/shared/BigDecimalJs.kt
+++ b/shared/src/commonMain/kotlin/org/cqframework/cql/shared/BigDecimalJs.kt
@@ -1,11 +1,8 @@
-@file:OptIn(ExperimentalJsExport::class)
-
 package org.cqframework.cql.shared
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal as KtBigDecimal
 import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.RoundingMode as KtRoundingMode
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 

--- a/shared/src/commonMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
+++ b/shared/src/commonMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
@@ -1,8 +1,5 @@
 package org.cqframework.cql.shared
 
 import kotlin.annotation.AnnotationTarget.*
-import kotlin.js.ExperimentalJsExport
 
-@OptIn(ExperimentalJsExport::class)
-@Target(CLASS, PROPERTY, FUNCTION, FILE)
-expect annotation class JsOnlyExport()
+@Target(CLASS, PROPERTY, FUNCTION, FILE) expect annotation class JsOnlyExport()

--- a/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QNameJs.kt
+++ b/shared/src/commonMain/kotlin/org/cqframework/cql/shared/QNameJs.kt
@@ -1,11 +1,9 @@
 package org.cqframework.cql.shared
 
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.js.JsName
 
 /** A minimal pure-Kotlin implementation of QName for non-Java environments. */
-@OptIn(ExperimentalJsExport::class)
 @JsOnlyExport
 @JsName("QName")
 class QNameJs(

--- a/shared/src/jsMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
+++ b/shared/src/jsMain/kotlin/org/cqframework/cql/shared/JsOnlyExport.kt
@@ -1,4 +1,3 @@
 package org.cqframework.cql.shared
 
-@OptIn(ExperimentalJsExport::class)
 actual typealias JsOnlyExport = JsExport

--- a/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlParserDomApi.kt
+++ b/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlParserDomApi.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.shared.serializing
 
-import kotlin.js.ExperimentalWasmJsInterop
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.w3c.dom.parsing.DOMParser

--- a/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlParserPolyfill.kt
+++ b/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlParserPolyfill.kt
@@ -1,8 +1,4 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 package org.cqframework.cql.shared.serializing
-
-import kotlin.js.ExperimentalWasmJsInterop
 
 @JsModule("saxes")
 private external object Saxes {

--- a/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlWasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/org/cqframework/cql/shared/serializing/XmlWasmJs.kt
@@ -1,13 +1,9 @@
-@file:OptIn(ExperimentalWasmJsInterop::class)
-
 /*
  * This file contains the implementation of XML parsing and serialization
  * for the WASM/JS target.
  */
 
 package org.cqframework.cql.shared.serializing
-
-import kotlin.js.ExperimentalWasmJsInterop
 
 /**
  * Returns true if the DOM API is available in the current environment for XML parsing and


### PR DESCRIPTION
* Add `ExperimentalJsExport`, `ExperimentalJsStatic`, `ExperimentalWasmJsInterop` as Kotlin compiler options. This is commonly done in KMP/JS projects so that you don't have add this everywhere:
```kt
import kotlin.js.ExperimentalJsExport
import kotlin.js.ExperimentalJsStatic
import kotlin.js.ExperimentalWasmJsInterop

@OptIn(ExperimentalJsExport::class)
@OptIn(ExperimentalJsStatic::class)
@OptIn(ExperimentalWasmJsInterop::class)
```