### PR TITLE
Fix convert of calendar-unit quantities returning null (#1682)

### DIFF
--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluator.kt
@@ -37,7 +37,12 @@ object ConvertQuantityEvaluator {
                 return null
             }
             try {
-                val result = ucumService.convert(argument.value!!, argument.unit!!, unit.value)
+                // FHIRHelpers.ToQuantity (and CQL calendar-duration literals) produce calendar
+                // keyword units such as "day", which UCUM cannot parse. Normalize both operands to
+                // their UCUM codes before converting.
+                val sourceUnit = Quantity.toUcumUnit(argument.unit!!)
+                val targetUnit = Quantity.toUcumUnit(unit.value)
+                val result = ucumService.convert(argument.value!!, sourceUnit, targetUnit)
                 return Quantity().withValue(result).withUnit(unit.value)
             } catch (e: Exception) {
                 return null

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/runtime/Quantity.kt
@@ -57,6 +57,34 @@ class Quantity : StructuredValue(), NamedTypeValue, Comparable<Quantity> {
             return unit == null || unit == "" || unit == DEFAULT_UNIT
         }
 
+        /**
+         * Normalizes a CQL calendar-duration keyword (e.g. "day"/"days") to its UCUM code (e.g.
+         * "d") so the value can be handed to the UCUM service. Units that are not calendar keywords
+         * are returned unchanged.
+         */
+        @JvmStatic
+        fun toUcumUnit(unit: kotlin.String): kotlin.String {
+            return when (unit) {
+                "year",
+                "years" -> "a"
+                "month",
+                "months" -> "mo"
+                "week",
+                "weeks" -> "wk"
+                "day",
+                "days" -> "d"
+                "hour",
+                "hours" -> "h"
+                "minute",
+                "minutes" -> "min"
+                "second",
+                "seconds" -> "s"
+                "millisecond",
+                "milliseconds" -> "ms"
+                else -> unit
+            }
+        }
+
         fun unitsEqual(leftUnit: kotlin.String?, rightUnit: kotlin.String?): kotlin.Boolean {
             if (isDefaultUnit(leftUnit) && isDefaultUnit(rightUnit)) {
                 return true

--- a/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/runtime/QuantityTest.kt
+++ b/engine/src/commonTest/kotlin/org/opencds/cqf/cql/engine/runtime/QuantityTest.kt
@@ -1,0 +1,42 @@
+package org.opencds.cqf.cql.engine.runtime
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class QuantityTest {
+    @Test
+    fun toUcumUnitMapsCalendarKeywordsToUcumCodes() {
+        // Every CQL calendar-duration keyword (singular and plural) maps to its UCUM code so the
+        // value can be handed to the UCUM service (#1682).
+        assertEquals("a", Quantity.toUcumUnit("year"))
+        assertEquals("a", Quantity.toUcumUnit("years"))
+        assertEquals("mo", Quantity.toUcumUnit("month"))
+        assertEquals("mo", Quantity.toUcumUnit("months"))
+        assertEquals("wk", Quantity.toUcumUnit("week"))
+        assertEquals("wk", Quantity.toUcumUnit("weeks"))
+        assertEquals("d", Quantity.toUcumUnit("day"))
+        assertEquals("d", Quantity.toUcumUnit("days"))
+        assertEquals("h", Quantity.toUcumUnit("hour"))
+        assertEquals("h", Quantity.toUcumUnit("hours"))
+        assertEquals("min", Quantity.toUcumUnit("minute"))
+        assertEquals("min", Quantity.toUcumUnit("minutes"))
+        assertEquals("s", Quantity.toUcumUnit("second"))
+        assertEquals("s", Quantity.toUcumUnit("seconds"))
+        assertEquals("ms", Quantity.toUcumUnit("millisecond"))
+        assertEquals("ms", Quantity.toUcumUnit("milliseconds"))
+    }
+
+    @Test
+    fun toUcumUnitLeavesNonCalendarUnitsUnchanged() {
+        // Already-valid UCUM codes (including UCUM's own time atoms and the annotation/default
+        // units) must pass through untouched.
+        assertEquals("mg", Quantity.toUcumUnit("mg"))
+        assertEquals("g", Quantity.toUcumUnit("g"))
+        assertEquals("mg/dL", Quantity.toUcumUnit("mg/dL"))
+        assertEquals("d", Quantity.toUcumUnit("d"))
+        assertEquals("wk", Quantity.toUcumUnit("wk"))
+        assertEquals("1", Quantity.toUcumUnit("1"))
+        assertEquals("", Quantity.toUcumUnit(""))
+        assertEquals("{score}", Quantity.toUcumUnit("{score}"))
+    }
+}

--- a/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluatorTest.kt
+++ b/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluatorTest.kt
@@ -1,0 +1,27 @@
+package org.opencds.cqf.cql.engine.elm.executing
+
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+import org.opencds.cqf.cql.engine.execution.CqlTestBase
+import org.opencds.cqf.cql.engine.runtime.Quantity
+import org.opencds.cqf.cql.engine.runtime.toCqlString
+
+internal class ConvertQuantityEvaluatorTest : CqlTestBase() {
+    @Test
+    fun convertQuantityWithCalendarUnitSource() {
+        // Regression for #1682: FHIRHelpers.ToQuantity yields calendar-keyword units (a FHIR 'd'
+        // becomes "day"), which UCUM cannot parse. Converting such a quantity must still succeed
+        // instead of silently returning null.
+        val ucumService = environment!!.libraryManager!!.ucumService
+        val source = Quantity().withValue(BigDecimal("30")).withUnit("day")
+
+        val result =
+            ConvertQuantityEvaluator.convertQuantity(source, "d".toCqlString(), ucumService)
+
+        assertNotNull(result)
+        assertEquals("d", result!!.unit)
+        assertEquals(0, result.value!!.compareTo(BigDecimal("30")))
+    }
+}

--- a/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluatorTest.kt
+++ b/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/elm/executing/ConvertQuantityEvaluatorTest.kt
@@ -3,25 +3,102 @@ package org.opencds.cqf.cql.engine.elm.executing
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.execution.CqlTestBase
 import org.opencds.cqf.cql.engine.runtime.Quantity
 import org.opencds.cqf.cql.engine.runtime.toCqlString
 
 internal class ConvertQuantityEvaluatorTest : CqlTestBase() {
+    private val ucumService = libraryManager.ucumService
+
+    private fun convert(value: kotlin.String, unit: kotlin.String, target: kotlin.String) =
+        ConvertQuantityEvaluator.convertQuantity(
+            Quantity().withValue(BigDecimal(value)).withUnit(unit),
+            target.toCqlString(),
+            ucumService,
+        )
+
     @Test
     fun convertQuantityWithCalendarUnitSource() {
         // Regression for #1682: FHIRHelpers.ToQuantity yields calendar-keyword units (a FHIR 'd'
         // becomes "day"), which UCUM cannot parse. Converting such a quantity must still succeed
         // instead of silently returning null.
-        val ucumService = environment!!.libraryManager!!.ucumService
-        val source = Quantity().withValue(BigDecimal("30")).withUnit("day")
-
-        val result =
-            ConvertQuantityEvaluator.convertQuantity(source, "d".toCqlString(), ucumService)
+        val result = convert("30", "day", "d")
 
         assertNotNull(result)
         assertEquals("d", result!!.unit)
         assertEquals(0, result.value!!.compareTo(BigDecimal("30")))
+    }
+
+    @Test
+    fun convertQuantityCalendarSourceActuallyConverts() {
+        // A value-changing conversion proves the calendar keyword is normalized *and* the UCUM
+        // conversion runs (not merely relabeled): 1 week = 7 days.
+        val result = convert("1", "week", "d")
+
+        assertNotNull(result)
+        assertEquals("d", result!!.unit)
+        assertEquals(0, result.value!!.compareTo(BigDecimal("7")))
+    }
+
+    @Test
+    fun convertQuantityCalendarSourceAndCalendarTarget() {
+        // The reported shape, `convert D.daysSupply to days`: both source and target are calendar
+        // keywords. The result keeps the requested target keyword as its unit.
+        val result = convert("30", "day", "days")
+
+        assertNotNull(result)
+        assertEquals("days", result!!.unit)
+        assertEquals(0, result.value!!.compareTo(BigDecimal("30")))
+    }
+
+    @Test
+    fun convertQuantityCalendarTargetActuallyConverts() {
+        // Calendar keyword as the target, with a value-changing conversion: 2 days = 48 hours.
+        val result = convert("2", "day", "hour")
+
+        assertNotNull(result)
+        assertEquals("hour", result!!.unit)
+        assertEquals(0, result.value!!.compareTo(BigDecimal("48")))
+    }
+
+    @Test
+    fun convertQuantityPlainUcumUnitsUnaffected() {
+        // The normalization must not disturb ordinary UCUM conversions: 5 mg = 0.005 g.
+        val result = convert("5", "mg", "g")
+
+        assertNotNull(result)
+        assertEquals("g", result!!.unit)
+        assertEquals(0, result.value!!.compareTo(BigDecimal("0.005")))
+    }
+
+    @Test
+    fun convertQuantityIncompatibleUnitsReturnNull() {
+        // Mass cannot be converted to a duration; UCUM throws and the operator yields null.
+        assertNull(convert("5", "mg", "day"))
+    }
+
+    @Test
+    fun convertQuantityNullArgumentsReturnNull() {
+        assertNull(ConvertQuantityEvaluator.convertQuantity(null, "g".toCqlString(), ucumService))
+        assertNull(
+            ConvertQuantityEvaluator.convertQuantity(
+                Quantity().withValue(BigDecimal("5")).withUnit("mg"),
+                null,
+                ucumService,
+            )
+        )
+    }
+
+    @Test
+    fun convertQuantityNullUcumServiceReturnsNull() {
+        assertNull(
+            ConvertQuantityEvaluator.convertQuantity(
+                Quantity().withValue(BigDecimal("5")).withUnit("mg"),
+                "g".toCqlString(),
+                null,
+            )
+        )
     }
 }


### PR DESCRIPTION
## Problem

`(convert D.daysSupply to days).value` returns null when it should return the value.

`MedicationDispense.daysSupply` (and similar fields) is a FHIR Quantity carrying the UCUM code 'd'. When that value flows into CQL, `FHIRHelpers.ToQuantity` normalizes the unit to the CQL calendar keyword 'day', which is intentional, since CQL calendar arithmetic depends on these keywords.

The problem is downstream: ConvertQuantityEvaluator passed that 'day' string straight to the UCUM service:

`ucumService.convert(argument.value, argument.unit /* "day" */, unit.value /* "d" */)`

'day' is not a valid UCUM atom (UCUM's day is 'd'), so convert throws, and the evaluator's catch swallows it into null. Reading .value directly (`D.daysSupply.value`) works because it never touches the unit.

Notably, the translator already normalizes the target of convert … to days to 'd' (via ensureUcumUnit); the gap is only on the source unit, which is produced at runtime by FHIRHelpers.

## Fix

- Added `Quantity.toUcumUnit(unit)` - normalizes CQL calendar-duration keywords to their UCUM codes. It reuses the same calendar↔UCUM table already encoded in `Quantity.unitsEqual/unitsEquivalent`, and returns non-calendar units unchanged.
- ConvertQuantityEvaluator now normalizes both operands (argument.unit and the target unit.value) through toUcumUnit before calling ucumService.convert, so a source unit of 'day' resolves to 'd' and the conversion succeeds.

The fix is deliberately in the engine - `FHIRHelpers.ToQuantity` emitting calendar keywords is correct and spec-conformant, and ConvertQuantity is documented as a UCUM-based operation, so normalizing calendar keywords to UCUM at that boundary is the right layer.

## Tests

Added ConvertQuantityEvaluatorTest, which converts a Quantity(30, "day") — exactly what `FHIRHelpers.ToQuantity` produces from a FHIR daysSupply — to 'd' and asserts 30 'd'. Without the fix this returns null (UCUM rejects "day"), so it's a genuine red→green guard.

Validated: spotlessApply, :engine:detekt, full :engine:jvmTest, full :engine-fhir:jvmTest - all green.

Notes

- There is no canonical cql-tests coverage for this scenario, so the new engine test is the regression guard. A FHIR-integration test mirroring the exact `MedicationDispense.daysSupply` path (in engine-fhir/clinical-reasoning) would be a good follow-up but isn't required for the fix.

Closes #1682.