### PR TITLE
Key evaluated resources by IDs

### DIFF
--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourceTestUtils.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/data/EvaluatedResourceTestUtils.kt
@@ -235,7 +235,7 @@ internal object EvaluatedResourceTestUtils {
         for (expressionName in expressionResults.keys) {
             val expressionResult: ExpressionResult = expressionResults[expressionName]!!
 
-            val actualEvaluatedResourcesForName = expressionResult.evaluatedResources!!
+            val actualEvaluatedResourcesForName = expressionResult.evaluatedResources.values
             val expectedEvaluatedResourcesForName = expectedEvaluatedResources[expressionName]!!
 
             assertResourcesEqual(expectedEvaluatedResourcesForName, actualEvaluatedResourcesForName)
@@ -253,7 +253,7 @@ internal object EvaluatedResourceTestUtils {
         expectedEvaluatedResources: Collection<IBaseResource>,
     ) {
         val expressionResult = evaluationResult[expressionName]
-        val actualEvaluatedResources = expressionResult!!.evaluatedResources!!
+        val actualEvaluatedResources = expressionResult!!.evaluatedResources.values
         val actualValue = expressionResult.value
 
         assertResourcesEqual(expectedEvaluatedResources, actualEvaluatedResources)
@@ -270,7 +270,7 @@ internal object EvaluatedResourceTestUtils {
         MatcherAssert.assertThat(evaluationResults, CoreMatchers.`is`(Matchers.notNullValue()))
         val evaluationResult = evaluationResults!!.getResultFor(libraryIdentifier)
         val expressionResult = evaluationResult!![expressionName]
-        val actualEvaluatedResources = expressionResult!!.evaluatedResources!!
+        val actualEvaluatedResources = expressionResult!!.evaluatedResources.values
         val actualValue = expressionResult.value
 
         assertResourcesEqual(expectedEvaluatedResources, actualEvaluatedResources)
@@ -288,7 +288,7 @@ internal object EvaluatedResourceTestUtils {
             CoreMatchers.`is`(Matchers.notNullValue()),
         )
         val expressionResult = evaluationResult!![expressionName]
-        val actualEvaluatedResources = expressionResult!!.evaluatedResources!!
+        val actualEvaluatedResources = expressionResult!!.evaluatedResources.values
         val actualValue = expressionResult.value
 
         assertResourcesEqual(expectedEvaluatedResources, actualEvaluatedResources)

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ExpressionDefEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/ExpressionDefEvaluator.kt
@@ -24,7 +24,7 @@ object ExpressionDefEvaluator {
 
             if (isExpressionCachingEnabled && isExpressionCached) {
                 val er = state.cache.getCachedExpression(libraryId, expressionDef.name)
-                state.evaluatedResources!!.addAll(er!!.evaluatedResources!!)
+                state.saveEvaluatedResources(er!!.evaluatedResources)
 
                 // TODO(jmoringe): make public interface
                 val frame = state.topActivationFrame

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/MessageEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/MessageEvaluator.kt
@@ -14,7 +14,6 @@ import org.opencds.cqf.cql.engine.runtime.List
 import org.opencds.cqf.cql.engine.runtime.String
 import org.opencds.cqf.cql.engine.runtime.Tuple
 import org.opencds.cqf.cql.engine.runtime.Value
-import org.opencds.cqf.cql.engine.runtime.getNamedTypeForCqlValue
 import org.opencds.cqf.cql.engine.runtime.systemModelNamespaceUri
 
 object MessageEvaluator {
@@ -88,12 +87,7 @@ object MessageEvaluator {
                 is Tuple,
                 is List ->
                     state!!.environment.resolveDataProviderByModelUriOrNull(systemModelNamespaceUri)
-                else ->
-                    state!!
-                        .environment
-                        .resolveDataProviderByModelUriOrNull(
-                            getNamedTypeForCqlValue(source)?.getNamespaceURI()
-                        )
+                else -> state!!.environment.resolveDataProvider(source)
             }
 
         return dataProvider?.phiObfuscationSupplier()?.invoke()?.obfuscate(source) ?: ""

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/RetrieveEvaluator.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/elm/executing/RetrieveEvaluator.kt
@@ -30,14 +30,9 @@ object RetrieveEvaluator {
                This whole block is a bit a hack in the sense that the need to switch to the context (e.g. Practitioner) identifies itself in a non-domain specific way
             */
             val contextValue = visitor.visitExpression(context, state)!!
-            val dataProvider =
-                state!!
-                    .environment
-                    .resolveDataProviderByModelUri(
-                        getNamedTypeForCqlValue(contextValue)?.getNamespaceURI()
-                    )
+            val dataProvider = state!!.environment.resolveDataProvider(contextValue)
             val contextTypeName = getNamedTypeForCqlValue(contextValue)!!.getLocalPart()
-            val contextId = dataProvider.resolveId(contextValue)
+            val contextId = dataProvider?.resolveId(contextValue)
 
             state.setContextValue(contextTypeName, contextId)
             isEnteredContext = state.enterContext(contextTypeName)
@@ -109,7 +104,7 @@ object RetrieveEvaluator {
             // TODO: We probably shouldn't eagerly load this, but we need to track
             // this throughout the engine and only add it to the list when it's actually used
             if (result != null) {
-                state.evaluatedResources!!.addAll(result)
+                state.saveEvaluatedResources(result)
             }
         } finally {
             // Need to effectively reverse the context change we did at the beginning of this method

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/Environment.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/Environment.kt
@@ -11,6 +11,7 @@ import org.opencds.cqf.cql.engine.data.ExternalFunctionProvider
 import org.opencds.cqf.cql.engine.data.SystemDataProvider
 import org.opencds.cqf.cql.engine.exception.CqlException
 import org.opencds.cqf.cql.engine.runtime.Value
+import org.opencds.cqf.cql.engine.runtime.getNamedTypeForCqlValue
 import org.opencds.cqf.cql.engine.runtime.systemModelNamespaceUri
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider
 
@@ -77,6 +78,14 @@ constructor(
         dataProviders[modelUri] = dataProvider
     }
 
+    /** Returns the data provider for the type of the given CQL [Value]. */
+    fun resolveDataProvider(value: Value?): DataProvider? {
+        return resolveDataProviderByModelUriOrNull(
+            getNamedTypeForCqlValue(value)?.getNamespaceURI()
+        )
+    }
+
+    /** Returns the data provider for the given [QName] type. */
     @JsName("resolveDataProviderByQName")
     fun resolveDataProvider(dataType: QName): DataProvider {
         var dataType = dataType
@@ -84,11 +93,15 @@ constructor(
         return resolveDataProviderByModelUri(dataType.getNamespaceURI())
     }
 
+    /** Returns the data provider registered for the given model URI. */
     fun resolveDataProviderByModelUri(modelUri: String?): DataProvider {
         return resolveDataProviderByModelUriOrNull(modelUri)
             ?: throw CqlException("Could not resolve data provider for model '${modelUri}'.")
     }
 
+    /**
+     * Returns the data provider registered for the given model URI, or null if none is registered.
+     */
     fun resolveDataProviderByModelUriOrNull(modelUri: String?): DataProvider? {
         return dataProviders[modelUri]
     }

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/ExpressionResult.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/ExpressionResult.kt
@@ -3,5 +3,11 @@ package org.opencds.cqf.cql.engine.execution
 import org.cqframework.cql.shared.JsOnlyExport
 import org.opencds.cqf.cql.engine.runtime.Value
 
+/** Represent the result of evaluating an expression. */
 @JsOnlyExport
-class ExpressionResult(val value: Value?, val evaluatedResources: MutableSet<Value?>?)
+class ExpressionResult(
+    /** The value of the expression. */
+    val value: Value?,
+    /** The evaluated resources, keyed by their string IDs. */
+    val evaluatedResources: Map<kotlin.String, Value>,
+)

--- a/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
+++ b/engine/src/commonMain/kotlin/org/opencds/cqf/cql/engine/execution/State.kt
@@ -140,7 +140,11 @@ constructor(
      */
     @Volatile var currentCallSite: Element? = null
 
-    private val evaluatedResourceStack = ArrayDeque<MutableSet<Value?>>()
+    /**
+     * In each entry of the stack, the resources are keyed by their string IDs. Previously, the
+     * evaluated resources were stored in a set, which caused poor performance.
+     */
+    private val evaluatedResourceStack = ArrayDeque<MutableMap<kotlin.String, Value>>()
 
     val parameters = mutableMapOf<kotlin.String, Value?>()
     var contextValues = mutableMapOf<kotlin.String, kotlin.String?>()
@@ -502,13 +506,10 @@ constructor(
             return null
         }
 
-    val evaluatedResources: MutableSet<Value?>?
+    val evaluatedResources: Map<kotlin.String, Value>
         get() {
-            check(!evaluatedResourceStack.isEmpty()) {
-                "Attempted to get the evaluatedResource stack when it's empty"
-            }
-
             return this.evaluatedResourceStack.firstOrNull()
+                ?: error("Attempted to get the evaluatedResource stack when it's empty")
         }
 
     fun clearEvaluatedResources() {
@@ -517,7 +518,7 @@ constructor(
     }
 
     fun pushEvaluatedResourceStack() {
-        evaluatedResourceStack.addFirst(HashSet<Value?>())
+        evaluatedResourceStack.addFirst(mutableMapOf())
     }
 
     /**
@@ -537,6 +538,32 @@ constructor(
         carryOverEvaluatedResourcesUpCallStack()
     }
 
+    /**
+     * Adds the resource to the top of the evaluated resource stack, keyed by its string ID. The
+     * resource is only stored if it is not null and has a non-null ID.
+     */
+    fun saveEvaluatedResource(resource: Value?) {
+        if (resource != null) {
+            val dataProvider = environment.resolveDataProvider(resource)
+            val id = dataProvider?.resolveId(resource)
+            if (id != null) {
+                this.evaluatedResourceStack.first()[id] = resource
+            }
+        }
+    }
+
+    /** Adds the resources to the top of the evaluated resource stack, keyed by their string IDs. */
+    fun saveEvaluatedResources(resources: Iterable<Value?>) {
+        for (resource in resources) {
+            saveEvaluatedResource(resource)
+        }
+    }
+
+    /** Adds the resources keyed by their string IDs to the top of the evaluated resource stack. */
+    fun saveEvaluatedResources(resources: Map<kotlin.String, Value>) {
+        this.evaluatedResourceStack.first().putAll(resources)
+    }
+
     private fun carryOverEvaluatedResourcesUpCallStack() {
         val previousStackEvaluatedResources = evaluatedResourceStack.removeFirst()
         val currentStackEvaluatedResources = evaluatedResourceStack.firstOrNull()
@@ -544,7 +571,7 @@ constructor(
         checkNotNull(currentStackEvaluatedResources) {
             "Attempted to carry over evaluated resources when the current stack is empty"
         }
-        currentStackEvaluatedResources.addAll(previousStackEvaluatedResources)
+        currentStackEvaluatedResources.putAll(previousStackEvaluatedResources)
     }
 
     fun resolveAlias(name: String?): Value? {

--- a/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResultTest.kt
+++ b/engine/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/execution/EvaluationResultTest.kt
@@ -10,7 +10,7 @@ class EvaluationResultTest {
     fun getterAndSetterTest() {
         val evaluationResult = EvaluationResult()
         val expressionRef = EvaluationExpressionRef("expr1")
-        val expressionResult = ExpressionResult(5.toCqlInteger(), null)
+        val expressionResult = ExpressionResult(5.toCqlInteger(), emptyMap())
 
         // Test setting and getting by reference
         evaluationResult[expressionRef] = expressionResult


### PR DESCRIPTION
Currently, the evaluated resources are tracked in a `HashSet<Value>` where the hash needs to be built for every added resouce.

This PR changes `ExpressionResult.evaluatedResources` from `Set<Value>` to `Map<kotlin.String, Value>` where the resources are keyed by their string IDs.

For every evaluated resource, the ID is resloved using `ModelResolver.resolveId(evaluatedResource)`. For FHIR resources, the model resolver returns the [`Resource.id`](https://hl7.org/fhir/R4/resource-definitions.html#Resource.id) value.