### PR TITLE
Fix overrides in `R4FhirModelResolver.resolveType()`

### DIFF
--- a/engine-fhir/detekt-baseline.xml
+++ b/engine-fhir/detekt-baseline.xml
@@ -15,7 +15,6 @@
     <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$open fun resolveType(typeName: String?): Class&lt;*>?</ID>
     <ID>CyclomaticComplexMethod:FhirModelResolverTest.kt$private fun validateCqlValueAgainstModel( fhirVersion: FhirVersionEnum, expectedFhirTypeName: String, cqlValue: Any?, )</ID>
     <ID>CyclomaticComplexMethod:Parser.kt$private fun extractPropertyFromJsonObjectAsCqlValue( jsonObject: JsonObject, propertyKey: kotlin.String, dataType: DataType, model: Model, ): Value?</ID>
-    <ID>CyclomaticComplexMethod:R4FhirModelResolver.kt$R4FhirModelResolver$override fun resolveType(typeName: String?): Class&lt;*>?</ID>
     <ID>CyclomaticComplexMethod:R4FhirQueryGenerator.kt$R4FhirQueryGenerator$override fun generateFhirQueries( dataRequirement: ICompositeType?, evaluationDateTime: DateTime?, contextValues: MutableMap&lt;String, String?>?, parameters: MutableMap&lt;String, Value?>?, capabilityStatement: IBaseConformance?, ): MutableList&lt;String></ID>
     <ID>CyclomaticComplexMethod:R5FhirModelResolver.kt$R5FhirModelResolver$override fun resolveType(typeName: String?): Class&lt;*>?</ID>
     <ID>CyclomaticComplexMethod:SearchParameterMap.kt$SearchParameterMap$fun toNormalizedQueryString(theCtx: FhirContext): String</ID>
@@ -86,6 +85,7 @@
     <ID>LongMethod:TestFHIRHelpers.kt$TestFHIRHelpers$@Test fun testFhirHelpers()</ID>
     <ID>LongMethod:TestFhirDataProviderDstu3.kt$TestFhirDataProviderDstu3$fun testContained()</ID>
     <ID>LongMethod:TestFhirPath.kt$TestFhirPath$protected fun runTest( test: Test, basePathInput: String?, fhirContext: FhirContext, provider: CompositeDataProvider?, resolver: FhirModelResolver&lt;*, *, *, *, *, *, *, *>, )</ID>
+    <ID>LongMethod:TestR4ModelResolver.kt$TestR4ModelResolver$@Test fun modelInfoSpecialCaseTests()</ID>
     <ID>LongParameterList:BaseFhirQueryGenerator.kt$BaseFhirQueryGenerator$( context: String?, contextPath: String?, contextValue: String?, dataType: String?, templateId: String?, codeFilters: MutableList&lt;CodeFilter>?, dateFilters: MutableList&lt;DateFilter>?, )</ID>
     <ID>LongParameterList:BaseFhirQueryGenerator.kt$BaseFhirQueryGenerator$( context: String?, contextPath: String?, contextValue: String?, dataType: String?, templateId: String?, codePath: String?, codes: Iterable&lt;Code?>?, valueSet: String?, datePath: String?, dateLowPath: String?, dateHighPath: String?, dateRange: Interval?, )</ID>
     <ID>LongParameterList:FhirQueryGeneratorFactory.kt$FhirQueryGeneratorFactory$( modelResolver: ModelResolver, searchParameterResolver: SearchParameterResolver, terminologyProvider: TerminologyProvider?, shouldExpandValueSets: Boolean?, maxCodesPerQuery: Int?, pageSize: Int?, queryBatchThreshold: Int?, )</ID>

--- a/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.kt
+++ b/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.kt
@@ -140,10 +140,8 @@ open class R4FhirModelResolver(fhirContext: FhirContext) :
             "ContractResourcePublicationStatusCodes" ->
                 typeName = $$"Contract$ContractPublicationStatus"
             "CurrencyCode" -> typeName = "CodeType"
-            "MedicationAdministrationStatus" -> typeName = "CodeType"
-            "MedicationDispenseStatus" -> typeName = "CodeType"
-            "MedicationKnowledgeStatus" -> typeName = "CodeType"
-            "Messageheader_Response_Request" -> typeName = "CodeType"
+            "Messageheader_Response_Request" ->
+                typeName = $$"MessageDefinition$MessageheaderResponseRequest"
             "MimeType" -> typeName = "CodeType"
             else -> {}
         }

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.kt
@@ -78,7 +78,7 @@ class TestDstu2ModelResolver {
         }
 
         for (enumType in enums) {
-            resolver.resolveType(enumType.getSimpleName())
+            resolver.resolveType(enumType.simpleName)
         }
     }
 
@@ -117,18 +117,18 @@ class TestDstu2ModelResolver {
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct
             // type to be created.
-            val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
+            val instance = resolver.createHapiInstance(enumType.simpleName) as Enumeration<*>?
             assertNotNull(instance)
 
             val enumFactory: Field?
             try {
                 enumFactory = instance.javaClass.getDeclaredField("myEnumFactory")
-                enumFactory.setAccessible(true)
+                enumFactory.isAccessible = true
                 val factory = enumFactory.get(instance) as EnumFactory<*>
 
                 assertEquals(
-                    factory.javaClass.getSimpleName().replace("EnumFactory", ""),
-                    enumType.getSimpleName(),
+                    factory.javaClass.simpleName.replace("EnumFactory", ""),
+                    enumType.simpleName,
                 )
             } catch (e: Exception) {
                 throw AssertionError("error getting factory type. " + e.message)

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.kt
@@ -3,6 +3,11 @@ package org.opencds.cqf.cql.engine.fhir.model
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import java.lang.reflect.Field
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.cqframework.cql.cql2elm.ModelManager
 import org.hl7.cql.model.ModelIdentifier
 import org.hl7.elm_modelinfo.r1.ClassInfo
@@ -10,15 +15,13 @@ import org.hl7.elm_modelinfo.r1.TypeInfo
 import org.hl7.fhir.dstu2.model.EnumFactory
 import org.hl7.fhir.dstu2.model.Enumeration
 import org.hl7.fhir.dstu2.model.Enumerations
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
 
 class TestDstu2ModelResolver {
     @Test
     fun resolverThrowsExceptionForUnknownType() {
         val resolver = Dstu2FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU2))
-        Assertions.assertThrows(UnknownType::class.java) {
+        assertFailsWith<UnknownType> {
             resolver.resolveType("ImpossibleTypeThatDoesn'tExistAndShouldBlowUp")
         }
     }
@@ -94,7 +97,7 @@ class TestDstu2ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (type in Enumerations.ResourceType.entries) {
@@ -108,22 +111,22 @@ class TestDstu2ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct
             // type to be created.
             val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
 
             val enumFactory: Field?
             try {
-                enumFactory = instance!!.javaClass.getDeclaredField("myEnumFactory")
+                enumFactory = instance.javaClass.getDeclaredField("myEnumFactory")
                 enumFactory.setAccessible(true)
                 val factory = enumFactory.get(instance) as EnumFactory<*>
 
-                Assertions.assertEquals(
+                assertEquals(
                     factory.javaClass.getSimpleName().replace("EnumFactory", ""),
                     enumType.getSimpleName(),
                 )
@@ -138,45 +141,40 @@ class TestDstu2ModelResolver {
         val resolver = Dstu2FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU2))
 
         var path = resolver.getContextPath("Patient", "Patient")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("id", path)
+        assertEquals("id", path)
 
         path = resolver.getContextPath(null, "Encounter")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         // TODO: Consider making this an exception on the resolver because
         // if this happens it means something went wrong in the context.
         path = resolver.getContextPath("Patient", null)
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "Condition")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("patient", path)
+        assertEquals("patient", path)
 
         path = resolver.getContextPath("Patient", "Appointment")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("participant.actor", path)
+        assertEquals("participant.actor", path)
 
         path = resolver.getContextPath("Patient", "Observation")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Encounter")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("patient", path)
+        assertEquals("patient", path)
 
         path = resolver.getContextPath("Patient", "MedicationStatement")
-        Assertions.assertEquals("patient", path)
+        assertEquals("patient", path)
 
         path = resolver.getContextPath("Patient", "QuestionnaireResponse")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         // Issue 527 - https://github.com/DBCG/cql_engine/issues/527
         path = resolver.getContextPath("Unfiltered", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Unspecified", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
     }
 
     companion object {

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.kt
@@ -60,7 +60,7 @@ internal class TestDstu3ModelResolver {
         }
 
         for (enumType in enums) {
-            resolver.resolveType(enumType.getSimpleName())
+            resolver.resolveType(enumType.simpleName)
         }
     }
 
@@ -182,12 +182,12 @@ internal class TestDstu3ModelResolver {
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct
             // type to be created.
-            val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
+            val instance = resolver.createHapiInstance(enumType.simpleName) as Enumeration<*>?
             assertNotNull(instance)
 
             assertEquals(
-                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
-                enumType.getSimpleName(),
+                instance.getEnumFactory().javaClass.simpleName.replace("EnumFactory", ""),
+                enumType.simpleName,
             )
         }
 

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.kt
@@ -3,8 +3,12 @@ package org.opencds.cqf.cql.engine.fhir.model
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.context.FhirVersionEnum
 import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.cqframework.cql.cql2elm.ModelManager
 import org.hl7.cql.model.ModelIdentifier
@@ -15,8 +19,6 @@ import org.hl7.fhir.dstu3.model.Enumeration
 import org.hl7.fhir.dstu3.model.Enumerations
 import org.hl7.fhir.dstu3.model.Patient
 import org.hl7.fhir.dstu3.model.Quantity
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
 import org.opencds.cqf.cql.engine.runtime.ClassInstance
 
@@ -24,7 +26,7 @@ internal class TestDstu3ModelResolver {
     @Test
     fun resolverThrowsExceptionForUnknownType() {
         val resolver = Dstu3FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU3))
-        Assertions.assertThrows(UnknownType::class.java) {
+        assertFailsWith<UnknownType> {
             resolver.resolveType("ImpossibleTypeThatDoesn'tExistAndShouldBlowUp")
         }
     }
@@ -95,21 +97,54 @@ internal class TestDstu3ModelResolver {
         val resolver = Dstu3FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU3))
 
         // This tests resolution of inner classes. They aren't registered directly.
-        resolver.resolveType("TestScriptRequestMethodCode")
-        resolver.resolveType("FHIRDeviceStatus")
+        assertEquals(
+            org.hl7.fhir.dstu3.model.TestScript.TestScriptRequestMethodCode::class.java,
+            resolver.resolveType("TestScriptRequestMethodCode"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Device.FHIRDeviceStatus::class.java,
+            resolver.resolveType("FHIRDeviceStatus"),
+        )
 
         // This tests the special case handling of "Codes".
-        resolver.resolveType("ImmunizationStatusCodes")
-        resolver.resolveType("ConditionClinicalStatusCodes")
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Immunization.ImmunizationStatus::class.java,
+            resolver.resolveType("ImmunizationStatusCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus::class.java,
+            resolver.resolveType("ConditionClinicalStatusCodes"),
+        )
 
         // These are oddballs requiring manual mapping.
-        resolver.resolveType("ConfidentialityClassification")
-        resolver.resolveType("ContractResourceStatusCodes")
-        resolver.resolveType("EventStatus")
-        resolver.resolveType("qualityType")
-        resolver.resolveType("FinancialResourceStatusCodes")
-        resolver.resolveType("repositoryType")
-        resolver.resolveType("SampledDataDataType")
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Composition.DocumentConfidentiality::class.java,
+            resolver.resolveType("ConfidentialityClassification"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Contract.ContractStatus::class.java,
+            resolver.resolveType("ContractResourceStatusCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Procedure.ProcedureStatus::class.java,
+            resolver.resolveType("EventStatus"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Sequence.QualityType::class.java,
+            resolver.resolveType("qualityType"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.ClaimResponse.ClaimResponseStatus::class.java,
+            resolver.resolveType("FinancialResourceStatusCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.Sequence.RepositoryType::class.java,
+            resolver.resolveType("repositoryType"),
+        )
+        assertEquals(
+            org.hl7.fhir.dstu3.model.StringType::class.java,
+            resolver.resolveType("SampledDataDataType"),
+        )
     }
 
     @Test
@@ -127,7 +162,7 @@ internal class TestDstu3ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (type in Enumerations.ResourceType.entries) {
@@ -141,17 +176,17 @@ internal class TestDstu3ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct
             // type to be created.
             val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
 
-            Assertions.assertEquals(
-                instance!!.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
+            assertEquals(
+                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
                 enumType.getSimpleName(),
             )
         }
@@ -160,10 +195,10 @@ internal class TestDstu3ModelResolver {
         // This list is not exhaustive. It's meant as a spot check for the resolution
         // code.
         var instance = resolver.createHapiInstance("TestScriptRequestMethodCode")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
 
         instance = resolver.createHapiInstance("FHIRDeviceStatus")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
     }
 
     @Test
@@ -171,51 +206,48 @@ internal class TestDstu3ModelResolver {
         val resolver = Dstu3FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU3))
 
         var path = resolver.getContextPath("Patient", "Patient")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("id", path)
+        assertEquals("id", path)
 
         path = resolver.getContextPath(null, "Encounter")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         // TODO: Consider making this an exception on the resolver because
         // if this happens it means something went wrong in the context.
         path = resolver.getContextPath("Patient", null)
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "Condition")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertNotNull(path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Appointment")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("participant.actor", path)
+        assertNotNull(path)
+        assertEquals("participant.actor", path)
 
         path = resolver.getContextPath("Patient", "Account")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Encounter")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "MedicationStatement")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Task")
-        Assertions.assertEquals("for", path)
+        assertEquals("for", path)
 
         path = resolver.getContextPath("Patient", "Coverage")
-        Assertions.assertEquals("beneficiary", path)
+        assertEquals("beneficiary", path)
 
         path = resolver.getContextPath("Patient", "QuestionnaireResponse")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         // Issue 527 - https://github.com/DBCG/cql_engine/issues/527
         path = resolver.getContextPath("Unfiltered", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Unspecified", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
     }
 
     @Test

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.kt
@@ -6,9 +6,12 @@ import java.math.BigDecimal
 import java.text.ParseException
 import java.util.*
 import javax.xml.namespace.QName
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.apache.commons.lang3.time.DateUtils
 import org.cqframework.cql.cql2elm.ModelManager
@@ -25,8 +28,6 @@ import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.Procedure
 import org.hl7.fhir.r4.model.Quantity
 import org.hl7.fhir.r4.model.VisionPrescription
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
 import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.Date
@@ -36,7 +37,7 @@ internal class TestR4ModelResolver {
     @Test
     fun resolverThrowsExceptionForUnknownType() {
         val resolver = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
-        Assertions.assertThrows(UnknownType::class.java) {
+        assertFailsWith<UnknownType> {
             resolver.resolveType("ImpossibleTypeThatDoesn'tExistAndShouldBlowUp")
         }
     }
@@ -78,37 +79,100 @@ internal class TestR4ModelResolver {
         val resolver = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
 
         // This tests resolution of inner classes. They aren't registered directly.
-        resolver.resolveType("TestScriptRequestMethodCode")
-        resolver.resolveType("FHIRDeviceStatus")
+        assertEquals(
+            org.hl7.fhir.r4.model.TestScript.TestScriptRequestMethodCode::class.java,
+            resolver.resolveType("TestScriptRequestMethodCode"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.Device.FHIRDeviceStatus::class.java,
+            resolver.resolveType("FHIRDeviceStatus"),
+        )
 
         // This tests the special case handling of "Codes".
-        resolver.resolveType("ImmunizationStatusCodes")
+        assertEquals(
+            org.hl7.fhir.r4.model.Immunization.ImmunizationStatus::class.java,
+            resolver.resolveType("ImmunizationStatusCodes"),
+        )
 
         // These have different capitalization conventions
-        resolver.resolveType("status")
-        resolver.resolveType("orientationType")
-        resolver.resolveType("strandType")
-        resolver.resolveType("sequenceType")
+        assertEquals(
+            org.hl7.fhir.r4.model.VerificationResult.Status::class.java,
+            resolver.resolveType("status"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MolecularSequence.OrientationType::class.java,
+            resolver.resolveType("orientationType"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MolecularSequence.StrandType::class.java,
+            resolver.resolveType("strandType"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MolecularSequence.SequenceType::class.java,
+            resolver.resolveType("sequenceType"),
+        )
 
         // These are oddballs requiring manual mapping. They may represent errors in the ModelInfo.
-        resolver.resolveType("ConfidentialityClassification")
-        resolver.resolveType("ContractResourceStatusCodes")
-        resolver.resolveType("EventStatus")
-        resolver.resolveType("FinancialResourceStatusCodes")
-        resolver.resolveType("SampledDataDataType")
-        resolver.resolveType("ClaimProcessingCodes")
-        resolver.resolveType("ContractResourcePublicationStatusCodes")
+        assertEquals(
+            org.hl7.fhir.r4.model.Composition.DocumentConfidentiality::class.java,
+            resolver.resolveType("ConfidentialityClassification"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.Contract.ContractStatus::class.java,
+            resolver.resolveType("ContractResourceStatusCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.Procedure.ProcedureStatus::class.java,
+            resolver.resolveType("EventStatus"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.ClaimResponse.ClaimResponseStatus::class.java,
+            resolver.resolveType("FinancialResourceStatusCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.StringType::class.java,
+            resolver.resolveType("SampledDataDataType"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.ClaimResponse.RemittanceOutcome::class.java,
+            resolver.resolveType("ClaimProcessingCodes"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.Contract.ContractPublicationStatus::class.java,
+            resolver.resolveType("ContractResourcePublicationStatusCodes"),
+        )
 
         // These are known glitches in the ModelInfo
-        resolver.resolveType("vConfidentialityClassification")
+        assertEquals(
+            org.hl7.fhir.r4.model.Composition.DocumentConfidentiality::class.java,
+            resolver.resolveType("vConfidentialityClassification"),
+        )
 
         // This is a mapping for a value set that doesn't have a first-class enumeration
-        resolver.resolveType("CurrencyCode")
-        resolver.resolveType("MedicationAdministrationStatus")
-        resolver.resolveType("MedicationDispenseStatus")
-        resolver.resolveType("MedicationKnowledgeStatus")
-        resolver.resolveType("Messageheader_Response_Request")
-        resolver.resolveType("MimeType")
+        assertEquals(
+            org.hl7.fhir.r4.model.CodeType::class.java,
+            resolver.resolveType("CurrencyCode"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MessageDefinition.MessageheaderResponseRequest::class.java,
+            resolver.resolveType("Messageheader_Response_Request"),
+        )
+        assertEquals(org.hl7.fhir.r4.model.CodeType::class.java, resolver.resolveType("MimeType"))
+
+        // These were previously incorrectly mapped to CodeType
+        assertEquals(
+            org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus::class
+                .java,
+            resolver.resolveType("MedicationAdministrationStatus"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MedicationDispense.MedicationDispenseStatus::class.java,
+            resolver.resolveType("MedicationDispenseStatus"),
+        )
+        assertEquals(
+            org.hl7.fhir.r4.model.MedicationKnowledge.MedicationKnowledgeStatus::class.java,
+            resolver.resolveType("MedicationKnowledgeStatus"),
+        )
     }
 
     @Test
@@ -197,7 +261,7 @@ internal class TestR4ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (type in Enumerations.ResourceType.entries) {
@@ -211,17 +275,17 @@ internal class TestR4ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct type to
             // be created.
             val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
 
-            Assertions.assertEquals(
-                instance!!.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
+            assertEquals(
+                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
                 enumType.getSimpleName(),
             )
         }
@@ -229,10 +293,10 @@ internal class TestR4ModelResolver {
         // These are some inner classes that don't appear in the enums above
         // This list is not exhaustive. It's meant as a spot check for the resolution code.
         var instance = resolver.createHapiInstance("TestScriptRequestMethodCode")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
 
         instance = resolver.createHapiInstance("FHIRDeviceStatus")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
     }
 
     @Test
@@ -240,54 +304,49 @@ internal class TestR4ModelResolver {
         val resolver = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
 
         var path = resolver.getContextPath("Patient", "Patient")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("id", path)
+        assertEquals("id", path)
 
         path = resolver.getContextPath(null, "Encounter")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         // TODO: Consider making this an exception on the resolver because
         // if this happens it means something went wrong in the context.
         path = resolver.getContextPath("Patient", null)
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "Condition")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Appointment")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("participant.actor", path)
+        assertEquals("participant.actor", path)
 
         path = resolver.getContextPath("Patient", "Account")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Encounter")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "ValueSet")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "MedicationStatement")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Task")
-        Assertions.assertEquals("for", path)
+        assertEquals("for", path)
 
         path = resolver.getContextPath("Patient", "Coverage")
-        Assertions.assertEquals("beneficiary", path)
+        assertEquals("beneficiary", path)
 
         path = resolver.getContextPath("Patient", "QuestionnaireResponse")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         // Issue 527 - https://github.com/DBCG/cql_engine/issues/527
         path = resolver.getContextPath("Unfiltered", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Unspecified", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
     }
 
     @Test
@@ -365,7 +424,7 @@ internal class TestR4ModelResolver {
         val patient = Patient()
         patient.setId(expectedId)
 
-        Assertions.assertEquals(resolver.resolveId(resolver.toCqlValue(patient)), expectedId)
+        assertEquals(expectedId, resolver.resolveId(resolver.toCqlValue(patient)))
     }
 
     @Test
@@ -405,23 +464,21 @@ internal class TestR4ModelResolver {
         val procedure = Procedure()
         procedure.setId(expectedId)
 
-        Assertions.assertEquals(resolver.resolveId(resolver.toCqlValue(procedure)), expectedId)
+        assertEquals(expectedId, resolver.resolveId(resolver.toCqlValue(procedure)))
     }
 
     @Test
     fun resolveIdStringReturnsNull() {
         val resolver = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
 
-        Assertions.assertNull(resolver.resolveId(Date(2000)))
+        assertNull(resolver.resolveId(Date(2000)))
     }
 
     @Test
     fun resolveIdStringTypeReturnsNull() {
         val resolver = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
 
-        Assertions.assertNull(
-            resolver.resolveId(org.opencds.cqf.cql.engine.runtime.String.EMPTY_STRING)
-        )
+        assertNull(resolver.resolveId(org.opencds.cqf.cql.engine.runtime.String.EMPTY_STRING))
     }
 
     companion object {

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.kt
@@ -70,7 +70,7 @@ internal class TestR4ModelResolver {
         }
 
         for (enumType in enums) {
-            resolver.resolveType(enumType.getSimpleName())
+            resolver.resolveType(enumType.simpleName)
         }
     }
 
@@ -281,12 +281,12 @@ internal class TestR4ModelResolver {
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct type to
             // be created.
-            val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
+            val instance = resolver.createHapiInstance(enumType.simpleName) as Enumeration<*>?
             assertNotNull(instance)
 
             assertEquals(
-                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
-                enumType.getSimpleName(),
+                instance.getEnumFactory().javaClass.simpleName.replace("EnumFactory", ""),
+                enumType.simpleName,
             )
         }
 

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.kt
@@ -5,9 +5,12 @@ import ca.uhn.fhir.context.FhirVersionEnum
 import java.math.BigDecimal
 import java.text.ParseException
 import java.util.*
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.apache.commons.lang3.time.DateUtils
 import org.cqframework.cql.shared.QName
@@ -18,8 +21,6 @@ import org.hl7.fhir.r5.model.Enumerations.FHIRTypes
 import org.hl7.fhir.r5.model.Patient
 import org.hl7.fhir.r5.model.Quantity
 import org.hl7.fhir.r5.model.VisionPrescription
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
 import org.opencds.cqf.cql.engine.runtime.ClassInstance
 import org.opencds.cqf.cql.engine.runtime.toCqlString
@@ -29,7 +30,7 @@ internal class TestR5ModelResolver {
     fun resolverThrowsExceptionForUnknownType() {
         val resolver = R5FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R5))
 
-        Assertions.assertThrows(UnknownType::class.java) {
+        assertFailsWith<UnknownType> {
             resolver.resolveType("ImpossibleTypeThatDoesn'tExistAndShouldBlowUp")
         }
     }
@@ -150,17 +151,17 @@ internal class TestR5ModelResolver {
 
             val instance = resolver.createHapiInstance(type.toCode())
 
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
         }
 
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct type to
             // be created.
             val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
-            Assertions.assertNotNull(instance)
+            assertNotNull(instance)
 
-            Assertions.assertEquals(
-                instance!!.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
+            assertEquals(
+                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
                 enumType.getSimpleName(),
             )
         }
@@ -168,10 +169,10 @@ internal class TestR5ModelResolver {
         // These are some inner classes that don't appear in the enums above
         // This list is not exhaustive. It's meant as a spot check for the resolution code.
         var instance = resolver.createHapiInstance("TestScriptRequestMethodCode")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
 
         instance = resolver.createHapiInstance("FHIRDeviceStatus")
-        Assertions.assertNotNull(instance)
+        assertNotNull(instance)
     }
 
     @Test
@@ -179,54 +180,49 @@ internal class TestR5ModelResolver {
         val resolver = R5FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R5))
 
         var path = resolver.getContextPath("Patient", "Patient")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("id", path)
+        assertEquals("id", path)
 
         path = resolver.getContextPath(null, "Encounter")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         // TODO: Consider making this an exception on the resolver because
         // if this happens it means something went wrong in the context.
         path = resolver.getContextPath("Patient", null)
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "Condition")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Appointment")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Account")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Encounter")
-        Assertions.assertNotNull(path)
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "ValueSet")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Patient", "MedicationStatement")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         path = resolver.getContextPath("Patient", "Task")
-        Assertions.assertEquals("for", path)
+        assertEquals("for", path)
 
         path = resolver.getContextPath("Patient", "Coverage")
-        Assertions.assertEquals("beneficiary", path)
+        assertEquals("beneficiary", path)
 
         path = resolver.getContextPath("Patient", "QuestionnaireResponse")
-        Assertions.assertEquals("subject", path)
+        assertEquals("subject", path)
 
         // Issue 527 - https://github.com/DBCG/cql_engine/issues/527
         path = resolver.getContextPath("Unfiltered", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
 
         path = resolver.getContextPath("Unspecified", "MedicationStatement")
-        Assertions.assertNull(path)
+        assertNull(path)
     }
 
     @Test

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/TestR5ModelResolver.kt
@@ -53,7 +53,7 @@ internal class TestR5ModelResolver {
         }
 
         for (enumType in enums) {
-            resolver.resolveType(enumType.getSimpleName())
+            resolver.resolveType(enumType.simpleName)
         }
     }
 
@@ -157,12 +157,12 @@ internal class TestR5ModelResolver {
         for (enumType in enums) {
             // For the enums we actually expect an Enumeration with a factory of the correct type to
             // be created.
-            val instance = resolver.createHapiInstance(enumType.getSimpleName()) as Enumeration<*>?
+            val instance = resolver.createHapiInstance(enumType.simpleName) as Enumeration<*>?
             assertNotNull(instance)
 
             assertEquals(
-                instance.getEnumFactory().javaClass.getSimpleName().replace("EnumFactory", ""),
-                enumType.getSimpleName(),
+                instance.getEnumFactory().javaClass.simpleName.replace("EnumFactory", ""),
+                enumType.simpleName,
             )
         }
 


### PR DESCRIPTION
* Fix type name overrides in `R4FhirModelResolver.resolveType()`. Previously, this method incorrectly returned `org.hl7.fhir.r4.model.CodeType` for the `MedicationAdministrationStatus`, `MedicationDispenseStatus`, `MedicationKnowledgeStatus`, and `Messageheader_Response_Request` type names. In HAPI FHIR R4, there are dedicated enums corresponding to these types, which should be returned instead:
```
org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus
org.hl7.fhir.r4.model.MedicationDispense.MedicationDispenseStatus
org.hl7.fhir.r4.model.MedicationKnowledge.MedicationKnowledgeStatus
org.hl7.fhir.r4.model.MessageDefinition.MessageheaderResponseRequest
```
Without the overrides, the first three are resolved correctly (using same resolution logic as, e.g. `FHIR.AdministrativeGender`). `FHIR.Messageheader_Response_Request` still needs to be manually mapped to the corresponding HAPI FHIR R4 enum.
* Update tests to include result checks for `resolveType()` calls.