### PR TITLE
Fix loading of compiled libraries

### DIFF
--- a/cql-to-elm/detekt-baseline.xml
+++ b/cql-to-elm/detekt-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>MaxLineLength:LibraryManager.kt$LibraryManager$"Library ${library.identifier?.id} uses ${it.localIdentifier} model with URI ${it.uri} but resolved model has name ${model.modelInfo.name} and URI ${model.modelInfo.url}"</ID>
-    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun dataTypeToProfileQName(type: DataType?): QName?</ID>
-    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun getTypeUri(type: DataType?): String?</ID>
-    <ID>TooManyFunctions:TypeResolver.kt$TypeResolver</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/cql-to-elm/detekt-baseline.xml
+++ b/cql-to-elm/detekt-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:LibraryManager.kt$LibraryManager$"Library ${library.identifier?.id} uses ${it.localIdentifier} model with URI ${it.uri} but resolved model has name ${model.modelInfo.name} and URI ${model.modelInfo.url}"</ID>
+    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun dataTypeToProfileQName(type: DataType?): QName?</ID>
+    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun getTypeUri(type: DataType?): String?</ID>
+    <ID>TooManyFunctions:TypeResolver.kt$TypeResolver</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/Cql2ElmVisitor.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/Cql2ElmVisitor.kt
@@ -494,9 +494,9 @@ class Cql2ElmVisitor(
                                 .withExpression(
                                     of.createSingletonFrom().withOperand(contextRetrieve)
                                 )
-                        track(modelContextDefinition, ctx)
                         modelContextDefinition.expression!!.resultType = contextType
                         modelContextDefinition.resultType = contextType
+                        track(modelContextDefinition, ctx)
                         libraryBuilder.addExpression(modelContextDefinition)
                         this.contextDefinitions[modelContext.name] = modelContextDefinition
                     }
@@ -506,11 +506,11 @@ class Cql2ElmVisitor(
                             .withName(unqualifiedIdentifier)
                             .withContext(this.currentContext)
                             .withExpression(of.createNull())
-                    track(modelContextDefinition, ctx)
                     modelContextDefinition.expression!!.resultType =
                         libraryBuilder.resolveTypeName("System", "Any")
                     modelContextDefinition.resultType =
                         modelContextDefinition.expression!!.resultType
+                    track(modelContextDefinition, ctx)
                     libraryBuilder.addExpression(modelContextDefinition)
                     this.contextDefinitions[modelContext.name] = modelContextDefinition
                 }
@@ -4549,6 +4549,10 @@ class Cql2ElmVisitor(
         }
     }
 
+    /**
+     * Adds trackbacks, locator, `resultTypeName`/`resultTypeSpecifier` to the ELM [Element]. For
+     * result types to be added to ELM, make sure this is called after [Element.resultType] is set.
+     */
     private fun track(trackable: Element?, pt: ParseTree): TrackBack? {
         val tb = getTrackBack(pt)
         if (tb != null) {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
@@ -10,6 +10,7 @@ import org.cqframework.cql.cql2elm.model.CompiledLibrary
 import org.cqframework.cql.cql2elm.tracking.Trackable.resultType
 import org.cqframework.cql.cql2elm.ucum.UcumService
 import org.cqframework.cql.cql2elm.ucum.defaultLazyUcumService
+import org.cqframework.cql.cql2elm.utils.getTranslatorVersion
 import org.cqframework.cql.cql2elm.utils.logger
 import org.cqframework.cql.elm.serializing.DefaultElmLibraryReaderProvider
 import org.cqframework.cql.elm.serializing.ElmLibraryReaderProvider
@@ -51,6 +52,8 @@ constructor(
         }
 
     val ucumService by lazyUcumService
+
+    val typeResolver = TypeResolver(this)
 
     /**
      * A "well-known" library name is one that is allowed to resolve without a namespace in a
@@ -332,7 +335,25 @@ constructor(
             val compiledLibrary = CompiledLibrary()
             compiledLibrary.library = library
             compiledLibrary.identifier = library.identifier
-            library.usings?.def?.forEach { compiledLibrary.add(it) }
+            library.usings?.def?.forEach {
+                requireNotNull(it.localIdentifier) {
+                    "Missing model identifier in a using element in library ${library.identifier?.id}."
+                }
+
+                // To enable type resolution, the models referenced in ELM expressions need to be
+                // loaded.
+                val model = modelManager.resolveModel(it.localIdentifier!!, it.version)
+
+                // Extra compatibility check to make sure the model name and URI in the compiled
+                // library match those in the resolved model.
+                require(
+                    model.modelInfo.name == it.localIdentifier && model.modelInfo.url == it.uri
+                ) {
+                    "Library ${library.identifier?.id} uses ${it.localIdentifier} model with URI ${it.uri} but resolved model has name ${model.modelInfo.name} and URI ${model.modelInfo.url}"
+                }
+
+                compiledLibrary.add(it)
+            }
 
             library.includes?.def?.forEach { compiledLibrary.add(it) }
 
@@ -347,8 +368,16 @@ constructor(
             library.parameters?.def?.forEach { compiledLibrary.add(it) }
 
             library.statements?.def?.forEach {
-                requireNotNull(it.resultType) {
+                // Result types must be present for every expression
+                require(it.resultTypeName != null || it.resultTypeSpecifier != null) {
                     "Expression ${it.name} in library ${library.identifier?.id} does not have a result type."
+                }
+
+                // Resolve the result type for the expression
+                if (it.resultTypeName != null) {
+                    it.resultType = typeResolver.resolveTypeName(it.resultTypeName!!)
+                } else if (it.resultTypeSpecifier != null) {
+                    it.resultType = typeResolver.resolveTypeSpecifier(it.resultTypeSpecifier!!)
                 }
 
                 compiledLibrary.add(it)
@@ -417,14 +446,13 @@ constructor(
         return false
     }
 
+    /**
+     * Compares the version of the currently running translator with the version used to compile the
+     * resolved compiled library.
+     */
     private fun isVersionCompatible(library: Library): Boolean {
-        if (this.cqlCompilerOptions.compatibilityLevel.isNotEmpty()) {
-            val version = CompilerOptions.getCompilerVersion(library)
-            if (version != null) {
-                return version == this.cqlCompilerOptions.compatibilityLevel
-            }
-        }
-        return false
+        val version = CompilerOptions.getCompilerVersion(library) ?: return false
+        return version == getTranslatorVersion()
     }
 
     internal class FunctionSig(private val name: String, private val numArguments: Int) {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/LibraryManager.kt
@@ -349,6 +349,7 @@ constructor(
                 require(
                     model.modelInfo.name == it.localIdentifier && model.modelInfo.url == it.uri
                 ) {
+                    @Suppress("MaxLineLength")
                     "Library ${library.identifier?.id} uses ${it.localIdentifier} model with URI ${it.uri} but resolved model has name ${model.modelInfo.name} and URI ${model.modelInfo.url}"
                 }
 

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/TypeResolver.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/TypeResolver.kt
@@ -17,7 +17,10 @@ import org.hl7.elm.r1.NamedTypeSpecifier
 import org.hl7.elm.r1.TupleTypeSpecifier
 import org.hl7.elm.r1.TypeSpecifier
 
+@Suppress("TooManyFunctions")
 class TypeResolver(val libraryManager: LibraryManager) {
+
+    @Suppress("ReturnCount")
     fun getTypeUri(type: DataType?): String? {
         if (type is ListType) {
             return getTypeUri(type.elementType)
@@ -35,6 +38,7 @@ class TypeResolver(val libraryManager: LibraryManager) {
         return null
     }
 
+    @Suppress("ReturnCount")
     fun dataTypeToProfileQName(type: DataType?): QName? {
         if (type is ClassType) {
             if (type.identifier != null) {

--- a/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/TypeResolver.kt
+++ b/cql-to-elm/src/commonMain/kotlin/org/cqframework/cql/cql2elm/TypeResolver.kt
@@ -1,14 +1,7 @@
-package org.cqframework.cql.elm.requirements
+package org.cqframework.cql.cql2elm
 
-import javax.xml.namespace.QName
-import kotlin.Boolean
-import kotlin.IllegalArgumentException
-import kotlin.require
-import kotlin.requireNotNull
-import kotlin.text.lastIndexOf
-import kotlin.text.substring
-import org.cqframework.cql.cql2elm.LibraryManager
 import org.cqframework.cql.cql2elm.tracking.Trackable.resultType
+import org.cqframework.cql.shared.QName
 import org.hl7.cql.model.ChoiceType
 import org.hl7.cql.model.ClassType
 import org.hl7.cql.model.DataType
@@ -36,7 +29,7 @@ class TypeResolver(val libraryManager: LibraryManager) {
         }
 
         if (type is NamedType) {
-            return dataTypeToQName(type).localPart
+            return dataTypeToQName(type).getLocalPart()
         }
 
         return null
@@ -75,7 +68,7 @@ class TypeResolver(val libraryManager: LibraryManager) {
         if (type is NamedType) {
             val namedType = type as NamedType
             val modelInfo = libraryManager.modelManager.resolveModel(namedType.namespace).modelInfo
-            return QName(modelInfo.url, namedType.simpleName)
+            return QName(modelInfo.url!!, namedType.simpleName)
         }
 
         // ERROR:
@@ -85,13 +78,11 @@ class TypeResolver(val libraryManager: LibraryManager) {
     fun resolveTypeName(typeName: QName): DataType {
 
         // NOTE: This resolution path is ignoring prefix, namespace is required
-        require(!(typeName.namespaceURI == null || typeName.namespaceURI == "")) {
-            "namespaceURI is required"
-        }
+        require(typeName.getNamespaceURI().isNotEmpty()) { "namespaceURI is required" }
 
-        val model = libraryManager.modelManager.resolveModelByUri(typeName.namespaceURI)
-        val result = model.resolveTypeName(typeName.localPart)
-        requireNotNull(result) { "Could not resolve type ${typeName.toString()}" }
+        val model = libraryManager.modelManager.resolveModelByUri(typeName.getNamespaceURI())
+        val result = model.resolveTypeName(typeName.getLocalPart())
+        requireNotNull(result) { "Could not resolve type $typeName" }
         return result
     }
 
@@ -125,7 +116,7 @@ class TypeResolver(val libraryManager: LibraryManager) {
 
             else -> {
                 throw IllegalArgumentException(
-                    "Unknown type specifier category: ${typeSpecifier.javaClass.simpleName}"
+                    "Unknown type specifier category: ${typeSpecifier::class.simpleName}"
                 )
             }
         }

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/BaseTestLibrarySourceProvider.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/BaseTestLibrarySourceProvider.kt
@@ -1,0 +1,37 @@
+package org.cqframework.cql.cql2elm
+
+import kotlinx.io.Source
+import kotlinx.io.buffered
+import org.cqframework.cql.cql2elm.utils.asSource
+import org.cqframework.cql.cql2elm.utils.getTranslatorVersion
+import org.hl7.elm.r1.VersionedIdentifier
+
+/**
+ * Loads libraries from the resources directory and replaces `{translatorVersion}` with the current
+ * translator version in the library source to pass the compatibility checks.
+ */
+open class BaseTestLibrarySourceProvider(
+    val getFileName: (libraryIdentifier: VersionedIdentifier, type: LibraryContentType) -> String
+) : LibrarySourceProvider {
+
+    override fun getLibrarySource(libraryIdentifier: VersionedIdentifier): Source? {
+        return getLibraryContent(libraryIdentifier, LibraryContentType.CQL)
+    }
+
+    override fun getLibraryContent(
+        libraryIdentifier: VersionedIdentifier,
+        type: LibraryContentType,
+    ): Source? {
+        val inputStream =
+            BaseTestLibrarySourceProvider::class
+                .java
+                .getResourceAsStream(getFileName(libraryIdentifier, type))
+        if (inputStream != null) {
+            val content = inputStream.readBytes().toString(Charsets.UTF_8)
+            inputStream.close()
+            val contentFixed = content.replace("{translatorVersion}", getTranslatorVersion())
+            return contentFixed.asSource().buffered()
+        }
+        return null
+    }
+}

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
@@ -1,8 +1,11 @@
 package org.cqframework.cql.cql2elm
 
+import kotlin.test.assertEquals
 import org.cqframework.cql.cql2elm.model.CompiledLibrary
+import org.cqframework.cql.cql2elm.quick.FhirModelInfoProvider
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
+import org.hl7.cql.model.SystemModelInfoProvider
 import org.hl7.elm.r1.Library
 import org.hl7.elm.r1.VersionedIdentifier
 import org.junit.jupiter.api.AfterAll
@@ -341,6 +344,45 @@ internal class LibraryManagerTests {
         }
     }
 
+    @Test
+    fun compiledLibraryWithResultTypesResolvesSuccessfully() {
+        val libraryWithResultTypes =
+            libraryManager!!.resolveLibrary(VersionedIdentifier().withId("LibraryWithResultTypes"))
+        assertEquals("LibraryWithResultTypes", libraryWithResultTypes.library!!.identifier!!.id)
+    }
+
+    @Test
+    fun compiledLibraryWithoutResultTypesIsRejected() {
+        // Result types must be present for every expression, regardless of the `translatorOptions`
+        // value in the annotation. When a compiled library is not compatible (missing result types,
+        // etc.), library resolution will continue to load the library from the CQL source if it is
+        // present.
+        val cqlIncludeException =
+            Assertions.assertThrows(CqlIncludeException::class.java) {
+                libraryManager!!.resolveLibrary(
+                    VersionedIdentifier().withId("LibraryWithoutResultTypes")
+                )
+            }
+        assertEquals(
+            "Could not load source for library LibraryWithoutResultTypes, version null, namespace uri null.",
+            cqlIncludeException.message,
+        )
+    }
+
+    @Test
+    fun compiledLibraryWithIncompatibleTranslatorVersionIsRejected() {
+        val cqlIncludeException =
+            Assertions.assertThrows(CqlIncludeException::class.java) {
+                libraryManager!!.resolveLibrary(
+                    VersionedIdentifier().withId("LibraryWithIncompatibleTranslatorVersion")
+                )
+            }
+        assertEquals(
+            "Could not load source for library LibraryWithIncompatibleTranslatorVersion, version null, namespace uri null.",
+            cqlIncludeException.message,
+        )
+    }
+
     companion object {
         private val BASE_LIBRARY_ELM_IDENT = VersionedIdentifier().withId("BaseLibraryElm")
         private val BASE_LIBRARY_ELM_OTHER_IDENT =
@@ -355,27 +397,27 @@ internal class LibraryManagerTests {
         @JvmStatic
         @BeforeAll
         fun setup() {
-            val modelManager = ModelManager()
+            val modelManager =
+                ModelManager().apply {
+                    modelInfoLoader.registerModelInfoProvider(SystemModelInfoProvider())
+                    modelInfoLoader.registerModelInfoProvider(FhirModelInfoProvider())
+                }
 
-            libraryManager = LibraryManager(modelManager)
+            val compilerOptions = CqlCompilerOptions(CqlCompilerOptions.Options.EnableResultTypes)
+
+            libraryManager = LibraryManager(modelManager, compilerOptions)
             libraryManager!!
                 .librarySourceLoader
                 .registerProvider(TestLibrarySourceProvider("LibraryManagerTests"))
 
             // Used if we want to load a library with a mismatch in the version and want to test the
-            // subsequent version
-            // validation
-            libraryManagerVersionAgnostic = LibraryManager(modelManager)
+            // subsequent version validation
+            libraryManagerVersionAgnostic = LibraryManager(modelManager, compilerOptions)
             libraryManagerVersionAgnostic!!
                 .librarySourceLoader
                 .registerProvider(TestLibrarySourceVersionAgnosticProvider("LibraryManagerTests"))
 
-            libraryManagerOwnCache =
-                LibraryManager(
-                    modelManager,
-                    CqlCompilerOptions.Companion.defaultOptions(),
-                    HashMap(),
-                )
+            libraryManagerOwnCache = LibraryManager(modelManager, compilerOptions, HashMap())
             libraryManagerOwnCache!!
                 .librarySourceLoader
                 .registerProvider(TestLibrarySourceVersionAgnosticProvider("LibraryManagerTests"))

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
@@ -1,106 +1,104 @@
 package org.cqframework.cql.cql2elm
 
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import org.cqframework.cql.cql2elm.model.CompiledLibrary
 import org.cqframework.cql.cql2elm.quick.FhirModelInfoProvider
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.hl7.cql.model.SystemModelInfoProvider
 import org.hl7.elm.r1.Library
 import org.hl7.elm.r1.VersionedIdentifier
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
 
 @Suppress("MaxLineLength")
 internal class LibraryManagerTests {
     @Test
     fun invalidCql() {
-        val lib: Library? = libraryManagerOwnCache!!.resolveLibrary(INVALID_IDENT).library
+        val lib = libraryManagerOwnCache!!.resolveLibrary(INVALID_IDENT).library
 
-        Assertions.assertNotNull(lib)
-
-        MatcherAssert.assertThat(
-            libraryManagerOwnCache!!.compiledLibraries.values,
-            Matchers.empty(),
-        )
+        assertNotNull(lib)
+        assertTrue(libraryManagerOwnCache!!.compiledLibraries.values.isEmpty())
     }
 
     @Test
     fun resolveLibrariesErrors() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManagerOwnCache!!.resolveLibraries(mutableListOf())
         }
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManagerOwnCache!!.resolveLibraries(listOf(VersionedIdentifier()))
         }
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManagerOwnCache!!.resolveLibraries(listOf(VersionedIdentifier().withId(null)))
         }
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManagerOwnCache!!.resolveLibraries(listOf(VersionedIdentifier().withId("")))
         }
     }
 
     @Test
     fun basicElmTest() {
-        val lib: Library? = libraryManager!!.resolveLibrary(BASE_LIBRARY_ELM_IDENT).library
+        val lib = libraryManager!!.resolveLibrary(BASE_LIBRARY_ELM_IDENT).library
 
-        Assertions.assertNotNull(lib)
-        Assertions.assertNotNull(lib!!.statements!!.def)
+        assertNotNull(lib)
+        assertNotNull(lib.statements!!.def)
     }
 
     @Test
     fun basicElmTestMultiLib() {
-        val results: CompiledLibraryMultiResults =
-            libraryManager!!.resolveLibraries(listOf(BASE_LIBRARY_ELM_IDENT))
+        val results = libraryManager!!.resolveLibraries(listOf(BASE_LIBRARY_ELM_IDENT))
 
-        Assertions.assertNotNull(results)
+        assertNotNull(results)
 
         val compiledLibraries = results.allCompiledLibraries()
-        Assertions.assertNotNull(compiledLibraries)
-        MatcherAssert.assertThat(compiledLibraries.size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(results.allErrors(), Matchers.empty())
-        Assertions.assertFalse(results.hasErrors())
-        MatcherAssert.assertThat(results.allResultsWithoutErrorSeverity().size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT), Matchers.empty())
+        assertNotNull(compiledLibraries)
+        assertEquals(1, compiledLibraries.size)
+        assertTrue(results.allErrors().isEmpty())
+        assertFalse(results.hasErrors())
+        assertEquals(1, results.allResultsWithoutErrorSeverity().size)
+        assertTrue(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT).isEmpty())
 
         val compiledLibraryFirst = compiledLibraries[0]
         val compiledLibraryOnlyResult = results.onlyResult
-        MatcherAssert.assertThat(
+        assertEquals(
+            compiledLibraryFirst.identifier,
             compiledLibraryOnlyResult.compiledLibrary.identifier,
-            Matchers.equalTo(compiledLibraryFirst.identifier),
         )
 
         val library = compiledLibraryOnlyResult.compiledLibrary.library
 
-        Assertions.assertNotNull(library)
-        Assertions.assertNotNull(library!!.statements!!.def)
+        assertNotNull(library)
+        assertNotNull(library.statements!!.def)
     }
 
     @Test
     fun basicElmTestMultiLibTwoGoodLibs() {
-        val results: CompiledLibraryMultiResults =
+        val results =
             libraryManager!!.resolveLibraries(
                 listOf(BASE_LIBRARY_ELM_IDENT, BASE_LIBRARY_ELM_OTHER_IDENT)
             )
 
-        Assertions.assertNotNull(results)
+        assertNotNull(results)
 
         val compiledLibraries = results.allCompiledLibraries()
-        Assertions.assertNotNull(compiledLibraries)
-        MatcherAssert.assertThat(compiledLibraries.size, Matchers.equalTo(2))
-        MatcherAssert.assertThat(results.allErrors(), Matchers.empty())
-        Assertions.assertFalse(results.hasErrors())
-        MatcherAssert.assertThat(results.allResultsWithoutErrorSeverity().size, Matchers.equalTo(2))
-        MatcherAssert.assertThat(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT), Matchers.empty())
+        assertNotNull(compiledLibraries)
+        assertEquals(2, compiledLibraries.size)
+        assertTrue(results.allErrors().isEmpty())
+        assertFalse(results.hasErrors())
+        assertEquals(2, results.allResultsWithoutErrorSeverity().size)
+        assertTrue(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT).isEmpty())
 
         for (compiledLibrary in compiledLibraries) {
             val library = compiledLibrary.library
 
-            Assertions.assertNotNull(library)
-            Assertions.assertNotNull(library!!.statements!!.def)
+            assertNotNull(library)
+            assertNotNull(library.statements!!.def)
         }
     }
 
@@ -109,11 +107,11 @@ internal class LibraryManagerTests {
         val versionedIdentifier = listOf(BASE_LIBRARY_ELM_IDENT, BASE_LIBRARY_ELM_MISMATCH_ID_IDENT)
 
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManager!!.resolveLibraries(versionedIdentifier)
             }
 
-        Assertions.assertEquals(
+        assertEquals(
             "Could not load source for library BaseLibraryElmMismatchId, version 1.0.1, namespace uri null.", //                "Library BaseLibraryElmMismatchId was included with version null, but id:
             // BaseLibraryElmIdMismatch and version 1.0.0 of the library was found.",
             cqlIncludeException.message,
@@ -123,31 +121,27 @@ internal class LibraryManagerTests {
     @Test
     fun basicElmTestMultiLibOneGoodOneInvalidLibs() {
         val versionedIdentifier = listOf(BASE_LIBRARY_ELM_IDENT, INVALID_IDENT)
-        val results: CompiledLibraryMultiResults =
-            libraryManager!!.resolveLibraries(versionedIdentifier)
-        Assertions.assertNotNull(results)
+        val results = libraryManager!!.resolveLibraries(versionedIdentifier)
+        assertNotNull(results)
 
         val compiledLibraries = results.allCompiledLibraries()
-        Assertions.assertNotNull(compiledLibraries)
-        MatcherAssert.assertThat(compiledLibraries.size, Matchers.equalTo(2))
-        MatcherAssert.assertThat(results.allErrors(), Matchers.not(Matchers.empty()))
-        Assertions.assertTrue(results.hasErrors())
-        MatcherAssert.assertThat(results.allResultsWithoutErrorSeverity().size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT), Matchers.empty())
+        assertNotNull(compiledLibraries)
+        assertEquals(2, compiledLibraries.size)
+        assertTrue(results.allErrors().isNotEmpty())
+        assertTrue(results.hasErrors())
+        assertEquals(1, results.allResultsWithoutErrorSeverity().size)
+        assertTrue(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT).isEmpty())
 
         val library = results.getCompiledLibraryFor(BASE_LIBRARY_ELM_IDENT)
 
-        Assertions.assertNotNull(library)
-        Assertions.assertNotNull(library!!.library!!.statements!!.def)
+        assertNotNull(library)
+        assertNotNull(library.library!!.statements!!.def)
 
         val invalidIdentErrors = results.getErrorsFor(INVALID_IDENT)
-        MatcherAssert.assertThat(invalidIdentErrors.size, Matchers.equalTo(1))
+        assertEquals(1, invalidIdentErrors.size)
         val cqlCompilerException = invalidIdentErrors[0]
 
-        MatcherAssert.assertThat(
-            cqlCompilerException.message,
-            Matchers.equalTo("Syntax error at define"),
-        )
+        assertEquals("Syntax error at define", cqlCompilerException.message)
     }
 
     @Test
@@ -155,11 +149,11 @@ internal class LibraryManagerTests {
         val versionIdentifier = VersionedIdentifier().withId("BaseLibraryElmMismatchId")
 
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManager!!.resolveLibrary(versionIdentifier)
             }
 
-        Assertions.assertEquals(
+        assertEquals(
             "Library BaseLibraryElmMismatchId was included with version null, but id: BaseLibraryElmIdMismatch and version 1.0.0 of the library was found.",
             cqlIncludeException.message,
         )
@@ -170,11 +164,11 @@ internal class LibraryManagerTests {
         val versionedIdentifiers = listOf(BASE_LIBRARY_ELM_MISMATCH_ID_IDENT)
 
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManager!!.resolveLibraries(versionedIdentifiers)
             }
 
-        Assertions.assertEquals(
+        assertEquals(
             "Library BaseLibraryElmMismatchId was included with version null, but id: BaseLibraryElmIdMismatch and version 1.0.0 of the library was found.",
             cqlIncludeException.message,
         )
@@ -182,15 +176,14 @@ internal class LibraryManagerTests {
 
     @Test
     fun basicElmTestVersionMismatch() {
-        val versionIdentifier: VersionedIdentifier =
-            BASE_LIBRARY_ELM_MISMATCH_ID_IDENT.withVersion("1.0.1")
+        val versionIdentifier = BASE_LIBRARY_ELM_MISMATCH_ID_IDENT.withVersion("1.0.1")
 
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManagerVersionAgnostic!!.resolveLibrary(versionIdentifier)
             }
 
-        Assertions.assertEquals(
+        assertEquals(
             "Library BaseLibraryElmMismatchId was included with version 1.0.1, but id: BaseLibraryElmIdMismatch and version 1.0.0 of the library was found.",
             cqlIncludeException.message,
         )
@@ -198,16 +191,15 @@ internal class LibraryManagerTests {
 
     @Test
     fun basicElmTestVersionMismatchMultiLib() {
-        val versionIdentifier: VersionedIdentifier =
-            BASE_LIBRARY_ELM_MISMATCH_ID_IDENT.withVersion("1.0.1")
+        val versionIdentifier = BASE_LIBRARY_ELM_MISMATCH_ID_IDENT.withVersion("1.0.1")
         val versionIdentifiers = listOf(versionIdentifier)
 
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManagerVersionAgnostic!!.resolveLibraries(versionIdentifiers)
             }
 
-        Assertions.assertEquals(
+        assertEquals(
             "Library BaseLibraryElmMismatchId was included with version 1.0.1, but id: BaseLibraryElmIdMismatch and version 1.0.0 of the library was found.",
             cqlIncludeException.message,
         )
@@ -217,7 +209,7 @@ internal class LibraryManagerTests {
     fun basicElmTestSkipVersionCheck() {
         // Skip version check when requesting a library without a version but the library has a
         // version
-        Assertions.assertNotNull(
+        assertNotNull(
             libraryManagerVersionAgnostic!!.resolveLibrary(
                 VersionedIdentifier().apply {
                     id = "BaseLibraryElm" // has version 1.0.0
@@ -227,7 +219,7 @@ internal class LibraryManagerTests {
 
         // Skip version check when requesting a library with a version but the library does not have
         // a version
-        Assertions.assertNotNull(
+        assertNotNull(
             libraryManagerVersionAgnostic!!.resolveLibrary(
                 VersionedIdentifier().apply {
                     id = "BaseLibraryElmWithoutVersion" // does not have a version
@@ -240,7 +232,7 @@ internal class LibraryManagerTests {
     @Test
     fun testResolveLibraryIdentifierIdNull() {
         val versionedIdentifier = VersionedIdentifier().withId(null)
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManager!!.resolveLibrary(versionedIdentifier)
         }
     }
@@ -248,7 +240,7 @@ internal class LibraryManagerTests {
     @Test
     fun testResolveLibraryIdentifierIdEmpty() {
         val versionedIdentifier = VersionedIdentifier().withId("")
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertFailsWith<IllegalArgumentException> {
             libraryManager!!.resolveLibrary(versionedIdentifier)
         }
     }
@@ -261,13 +253,13 @@ internal class LibraryManagerTests {
         cachedLibrary.library = Library().withIdentifier(libraryIdentifier)
         libraryManager!!.compiledLibraries[libraryIdentifier] = cachedLibrary
 
-        val resolvedLibrary: CompiledLibrary = libraryManager!!.resolveLibrary(libraryIdentifier)
-        Assertions.assertSame(cachedLibrary, resolvedLibrary)
+        val resolvedLibrary = libraryManager!!.resolveLibrary(libraryIdentifier)
+        assertSame(cachedLibrary, resolvedLibrary)
     }
 
     @Test
     fun cacheModeNoneReportsDiagnosticsFromFreshCompilation() {
-        val cache = HashMap<VersionedIdentifier, CompiledLibrary>()
+        val cache = mutableMapOf<VersionedIdentifier, CompiledLibrary>()
         val manager = LibraryManager(ModelManager(), libraryCache = cache)
         manager.librarySourceLoader.registerProvider(
             TestLibrarySourceProvider("LibraryManagerTests")
@@ -282,10 +274,10 @@ internal class LibraryManagerTests {
         val resolvedLibrary =
             manager.resolveLibrary(INVALID_IDENT, errors, LibraryManager.CacheMode.NONE)
 
-        Assertions.assertNotSame(cachedLibrary, resolvedLibrary)
-        Assertions.assertSame(cachedLibrary, cache[INVALID_IDENT])
-        MatcherAssert.assertThat(errors.size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(errors[0].message, Matchers.equalTo("Syntax error at define"))
+        assertNotSame(cachedLibrary, resolvedLibrary)
+        assertSame(cachedLibrary, cache[INVALID_IDENT])
+        assertEquals(1, errors.size)
+        assertEquals("Syntax error at define", errors[0].message)
     }
 
     @Test
@@ -296,21 +288,20 @@ internal class LibraryManagerTests {
         cachedLibrary.library = Library().withIdentifier(libraryIdentifier)
         libraryManager!!.compiledLibraries[libraryIdentifier] = cachedLibrary
 
-        val results: CompiledLibraryMultiResults =
-            libraryManager!!.resolveLibraries(listOf(libraryIdentifier))
+        val results = libraryManager!!.resolveLibraries(listOf(libraryIdentifier))
 
         val compiledLibraries = results.allCompiledLibraries()
-        Assertions.assertNotNull(compiledLibraries)
-        MatcherAssert.assertThat(compiledLibraries.size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(results.allErrors(), Matchers.empty())
-        Assertions.assertFalse(results.hasErrors())
-        MatcherAssert.assertThat(results.allResultsWithoutErrorSeverity().size, Matchers.equalTo(1))
-        MatcherAssert.assertThat(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT), Matchers.empty())
+        assertNotNull(compiledLibraries)
+        assertEquals(1, compiledLibraries.size)
+        assertTrue(results.allErrors().isEmpty())
+        assertFalse(results.hasErrors())
+        assertEquals(1, results.allResultsWithoutErrorSeverity().size)
+        assertTrue(results.getErrorsFor(BASE_LIBRARY_ELM_IDENT).isEmpty())
 
         val resolvedLibrary = results.onlyResult.compiledLibrary
 
-        Assertions.assertNotNull(resolvedLibrary)
-        Assertions.assertSame(cachedLibrary, resolvedLibrary)
+        assertNotNull(resolvedLibrary)
+        assertSame(cachedLibrary, resolvedLibrary)
     }
 
     @Test
@@ -318,17 +309,16 @@ internal class LibraryManagerTests {
         // Some optimizations depend on the Library statements being sorted in lexicographic order
         // by name
         // This test validates that they are ordered
-        val lib: Library? =
+        val lib =
             libraryManager!!.resolveLibrary(VersionedIdentifier().withId("OutOfOrder")).library
 
-        Assertions.assertNotNull(lib)
-        Assertions.assertNotNull(lib!!.statements!!.def)
+        assertNotNull(lib)
+        assertNotNull(lib.statements!!.def)
 
         val defs = lib.statements!!.def
-        MatcherAssert.assertThat(
+        assertTrue(
+            defs.size > 3,
             "The list should be larger than 3 elements to validate it actually sorted",
-            defs.size,
-            Matchers.greaterThan(3),
         )
 
         for (i in 0..<defs.size - 1) {
@@ -337,10 +327,7 @@ internal class LibraryManagerTests {
 
             // Ensure that the left element is always less than or equal to the right element
             // In other words, they are ordered.
-            MatcherAssert.assertThat(
-                left.name!!.compareTo(right.name!!),
-                Matchers.lessThanOrEqualTo(0),
-            )
+            assertTrue(left.name!! <= right.name!!)
         }
     }
 
@@ -358,7 +345,7 @@ internal class LibraryManagerTests {
         // library resolution will continue to load the library from the CQL source if it is
         // present.
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManager!!.resolveLibrary(
                     VersionedIdentifier().withId("LibraryWithoutResultTypes")
                 )
@@ -372,7 +359,7 @@ internal class LibraryManagerTests {
     @Test
     fun compiledLibraryWithIncompatibleTranslatorVersionIsRejected() {
         val cqlIncludeException =
-            Assertions.assertThrows(CqlIncludeException::class.java) {
+            assertFailsWith<CqlIncludeException> {
                 libraryManager!!.resolveLibrary(
                     VersionedIdentifier().withId("LibraryWithIncompatibleTranslatorVersion")
                 )

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/LibraryManagerTests.kt
@@ -354,8 +354,8 @@ internal class LibraryManagerTests {
     @Test
     fun compiledLibraryWithoutResultTypesIsRejected() {
         // Result types must be present for every expression, regardless of the `translatorOptions`
-        // value in the annotation. When a compiled library is not compatible (missing result types,
-        // etc.), library resolution will continue to load the library from the CQL source if it is
+        // annotation value. When a compiled library is not compatible (missing result types, etc.),
+        // library resolution will continue to load the library from the CQL source if it is
         // present.
         val cqlIncludeException =
             Assertions.assertThrows(CqlIncludeException::class.java) {

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TestLibrarySourceProvider.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TestLibrarySourceProvider.kt
@@ -1,32 +1,6 @@
 package org.cqframework.cql.cql2elm
 
-import kotlinx.io.Source
-import kotlinx.io.asSource
-import kotlinx.io.buffered
-import org.hl7.elm.r1.VersionedIdentifier
-
-class TestLibrarySourceProvider(val path: String? = "LibraryTests") : LibrarySourceProvider {
-
-    override fun getLibrarySource(libraryIdentifier: VersionedIdentifier): Source? {
-        return getLibraryContent(libraryIdentifier, LibraryContentType.CQL)
-    }
-
-    override fun getLibraryContent(
-        libraryIdentifier: VersionedIdentifier,
-        type: LibraryContentType,
-    ): Source? {
-        val inputStream =
-            TestLibrarySourceProvider::class
-                .java
-                .getResourceAsStream(getFileName(libraryIdentifier, type))
-        return inputStream?.asSource()?.buffered()
-    }
-
-    private fun getFileName(
-        libraryIdentifier: VersionedIdentifier,
-        type: LibraryContentType,
-    ): String {
-        val version = libraryIdentifier.version?.let { "-$it" } ?: ""
-        return "$path/${libraryIdentifier.id}${version}.${type.toString().lowercase()}"
-    }
-}
+class TestLibrarySourceProvider(path: String = "LibraryTests") :
+    BaseTestLibrarySourceProvider({ libraryIdentifier, type ->
+        "$path/${libraryIdentifier.id}${libraryIdentifier.version?.let { "-$it" } ?: ""}.${type.toString().lowercase()}"
+    })

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TestLibrarySourceVersionAgnosticProvider.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TestLibrarySourceVersionAgnosticProvider.kt
@@ -1,35 +1,10 @@
 package org.cqframework.cql.cql2elm
 
-import kotlinx.io.Source
-import kotlinx.io.asSource
-import kotlinx.io.buffered
-import org.hl7.elm.r1.VersionedIdentifier
-
 /**
  * Clone of the [TestLibrarySourceProvider] that does not enforce versioning in the file names and
  * thus will support tests that do not specify a version in the library identifier.
  */
-class TestLibrarySourceVersionAgnosticProvider(val path: String = "LibraryTests") :
-    LibrarySourceProvider {
-    override fun getLibrarySource(libraryIdentifier: VersionedIdentifier): Source? {
-        return getLibraryContent(libraryIdentifier, LibraryContentType.CQL)
-    }
-
-    override fun getLibraryContent(
-        libraryIdentifier: VersionedIdentifier,
-        type: LibraryContentType,
-    ): Source? {
-        val inputStream =
-            TestLibrarySourceVersionAgnosticProvider::class
-                .java
-                .getResourceAsStream(getFileName(libraryIdentifier, type))
-        return inputStream?.asSource()?.buffered()
-    }
-
-    private fun getFileName(
-        libraryIdentifier: VersionedIdentifier,
-        type: LibraryContentType,
-    ): String {
-        return "$path/${libraryIdentifier.id}.${type.toString().lowercase()}"
-    }
-}
+class TestLibrarySourceVersionAgnosticProvider(path: String = "LibraryTests") :
+    BaseTestLibrarySourceProvider({ libraryIdentifier, type ->
+        "$path/${libraryIdentifier.id}.${type.toString().lowercase()}"
+    })

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TranslationTests.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TranslationTests.kt
@@ -5,11 +5,15 @@ import java.io.IOException
 import java.util.Scanner
 import java.util.concurrent.CompletableFuture
 import java.util.stream.Collectors
+import javax.xml.namespace.QName
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.cqframework.cql.cql2elm.tracking.Trackable.resultType
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
-import org.hamcrest.Matchers.`is`
-import org.hl7.cql.model.DataType
 import org.hl7.cql.model.IntervalType
 import org.hl7.cql.model.SimpleType
 import org.hl7.cql_annotations.r1.CqlToElmInfo
@@ -23,11 +27,6 @@ import org.hl7.elm.r1.Null
 import org.hl7.elm.r1.ProperContains
 import org.hl7.elm.r1.Property
 import org.hl7.elm.r1.Query
-import org.hl7.elm.r1.TypeSpecifier
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 
 @Suppress("ForbiddenComment", "MaxLineLength")
 internal class TranslationTests {
@@ -35,7 +34,7 @@ internal class TranslationTests {
     // JSON, I want it to
     // verify the actual XML.
     @Test
-    @Disabled
+    @Ignore
     @Throws(IOException::class)
     fun patientPropertyAccess() {
         val expectedXmlFile =
@@ -49,11 +48,11 @@ internal class TranslationTests {
         val modelManager = ModelManager()
         val actualXml =
             CqlTranslator.fromFile(propertyTestFile.path, LibraryManager(modelManager)).toXml()
-        assertThat(actualXml, `is`(expectedXml))
+        assertEquals(expectedXml, actualXml)
     }
 
     @Test
-    @Disabled
+    @Ignore
     @Throws(IOException::class)
     fun forPrintElm() {
         val propertyTestFile =
@@ -87,7 +86,7 @@ internal class TranslationTests {
     }
 
     @Test
-    @Disabled
+    @Ignore
     @Throws(IOException::class)
     fun cms146v2XML() {
         val expectedXml = ""
@@ -95,7 +94,7 @@ internal class TranslationTests {
             File(Cql2ElmVisitorTest::class.java.getResource("CMS146v2_Test_CQM.cql")!!.file)
         val modelManager = ModelManager()
         val actualXml = CqlTranslator.fromFile(cqlFile.path, LibraryManager(modelManager)).toXml()
-        assertThat(actualXml, `is`(expectedXml))
+        assertEquals(expectedXml, actualXml)
     }
 
     @Test
@@ -107,11 +106,11 @@ internal class TranslationTests {
         val e = translator.errors[0]
         val tb = e.locator
 
-        Assertions.assertEquals(6, tb!!.startLine)
-        Assertions.assertEquals(6, tb.endLine)
+        assertEquals(6, tb!!.startLine)
+        assertEquals(6, tb.endLine)
 
-        Assertions.assertEquals(5, tb.startChar)
-        Assertions.assertEquals(10, tb.endChar)
+        assertEquals(5, tb.startChar)
+        assertEquals(10, tb.endChar)
     }
 
     @Test
@@ -124,8 +123,8 @@ internal class TranslationTests {
             )
         assertEquals(0, translator.errors.size)
         val defs = translator.translatedLibrary!!.library!!.statements!!.def
-        Assertions.assertNotNull(defs[1].annotation)
-        Assertions.assertTrue(defs[1].annotation.isNotEmpty())
+        assertNotNull(defs[1].annotation)
+        assertTrue(defs[1].annotation.isNotEmpty())
     }
 
     @Test
@@ -147,11 +146,11 @@ internal class TranslationTests {
             )
         assertEquals(0, translator.errors.size)
         val library = translator.translatedLibrary!!.library
-        Assertions.assertNotNull(library!!.annotation)
-        assertThat(library.annotation.size, Matchers.greaterThan(0))
-        assertThat(library.annotation[0], Matchers.instanceOf(CqlToElmInfo::class.java))
-        val info: CqlToElmInfo = library.annotation[0] as CqlToElmInfo
-        assertThat(info.translatorOptions, `is`<String?>("EnableAnnotations"))
+        assertNotNull(library!!.annotation)
+        assertTrue(library.annotation.isNotEmpty())
+        assertIs<CqlToElmInfo>(library.annotation[0])
+        val info = library.annotation[0] as CqlToElmInfo
+        assertEquals("EnableAnnotations", info.translatorOptions)
     }
 
     @Test
@@ -162,52 +161,40 @@ internal class TranslationTests {
         // Gets the "TooManyCasts" define
         var exp: Expression? =
             translator.translatedLibrary!!.library!!.statements!!.def[2].expression
-        assertThat<Expression?>(exp, `is`<Expression?>(Matchers.instanceOf(Query::class.java)))
+        assertIs<Query>(exp)
 
-        var query = exp as Query
+        var query = exp
         var returnClause = query.`return`
-        Assertions.assertNotNull(returnClause)
-        Assertions.assertNotNull(returnClause!!.expression)
-        assertThat<Expression?>(
-            returnClause.expression,
-            `is`<Expression?>(Matchers.instanceOf(FunctionRef::class.java)),
-        )
+        assertNotNull(returnClause)
+        assertNotNull(returnClause.expression)
+        assertIs<FunctionRef>(returnClause.expression)
 
         var functionRef = returnClause.expression as FunctionRef?
         assertEquals(1, functionRef!!.operand.size)
 
         // For a widening cast, no As is required, it should be a direct property access.
         var operand: Expression? = functionRef.operand[0]
-        assertThat<Expression?>(
-            operand,
-            `is`<Expression?>(Matchers.instanceOf(Property::class.java)),
-        )
+        assertIs<Property>(operand)
 
         // Gets the "NeedsACast" define
         exp = translator.translatedLibrary!!.library!!.statements!!.def[4].expression
-        assertThat<Expression?>(exp, `is`<Expression?>(Matchers.instanceOf(Query::class.java)))
+        assertIs<Query>(exp)
 
-        query = exp as Query
+        query = exp
         returnClause = query.`return`
-        Assertions.assertNotNull(returnClause)
-        Assertions.assertNotNull(returnClause!!.expression)
-        assertThat<Expression?>(
-            returnClause.expression,
-            `is`<Expression?>(Matchers.instanceOf(FunctionRef::class.java)),
-        )
+        assertNotNull(returnClause)
+        assertNotNull(returnClause.expression)
+        assertIs<FunctionRef>(returnClause.expression)
 
         functionRef = returnClause.expression as FunctionRef?
         assertEquals(1, functionRef!!.operand.size)
 
         // For narrowing choice casts, an As is expected
         operand = functionRef.operand[0]
-        assertThat(operand, `is`(Matchers.instanceOf(As::class.java)))
+        assertIs<As>(operand)
 
-        val asDef = operand as As
-        assertThat<TypeSpecifier?>(
-            asDef.asTypeSpecifier,
-            `is`<TypeSpecifier?>(Matchers.instanceOf(ChoiceTypeSpecifier::class.java)),
-        )
+        val asDef = operand
+        assertIs<ChoiceTypeSpecifier>(asDef.asTypeSpecifier)
     }
 
     // test for https://github.com/cqframework/clinical_quality_language/issues/1293
@@ -223,9 +210,9 @@ internal class TranslationTests {
             )
         assertEquals(0, translator.errors.size)
         val library = translator.translatedLibrary!!.library
-        assertThat(library!!.statements!!.def.size, `is`(2))
+        assertEquals(2, library!!.statements!!.def.size)
         val def = library.statements!!.def[0]
-        assertThat(def.context, `is`("Unfiltered"))
+        assertEquals("Unfiltered", def.context)
     }
 
     @Test
@@ -306,7 +293,7 @@ internal class TranslationTests {
     }
 
     @Test
-    @Disabled(
+    @Ignore(
         "Could not resolve call to operator Equal with signature (tuple{Foo:System.Any},tuple{Bar:System.Any}"
     )
     @Throws(IOException::class)
@@ -317,7 +304,7 @@ internal class TranslationTests {
 
     @Suppress("MaxLineLength")
     @Test
-    @Disabled(
+    @Ignore(
         "Could not resolve call to operator Equal with signature (tuple{a:System.String,b:System.Any},tuple{a:System.String,c:System.Any})"
     )
     @Throws(IOException::class)
@@ -327,7 +314,7 @@ internal class TranslationTests {
     }
 
     @Test
-    @Disabled(
+    @Ignore(
         "Could not resolve call to operator Collapse with signature (System.Any,System.Quantity)"
     )
     @Throws(IOException::class)
@@ -350,11 +337,11 @@ internal class TranslationTests {
             TestUtils.createTranslator(
                 "TestForwardDeclarationSameTypeDifferentNamespaceNormalTypes.cql"
             )
-        assertThat("Errors: " + translator.errors, translator.errors.size, Matchers.equalTo(0))
+        assertEquals(0, translator.errors.size, "Errors: " + translator.errors)
 
         val compileLibrary = translator.translatedLibrary!!.library
         val statements = compileLibrary!!.statements!!.def
-        assertThat(statements.size, Matchers.equalTo(3))
+        assertEquals(3, statements.size)
     }
 
     @Test
@@ -364,11 +351,11 @@ internal class TranslationTests {
             TestUtils.createTranslator(
                 "TestForwardDeclarationSameTypeDifferentNamespaceGenericTypes.cql"
             )
-        assertThat("Errors: " + translator.errors, translator.errors.size, Matchers.equalTo(0))
+        assertEquals(0, translator.errors.size, "Errors: " + translator.errors)
 
         val compileLibrary = translator.translatedLibrary!!.library
         val statements = compileLibrary!!.statements!!.def
-        assertThat(statements.size, Matchers.equalTo(3))
+        assertEquals(3, statements.size)
     }
 
     // This test creates a bunch of translators on the common pool to suss out any race conditions.
@@ -402,112 +389,82 @@ internal class TranslationTests {
         val compiledLibrary = translator.translatedLibrary!!.library
         val statements = compiledLibrary!!.statements!!.def
 
-        assertThat(statements.size, Matchers.equalTo(5))
+        assertEquals(5, statements.size)
 
         var test = statements[0]
-        assertThat<Expression?>(
-            test.expression,
-            Matchers.instanceOf<Expression?>(ProperContains::class.java),
-        )
+        assertIs<ProperContains>(test.expression)
         var properContains = test.expression as ProperContains?
-        assertThat(properContains!!.operand[0], Matchers.instanceOf(Interval::class.java))
+        assertIs<Interval>(properContains!!.operand[0])
         var interval = properContains.operand[0] as Interval
 
         var intervalResultType = interval.resultType
-        assertThat<DataType?>(
-            intervalResultType,
-            Matchers.instanceOf<DataType?>(IntervalType::class.java),
-        )
+        assertIs<IntervalType>(intervalResultType)
         var intervalType = intervalResultType as IntervalType?
-        assertThat(intervalType!!.pointType, Matchers.instanceOf(SimpleType::class.java))
+        assertIs<SimpleType>(intervalType!!.pointType)
         var pointType: SimpleType = intervalType.pointType as SimpleType
-        assertThat(pointType.name, Matchers.equalTo("System.Integer"))
-        assertThat(properContains.operand[1], Matchers.instanceOf(As::class.java))
+        assertEquals("System.Integer", pointType.name)
+        assertIs<As>(properContains.operand[1])
         var asDef = properContains.operand[1] as As
-        assertThat(asDef.asType.toString(), Matchers.equalTo("{urn:hl7-org:elm-types:r1}Integer"))
-        assertThat<Expression?>(asDef.operand, Matchers.instanceOf<Expression?>(Null::class.java))
+        assertEquals("{urn:hl7-org:elm-types:r1}Integer", asDef.asType.toString())
+        assertIs<Null>(asDef.operand)
 
         test = statements[1]
-        assertThat<Expression?>(
-            test.expression,
-            Matchers.instanceOf<Expression?>(ProperContains::class.java),
-        )
-        properContains = test.expression as ProperContains?
-        assertThat(properContains!!.operand[0], Matchers.instanceOf(Interval::class.java))
+        assertIs<ProperContains>(test.expression)
+        properContains = test.expression as ProperContains
+        assertIs<Interval>(properContains.operand[0])
         interval = properContains.operand[0] as Interval
 
         intervalResultType = interval.resultType
-        assertThat<DataType?>(
-            intervalResultType,
-            Matchers.instanceOf<DataType?>(IntervalType::class.java),
-        )
-        intervalType = intervalResultType as IntervalType?
-        assertThat(intervalType!!.pointType, Matchers.instanceOf(SimpleType::class.java))
+        assertIs<IntervalType>(intervalResultType)
+        intervalType = intervalResultType
+        assertIs<SimpleType>(intervalType.pointType)
         pointType = intervalType.pointType as SimpleType
-        assertThat(pointType.name, Matchers.equalTo("System.Integer"))
-        assertThat(properContains.operand[1], Matchers.instanceOf(As::class.java))
+        assertEquals("System.Integer", pointType.name)
+        assertIs<As>(properContains.operand[1])
         asDef = properContains.operand[1] as As
-        assertThat(asDef.asType.toString(), Matchers.equalTo("{urn:hl7-org:elm-types:r1}Integer"))
-        assertThat<Expression?>(asDef.operand, Matchers.instanceOf<Expression?>(Null::class.java))
+        assertEquals("{urn:hl7-org:elm-types:r1}Integer", asDef.asType.toString())
+        assertIs<Null>(asDef.operand)
 
         test = statements[2]
-        assertThat<Expression?>(
-            test.expression,
-            Matchers.instanceOf<Expression?>(ProperContains::class.java),
-        )
-        properContains = test.expression as ProperContains?
-        assertThat(properContains!!.operand[0], Matchers.instanceOf(Interval::class.java))
+        assertIs<ProperContains>(test.expression)
+        properContains = test.expression as ProperContains
+        assertIs<Interval>(properContains.operand[0])
         interval = properContains.operand[0] as Interval
 
         intervalResultType = interval.resultType
-        assertThat<DataType?>(
-            intervalResultType,
-            Matchers.instanceOf<DataType?>(IntervalType::class.java),
-        )
-        intervalType = intervalResultType as IntervalType?
-        assertThat(intervalType!!.pointType, Matchers.instanceOf(SimpleType::class.java))
+        assertIs<IntervalType>(intervalResultType)
+        intervalType = intervalResultType
+        assertIs<SimpleType>(intervalType.pointType)
         pointType = intervalType.pointType as SimpleType
-        assertThat(pointType.name, Matchers.equalTo("System.Any"))
-        assertThat(properContains.operand[1], Matchers.instanceOf(Null::class.java))
+        assertEquals("System.Any", pointType.name)
+        assertIs<Null>(properContains.operand[1])
 
         test = statements[3]
-        assertThat<Expression?>(
-            test.expression,
-            Matchers.instanceOf<Expression?>(ProperContains::class.java),
-        )
-        properContains = test.expression as ProperContains?
-        assertThat(properContains!!.operand[0], Matchers.instanceOf(Interval::class.java))
+        assertIs<ProperContains>(test.expression)
+        properContains = test.expression as ProperContains
+        assertIs<Interval>(properContains.operand[0])
         interval = properContains.operand[0] as Interval
         intervalResultType = interval.resultType
-        assertThat<DataType?>(
-            intervalResultType,
-            Matchers.instanceOf<DataType?>(IntervalType::class.java),
-        )
-        intervalType = intervalResultType as IntervalType?
-        assertThat(intervalType!!.pointType, Matchers.instanceOf(SimpleType::class.java))
+        assertIs<IntervalType>(intervalResultType)
+        intervalType = intervalResultType
+        assertIs<SimpleType>(intervalType.pointType)
         pointType = intervalType.pointType as SimpleType
-        assertThat(pointType.name, Matchers.equalTo("System.Any"))
-        assertThat(properContains.operand[1], Matchers.instanceOf(Null::class.java))
+        assertEquals("System.Any", pointType.name)
+        assertIs<Null>(properContains.operand[1])
 
         test = statements[4]
-        assertThat<Expression?>(
-            test.expression,
-            Matchers.instanceOf<Expression?>(ProperContains::class.java),
-        )
-        properContains = test.expression as ProperContains?
-        assertThat(properContains!!.operand[0], Matchers.instanceOf(Interval::class.java))
+        assertIs<ProperContains>(test.expression)
+        properContains = test.expression as ProperContains
+        assertIs<Interval>(properContains.operand[0])
         interval = properContains.operand[0] as Interval
 
         intervalResultType = interval.resultType
-        assertThat<DataType?>(
-            intervalResultType,
-            Matchers.instanceOf<DataType?>(IntervalType::class.java),
-        )
-        intervalType = intervalResultType as IntervalType?
-        assertThat(intervalType!!.pointType, Matchers.instanceOf(SimpleType::class.java))
+        assertIs<IntervalType>(intervalResultType)
+        intervalType = intervalResultType
+        assertIs<SimpleType>(intervalType.pointType)
         pointType = intervalType.pointType as SimpleType
-        assertThat(pointType.name, Matchers.equalTo("System.Integer"))
-        assertThat(properContains.operand[1], Matchers.instanceOf(As::class.java))
+        assertEquals("System.Integer", pointType.name)
+        assertIs<As>(properContains.operand[1])
     }
 
     @Test
@@ -521,11 +478,11 @@ internal class TranslationTests {
                 .map { obj: CqlCompilerException? -> obj!!.message }
                 .collect(Collectors.toList())
 
-        assertThat(warningMessages.toString(), translator.warnings.size, `is`(13))
+        assertEquals(13, translator.warnings.size, warningMessages.toString())
 
         val distinct = warningMessages.distinct()
 
-        assertThat(warningMessages.toString(), distinct.size, `is`(11))
+        assertEquals(11, distinct.size, warningMessages.toString())
 
         val hidingDefinition =
             "An alias identifier Definition is hiding another identifier of the same name."
@@ -546,9 +503,8 @@ internal class TranslationTests {
         val hidingLetFhir = "A let identifier FHIR is hiding another identifier of the same name."
         val hidingAliasLet = "A let identifier Alias is hiding another identifier of the same name."
 
-        assertThat(
-            distinct,
-            Matchers.containsInAnyOrder(
+        for (message in
+            listOf(
                 hidingDefinition,
                 hidingVarLet,
                 hidingContextValueSet,
@@ -560,8 +516,9 @@ internal class TranslationTests {
                 hidingContextFhir,
                 hidingLetFhir,
                 hidingAliasLet,
-            ),
-        )
+            )) {
+            assertContains(distinct, message)
+        }
     }
 
     @Test
@@ -575,9 +532,9 @@ internal class TranslationTests {
                 .stream()
                 .map { obj: CqlCompilerException? -> obj!!.message }
                 .collect(Collectors.toList())
-        assertThat(
+        assertContains(
             errorMessages,
-            Matchers.contains("Specified data type DomainResource does not support retrieval."),
+            "Specified data type DomainResource does not support retrieval.",
         )
     }
 
@@ -603,25 +560,37 @@ internal class TranslationTests {
         val compiledLibrary = translator.translatedLibrary!!.library
         val statements = compiledLibrary!!.statements!!.def
 
-        assertThat(statements.size, `is`(2))
+        assertEquals(2, statements.size)
         val encounterPeriod = statements[1]
-        assertThat(encounterPeriod.name, `is`("EncounterPeriod"))
-        assertThat<Expression?>(
-            encounterPeriod.expression,
-            Matchers.instanceOf<Expression?>(Query::class.java),
-        )
+        assertEquals("EncounterPeriod", encounterPeriod.name)
+        assertIs<Query>(encounterPeriod.expression)
         val query = encounterPeriod.expression as Query?
-        assertThat<Expression?>(
-            query!!.`return`!!.expression,
-            Matchers.instanceOf<Expression?>(FunctionRef::class.java),
-        )
+        assertIs<FunctionRef>(query!!.`return`!!.expression)
         val functionRef = query.`return`!!.expression as FunctionRef?
-        assertThat(functionRef!!.libraryName, `is`("FHIRHelpers"))
-        assertThat(functionRef.name, `is`("ToInterval"))
-        assertThat<Any?>(functionRef.signature, Matchers.notNullValue())
-        assertThat(functionRef.signature.size, `is`(1))
-        assertThat(functionRef.signature[0], Matchers.instanceOf(NamedTypeSpecifier::class.java))
+        assertEquals("FHIRHelpers", functionRef!!.libraryName)
+        assertEquals("ToInterval", functionRef.name)
+        assertNotNull(functionRef.signature)
+        assertEquals(1, functionRef.signature.size)
+        assertIs<NamedTypeSpecifier>(functionRef.signature[0])
         val namedTypeSpecifier = functionRef.signature[0] as NamedTypeSpecifier
-        assertThat(namedTypeSpecifier.name!!.localPart, `is`("Period"))
+        assertEquals("Period", namedTypeSpecifier.name!!.localPart)
+    }
+
+    @Test
+    fun contextHasResultType() {
+        val translator =
+            TestUtils.createTranslatorFromText(
+                """
+                library Lib1
+                using FHIR version '4.0.1'
+                context Patient
+            """
+                    .trimIndent(),
+                CqlCompilerOptions.Options.EnableResultTypes,
+            )
+        val library = translator.toELM()
+        assertNotNull(library)
+        val modelContextRetrieve = library.statements!!.def[0]
+        assertEquals(QName("http://hl7.org/fhir", "Patient"), modelContextRetrieve.resultTypeName)
     }
 }

--- a/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TranslationTests.kt
+++ b/cql-to-elm/src/jvmTest/kotlin/org/cqframework/cql/cql2elm/TranslationTests.kt
@@ -4,7 +4,6 @@ import java.io.File
 import java.io.IOException
 import java.util.Scanner
 import java.util.concurrent.CompletableFuture
-import java.util.stream.Collectors
 import javax.xml.namespace.QName
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -19,7 +18,6 @@ import org.hl7.cql.model.SimpleType
 import org.hl7.cql_annotations.r1.CqlToElmInfo
 import org.hl7.elm.r1.As
 import org.hl7.elm.r1.ChoiceTypeSpecifier
-import org.hl7.elm.r1.Expression
 import org.hl7.elm.r1.FunctionRef
 import org.hl7.elm.r1.Interval
 import org.hl7.elm.r1.NamedTypeSpecifier
@@ -159,8 +157,7 @@ internal class TranslationTests {
         val translator = TestUtils.createTranslator("TestNoImplicitCast.cql")
         assertEquals(0, translator.errors.size)
         // Gets the "TooManyCasts" define
-        var exp: Expression? =
-            translator.translatedLibrary!!.library!!.statements!!.def[2].expression
+        var exp = translator.translatedLibrary!!.library!!.statements!!.def[2].expression
         assertIs<Query>(exp)
 
         var query = exp
@@ -173,7 +170,7 @@ internal class TranslationTests {
         assertEquals(1, functionRef!!.operand.size)
 
         // For a widening cast, no As is required, it should be a direct property access.
-        var operand: Expression? = functionRef.operand[0]
+        var operand = functionRef.operand[0]
         assertIs<Property>(operand)
 
         // Gets the "NeedsACast" define
@@ -401,7 +398,7 @@ internal class TranslationTests {
         assertIs<IntervalType>(intervalResultType)
         var intervalType = intervalResultType as IntervalType?
         assertIs<SimpleType>(intervalType!!.pointType)
-        var pointType: SimpleType = intervalType.pointType as SimpleType
+        var pointType = intervalType.pointType as SimpleType
         assertEquals("System.Integer", pointType.name)
         assertIs<As>(properContains.operand[1])
         var asDef = properContains.operand[1] as As
@@ -472,11 +469,7 @@ internal class TranslationTests {
     fun hidingVariousUseCases() {
         val translator = TestUtils.runSemanticTest("HidingTests/TestHidingVariousUseCases.cql", 0)
         val warnings = translator.warnings
-        val warningMessages =
-            warnings
-                .stream()
-                .map { obj: CqlCompilerException? -> obj!!.message }
-                .collect(Collectors.toList())
+        val warningMessages = warnings.map { it.message }
 
         assertEquals(13, translator.warnings.size, warningMessages.toString())
 
@@ -527,11 +520,7 @@ internal class TranslationTests {
         // See:  https://github.com/cqframework/clinical_quality_language/issues/1392
         val translator = TestUtils.runSemanticTest("abstractClassNotRetrievable.cql", 1)
         val errors = translator.errors
-        val errorMessages =
-            errors
-                .stream()
-                .map { obj: CqlCompilerException? -> obj!!.message }
-                .collect(Collectors.toList())
+        val errorMessages = errors.map { it.message }
         assertContains(
             errorMessages,
             "Specified data type DomainResource does not support retrieval.",

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElm.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElm.json
@@ -1,8 +1,8 @@
 {
   "library": {
     "annotation" : [ {
-      "translatorOptions" : "EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion",
-      "translatorVersion" : "1.5",
+      "translatorOptions" : "EnableResultTypes",
+      "translatorVersion" : "{translatorVersion}",
       "type" : "CqlToElmInfo"
     }
     ],

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmMismatchId.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmMismatchId.json
@@ -1,8 +1,8 @@
 {
   "library": {
     "annotation" : [ {
-      "translatorOptions" : "EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion",
-      "translatorVersion" : "1.5",
+      "translatorOptions" : "EnableResultTypes",
+      "translatorVersion" : "{translatorVersion}",
       "type" : "CqlToElmInfo"
     }
     ],

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmOther.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmOther.json
@@ -1,8 +1,8 @@
 {
   "library": {
     "annotation" : [ {
-      "translatorOptions" : "EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion",
-      "translatorVersion" : "1.5",
+      "translatorOptions" : "EnableResultTypes",
+      "translatorVersion" : "{translatorVersion}",
       "type" : "CqlToElmInfo"
     }
     ],

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmWithoutVersion.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/BaseLibraryElmWithoutVersion.json
@@ -1,8 +1,8 @@
 {
   "library": {
     "annotation" : [ {
-      "translatorOptions" : "EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion",
-      "translatorVersion" : "1.5",
+      "translatorOptions" : "EnableResultTypes",
+      "translatorVersion" : "{translatorVersion}",
       "type" : "CqlToElmInfo"
     }
     ],

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithIncompatibleTranslatorVersion.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithIncompatibleTranslatorVersion.json
@@ -1,0 +1,46 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "type": "CqlToElmInfo",
+        "translatorVersion": "0.0.0",
+        "translatorOptions": "EnableResultTypes",
+        "signatureLevel": "Overloads"
+      }
+    ],
+    "identifier": {
+      "id": "LibraryWithIncompatibleTranslatorVersion"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "annotation": []
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+          "name": "expr1",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [],
+          "expression": {
+            "type": "Literal",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "annotation": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithResultTypes.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithResultTypes.json
@@ -1,0 +1,187 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "type": "CqlToElmInfo",
+        "translatorVersion": "{translatorVersion}",
+        "translatorOptions": "EnableResultTypes",
+        "signatureLevel": "Overloads"
+      }
+    ],
+    "identifier": {
+      "id": "LibraryWithResultTypes"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "annotation": []
+        },
+        {
+          "localIdentifier": "FHIR",
+          "uri": "http://hl7.org/fhir",
+          "version": "4.0.1",
+          "annotation": []
+        }
+      ]
+    },
+    "contexts": {
+      "def": [
+        {
+          "name": "Patient",
+          "annotation": []
+        },
+        {
+          "name": "Practitioner",
+          "annotation": []
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "resultTypeName": "{http://hl7.org/fhir}Patient",
+          "name": "Patient",
+          "context": "Patient",
+          "annotation": [],
+          "expression": {
+            "type": "SingletonFrom",
+            "annotation": [],
+            "signature": [],
+            "operand": {
+              "type": "Retrieve",
+              "dataType": "{http://hl7.org/fhir}Patient",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Patient",
+              "annotation": [],
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+          "name": "expr1",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [],
+          "expression": {
+            "type": "Literal",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "annotation": []
+          }
+        },
+        {
+          "name": "expr2",
+          "context": "Patient",
+          "accessLevel": "Public",
+          "annotation": [],
+          "resultTypeSpecifier": {
+            "type": "ListTypeSpecifier",
+            "annotation": [],
+            "elementType": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}String",
+              "annotation": []
+            }
+          },
+          "expression": {
+            "type": "List",
+            "annotation": [],
+            "resultTypeSpecifier": {
+              "type": "ListTypeSpecifier",
+              "annotation": [],
+              "elementType": {
+                "type": "NamedTypeSpecifier",
+                "name": "{urn:hl7-org:elm-types:r1}String",
+                "annotation": []
+              }
+            },
+            "element": [
+              {
+                "type": "Literal",
+                "resultTypeName": "{urn:hl7-org:elm-types:r1}String",
+                "valueType": "{urn:hl7-org:elm-types:r1}String",
+                "value": "a",
+                "annotation": []
+              }
+            ]
+          }
+        },
+        {
+          "resultTypeName": "{http://hl7.org/fhir}Practitioner",
+          "name": "Practitioner",
+          "context": "Practitioner",
+          "annotation": [],
+          "expression": {
+            "type": "SingletonFrom",
+            "annotation": [],
+            "signature": [],
+            "operand": {
+              "type": "Retrieve",
+              "dataType": "{http://hl7.org/fhir}Practitioner",
+              "templateId": "http://hl7.org/fhir/StructureDefinition/Practitioner",
+              "annotation": [],
+              "include": [],
+              "codeFilter": [],
+              "dateFilter": [],
+              "otherFilter": []
+            }
+          }
+        },
+        {
+          "name": "expr3",
+          "context": "Practitioner",
+          "accessLevel": "Public",
+          "annotation": [],
+          "resultTypeSpecifier": {
+            "type": "IntervalTypeSpecifier",
+            "annotation": [],
+            "pointType": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer",
+              "annotation": []
+            }
+          },
+          "expression": {
+            "type": "Interval",
+            "lowClosed": true,
+            "highClosed": true,
+            "annotation": [],
+            "resultTypeSpecifier": {
+              "type": "IntervalTypeSpecifier",
+              "annotation": [],
+              "pointType": {
+                "type": "NamedTypeSpecifier",
+                "name": "{urn:hl7-org:elm-types:r1}Integer",
+                "annotation": []
+              }
+            },
+            "low": {
+              "type": "Literal",
+              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "1",
+              "annotation": []
+            },
+            "high": {
+              "type": "Literal",
+              "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer",
+              "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+              "value": "2",
+              "annotation": []
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithoutResultTypes.json
+++ b/cql-to-elm/src/jvmTest/resources/org/cqframework/cql/cql2elm/LibraryManagerTests/LibraryWithoutResultTypes.json
@@ -1,0 +1,44 @@
+{
+  "library": {
+    "annotation": [
+      {
+        "type": "CqlToElmInfo",
+        "translatorVersion": "{translatorVersion}",
+        "translatorOptions": "EnableResultTypes",
+        "signatureLevel": "Overloads"
+      }
+    ],
+    "identifier": {
+      "id": "LibraryWithoutResultTypes"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "annotation": []
+        }
+      ]
+    },
+    "statements": {
+      "def": [
+        {
+          "name": "expr1",
+          "context": "Unfiltered",
+          "accessLevel": "Public",
+          "annotation": [],
+          "expression": {
+            "type": "Literal",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "annotation": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/elm-fhir/config/detekt-baseline.xml
+++ b/elm-fhir/config/detekt-baseline.xml
@@ -75,8 +75,6 @@
     <ID>ReturnCount:ElmRequirementsVisitor.kt$ElmRequirementsVisitor$private fun inferConditionRequirement( elm: Expression, context: ElmRequirementsContext, left: ElmRequirement?, right: ElmRequirement?, ): ElmRequirement</ID>
     <ID>ReturnCount:ElmRequirementsVisitor.kt$ElmRequirementsVisitor$public override fun aggregateResult( aggregate: ElmRequirement?, nextResult: ElmRequirement?, ): ElmRequirement?</ID>
     <ID>ReturnCount:ElmRequirementsVisitor.kt$ElmRequirementsVisitor$public override fun visitFields( elm: BinaryExpression, context: ElmRequirementsContext, ): ElmRequirement?</ID>
-    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun dataTypeToProfileQName(type: DataType?): QName?</ID>
-    <ID>ReturnCount:TypeResolver.kt$TypeResolver$fun getTypeUri(type: DataType?): String?</ID>
     <ID>SwallowedException:DataRequirementsProcessor.kt$DataRequirementsProcessor$fhirException: FHIRException</ID>
     <ID>SwallowedException:ElmRequirementsContext.kt$ElmRequirementsContext$e: Exception</ID>
     <ID>ThrowsCount:ElmAnalysisHelper.kt$ElmAnalysisHelper$@Suppress("UseRequire") @JvmStatic fun toFhirValue(context: ElmRequirementsContext, value: Expression?): DataType?</ID>
@@ -89,7 +87,6 @@
     <ID>TooManyFunctions:ElmQueryRequirement.kt$ElmQueryRequirement : ElmExpressionRequirement</ID>
     <ID>TooManyFunctions:ElmRequirementsContext.kt$ElmRequirementsContext</ID>
     <ID>TooManyFunctions:ElmRequirementsVisitor.kt$ElmRequirementsVisitor : BaseElmLibraryVisitor</ID>
-    <ID>TooManyFunctions:TypeResolver.kt$TypeResolver</ID>
     <ID>UnusedParameter:ElmDataRequirement.kt$ElmDataRequirement$context: ElmRequirementsContext?</ID>
     <ID>UnusedParameter:ElmQueryRequirement.kt$ElmQueryRequirement$childRequirements: ElmRequirement?</ID>
   </CurrentIssues>

--- a/elm-fhir/src/main/kotlin/org/cqframework/cql/elm/requirements/ElmRequirementsContext.kt
+++ b/elm-fhir/src/main/kotlin/org/cqframework/cql/elm/requirements/ElmRequirementsContext.kt
@@ -6,6 +6,7 @@ import javax.xml.namespace.QName
 import org.cqframework.cql.cql2elm.CqlCompilerOptions
 import org.cqframework.cql.cql2elm.LibraryManager
 import org.cqframework.cql.cql2elm.TypeBuilder
+import org.cqframework.cql.cql2elm.TypeResolver
 import org.cqframework.cql.cql2elm.model.CompiledLibrary
 import org.cqframework.cql.cql2elm.model.LibraryRef
 import org.cqframework.cql.cql2elm.tracking.Trackable.resultType


### PR DESCRIPTION
Closes #1827. Closes #1829.

* Move `TypeResolver` (converts ELM type names and type specifiers to CQL `DataType`s) from `elm-fhir` to `cql-to-elm` with added KMP support.
* Add `resultTypeName`/`resultTypeSpecifier` to ELM model context retrieve nodes by moving the `track()` call in the `Cql2ElmVisitor`. For those result types to be added to the ELM elements, `track()` needs to be called after the CQL result types are set.
* Fix `LibraryManager.isVersionCompatible()`. The compatibility check passes when the version of the currently running translator matches the version of the translator that the deserialized library was compiled with (the `translatorVersion` annotation value in the ELM library).
* Fix `LibraryManager.generateCompiledLibrary()`. To properly convert a deserialized ELM `Library` to a `CompiledLibrary`, the `resultTypeName`/`resultTypeSpecifier` of each ELM expression needs to be resolved into a CQL `DataType`. The library is only accepted if every expression has a resolvable result type. All models listed in the library's `usings` are loaded first (using model identifiers) to enable type resolution for ELM result types which use namespace URIs.
* Modernize `LibraryManagerTests` and `TranslationTests` along the way.