### PR TITLE
Generate type definitions for the `@cqframework/cql` NPM package

### DIFF
--- a/build-logic/src/main/kotlin/GenerateTypeDefinitions.kt
+++ b/build-logic/src/main/kotlin/GenerateTypeDefinitions.kt
@@ -1,0 +1,64 @@
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+/** Generates TypeScript declaration files (.exports.d.mts) for the CQL NPM package. */
+abstract class GenerateTypeDefinitions : DefaultTask() {
+
+    /** Directory containing the compiled Kotlin/JS files. */
+    @get:InputDirectory abstract val inputDir: DirectoryProperty
+
+    /** The .d.mts file in the input directory with all type definitions. */
+    @get:Input abstract val inputDMts: Property<String>
+
+    /** Output directory for the generated .exports.d.mts files. */
+    @get:OutputDirectory abstract val outputDir: DirectoryProperty
+
+    /** Module names to generate type definitions for. */
+    @get:Input abstract val modules: ListProperty<String>
+
+    @TaskAction
+    fun generate() {
+        val inputDirFile = inputDir.get().asFile
+        val outputDirFile = outputDir.get().asFile
+
+        val inputDMts = inputDMts.get()
+        val inputDMtsFile = File(inputDirFile, "$inputDMts.d.mts")
+        val inputDMtsContent = inputDMtsFile.readText()
+
+        val declaredTypes =
+            Regex(
+                    """^export declare (?:abstract )?(?:class|function|const|interface) (\w*)""",
+                    RegexOption.MULTILINE,
+                )
+                .findAll(inputDMtsContent)
+                .map { it.groupValues[1] }
+
+        for (mod in modules.get()) {
+            val mjsFile = File(inputDirFile, "$mod.mjs")
+            val mjsFileContent = mjsFile.readText()
+
+            val exports =
+                Regex("""export \{([^}]+)};""")
+                    .findAll(mjsFileContent)
+                    .map { it.groupValues[1] }
+                    .flatMap { Regex("""\w+ as (\w+)""").findAll(it) }
+                    .map { it.groupValues[1] }
+                    .filter { it in declaredTypes }
+
+            val content = buildString {
+                appendLine("export {")
+                exports.forEach { appendLine("  $it,") }
+                appendLine("} from \"./$inputDMts.d.mts\";")
+            }
+
+            File(outputDirFile, "$mod.exports.d.mts").writeText(content)
+        }
+    }
+}

--- a/npm-cql/build.gradle.kts
+++ b/npm-cql/build.gradle.kts
@@ -1,21 +1,36 @@
 plugins { id("cql.node-gradle-conventions") }
 
 val engineJsDistDir = project(":engine").layout.buildDirectory.dir("dist/js/productionLibrary")
-val preparedPackageDir = layout.buildDirectory.dir("npm-package")
 
-/** Assembles the `@cqframework/cql` NPM package. */
-val preparePackage by
-    tasks.registering(Sync::class) {
+val generateTypeDefinitions by
+    tasks.registering(GenerateTypeDefinitions::class) {
+        description = "Generates .d.mts files for the NPM package."
+
         dependsOn(
             ":engine:jsBrowserProductionLibraryDistribution",
             ":engine:jsNodeProductionLibraryDistribution",
         )
+
+        inputDir.set(engineJsDistDir)
+        inputDMts.set("engine")
+        outputDir.set(layout.buildDirectory.dir("generated-type-definitions"))
+        modules.set(listOf("cql", "cql-to-elm", "elm", "engine", "kotlin-kotlin-stdlib", "shared"))
+    }
+
+val preparedPackageDir = layout.buildDirectory.dir("npm-package")
+
+val preparePackage by
+    tasks.registering(Sync::class) {
+        description = "Assembles the `@cqframework/cql` NPM package."
+
+        dependsOn(generateTypeDefinitions)
 
         from(engineJsDistDir) { exclude("package.json") }
         from(layout.projectDirectory) {
             include("package.json", "README.md")
             expand("version" to project.version.toString())
         }
+        from(generateTypeDefinitions.map { it.outputDir })
         into(preparedPackageDir)
     }
 

--- a/npm-cql/package.json
+++ b/npm-cql/package.json
@@ -14,23 +14,27 @@
   "type": "module",
   "exports": {
     "./cql": {
-      "types": "./engine.d.mts",
+      "types": "./cql.exports.d.mts",
       "default": "./cql.mjs"
     },
     "./cql-to-elm": {
-      "types": "./engine.d.mts",
+      "types": "./cql-to-elm.exports.d.mts",
       "default": "./cql-to-elm.mjs"
     },
     "./elm": {
-      "types": "./engine.d.mts",
+      "types": "./elm.exports.d.mts",
       "default": "./elm.mjs"
     },
     "./engine": {
-      "types": "./engine.d.mts",
+      "types": "./engine.exports.d.mts",
       "default": "./engine.mjs"
     },
+    "./kotlin-kotlin-stdlib": {
+      "types": "./kotlin-kotlin-stdlib.exports.d.mts",
+      "default": "./kotlin-kotlin-stdlib.mjs"
+    },
     "./shared": {
-      "types": "./engine.d.mts",
+      "types": "./shared.exports.d.mts",
       "default": "./shared.mjs"
     }
   },


### PR DESCRIPTION
See https://github.com/cqframework/clinical_quality_language/issues/1768#issuecomment-4898553304.

The solution is to generate type definitions for every module (subpath export) in the `@cqframework/cql` package. The generated `cql.exports.d.mts`, `cql-to-elm.exports.d.mts`, `engine.exports.d.mts`, etc. re-export relevant type declarations from `engine.d.mts` generated by the Kotlin/JS compiler.

The `:npm-cql:generateTypeDefinitions` task is integrated into the Gradle build. The final npm package looks like this https://github.com/antvaset/cql-npm/tree/05d945b.