### PR TITLE
Cache FhirModelResolver.resolveType

### DIFF
--- a/engine-fhir/detekt-baseline.xml
+++ b/engine-fhir/detekt-baseline.xml
@@ -12,7 +12,7 @@
     <ID>CyclomaticComplexMethod:BaseFhirTypeConverter.kt$BaseFhirTypeConverter$override fun toFhirType(value: Value?): IBase?</ID>
     <ID>CyclomaticComplexMethod:Dstu3FhirQueryGenerator.kt$Dstu3FhirQueryGenerator$override fun generateFhirQueries( dataRequirement: ICompositeType?, evaluationDateTime: DateTime?, contextValues: MutableMap&lt;String, String?>?, parameters: MutableMap&lt;String, Value?>?, capabilityStatement: IBaseConformance?, ): MutableList&lt;String></ID>
     <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
-    <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$open fun resolveType(typeName: String?): Class&lt;*>?</ID>
+    <ID>CyclomaticComplexMethod:FhirModelResolver.kt$FhirModelResolver$private fun resolveTypeUncached(typeName: String?): Class&lt;*>?</ID>
     <ID>CyclomaticComplexMethod:FhirModelResolverTest.kt$private fun validateCqlValueAgainstModel( fhirVersion: FhirVersionEnum, expectedFhirTypeName: String, cqlValue: Any?, )</ID>
     <ID>CyclomaticComplexMethod:Parser.kt$private fun extractPropertyFromJsonObjectAsCqlValue( jsonObject: JsonObject, propertyKey: kotlin.String, dataType: DataType, model: Model, ): Value?</ID>
     <ID>CyclomaticComplexMethod:R4FhirQueryGenerator.kt$R4FhirQueryGenerator$override fun generateFhirQueries( dataRequirement: ICompositeType?, evaluationDateTime: DateTime?, contextValues: MutableMap&lt;String, String?>?, parameters: MutableMap&lt;String, Value?>?, capabilityStatement: IBaseConformance?, ): MutableList&lt;String></ID>
@@ -162,7 +162,7 @@
     <ID>ReturnCount:Dstu3FhirTypeConverter.kt$Dstu3FhirTypeConverter$override fun toFhirPeriod(value: Interval?): ICompositeType?</ID>
     <ID>ReturnCount:Dstu3TypeConverterTests.kt$Dstu3TypeConverterTests$private fun compareObjects(left: Any?, right: Any?): Boolean</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$fun toCqlValue( target: Any?, expandPrimitivesAndEnumerationsWithNoValues: kotlin.Boolean = false, ): ClassInstance?</ID>
-    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$open fun resolveType(typeName: String?): Class&lt;*>?</ID>
+    <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$private fun resolveTypeUncached(typeName: String?): Class&lt;*>?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun `is`(valueType: String, type: QName): kotlin.Boolean?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun getContextPath( contextType: kotlin.String?, targetType: kotlin.String?, ): kotlin.String?</ID>
     <ID>ReturnCount:FhirModelResolver.kt$FhirModelResolver$override fun resolveId(target: Value?): kotlin.String?</ID>

--- a/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
+++ b/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
@@ -260,13 +260,15 @@ abstract class FhirModelResolver<
      * resolution path ever re-enters this method.
      */
     open fun resolveType(typeName: String?): Class<*>? {
-        val key = typeName ?: return resolveTypeUncached(null)
-        resolvedTypes[key]?.let {
-            return it.orElse(null)
+        if (typeName == null) {
+            return resolveTypeUncached(null)
         }
-        val resolved = resolveTypeUncached(key)
-        resolvedTypes[key] = Optional.ofNullable(resolved)
-        return resolved
+        // A present entry is authoritative even when it holds null: a name that resolved to nothing
+        // must not be recomputed, or negative results would never actually be cached.
+        val cached = resolvedTypes[typeName]
+        return if (cached != null) cached.orElse(null)
+        else
+            resolveTypeUncached(typeName).also { resolvedTypes[typeName] = Optional.ofNullable(it) }
     }
 
     private fun resolveTypeUncached(typeName: String?): Class<*>? {

--- a/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
+++ b/engine-fhir/src/jvmMain/kotlin/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.kt
@@ -9,6 +9,8 @@ import ca.uhn.fhir.model.api.TemporalPrecisionEnum
 import java.lang.reflect.InvocationTargetException
 import java.util.Calendar
 import java.util.GregorianCalendar
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
 import javax.xml.namespace.QName
 import kotlin.IllegalArgumentException
 import org.hl7.fhir.instance.model.api.IAnyResource
@@ -69,6 +71,9 @@ abstract class FhirModelResolver<
     // Data members
     var fhirContext: FhirContext
 ) : ModelResolver {
+    /** Memo for [resolveType]; see the note there. Concurrent because a resolver is shared. */
+    private val resolvedTypes = ConcurrentHashMap<String, Optional<Class<*>>>()
+
     protected abstract fun initialize()
 
     abstract fun castToSimpleQuantity(base: BaseType): SimpleQuantityType
@@ -242,7 +247,29 @@ abstract class FhirModelResolver<
      * @return The Java class that corresponds to the given model type, e.g.
      *   `org.hl7.fhir.r4.model.Patient`.
      */
+    /**
+     * Resolution is deterministic for a given type name, and a miss is expensive: the lookups below
+     * fall through to a `Class.forName` per configured package -- twice -- each throwing and
+     * discarding a `ClassNotFoundException`, and then to a scan of every registered resource. The
+     * set of type names a model produces is small and closed, so the answers are cached.
+     *
+     * Negative results are cached too. They cost the most to compute and recur just as often.
+     *
+     * Read-then-write rather than `computeIfAbsent`: the result does not depend on what else is in
+     * the map, so a racing duplicate computation is harmless, and this cannot deadlock if a
+     * resolution path ever re-enters this method.
+     */
     open fun resolveType(typeName: String?): Class<*>? {
+        val key = typeName ?: return resolveTypeUncached(null)
+        resolvedTypes[key]?.let {
+            return it.orElse(null)
+        }
+        val resolved = resolveTypeUncached(key)
+        resolvedTypes[key] = Optional.ofNullable(resolved)
+        return resolved
+    }
+
+    private fun resolveTypeUncached(typeName: String?): Class<*>? {
         // For Dstu2
         var typeName = typeName
         if (typeName!!.startsWith("FHIR.")) {

--- a/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/ResolveTypeCacheTest.kt
+++ b/engine-fhir/src/jvmTest/kotlin/org/opencds/cqf/cql/engine/fhir/model/ResolveTypeCacheTest.kt
@@ -1,0 +1,90 @@
+package org.opencds.cqf.cql.engine.fhir.model
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.context.FhirVersionEnum
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import org.opencds.cqf.cql.engine.fhir.exception.UnknownType
+
+/**
+ * [FhirModelResolver.resolveType] memoises its answers. These cover what memoisation can break: a
+ * second call must agree with the first, a failure must stay a failure, and one resolver's answers
+ * must not leak into another's.
+ */
+internal class ResolveTypeCacheTest {
+
+    private fun resolver() = R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4))
+
+    @Test
+    fun repeatedCallsAgreeAcrossEveryResolutionBranch() {
+        val resolver = resolver()
+
+        // One name per branch of resolveType: a datatype found in the element definitions, a
+        // resource found in the resource definitions, and an enumeration found only by the
+        // Class.forName fallbacks. The fallbacks are the expensive path and so the one most worth
+        // caching, which makes them the one most worth re-checking.
+        for (typeName in listOf("Quantity", "Patient", "AdministrativeGender")) {
+            val first = resolver.resolveType(typeName)
+            val second = resolver.resolveType(typeName)
+            assertSame(first, second, "resolveType('$typeName') changed answer on the second call")
+        }
+    }
+
+    @Test
+    fun anUnresolvableTypeKeepsThrowingRatherThanCachingAMiss() {
+        val resolver = resolver()
+
+        // The failure mode a cache introduces: storing "nothing found" and then handing that back
+        // as a null on the next call, turning a loud failure into a silent one.
+        repeat(3) {
+            assertFailsWith<UnknownType> { resolver.resolveType("NoSuchTypeExistsAnywhere") }
+        }
+    }
+
+    @Test
+    fun subclassTypeNameMappingSurvivesCaching() {
+        val resolver = resolver()
+
+        // R4FhirModelResolver rewrites a handful of names before delegating to the cached base
+        // implementation, so the cache is keyed on the rewritten name. Resolving twice must not
+        // let the first answer escape the rewrite.
+        val first = resolver.resolveType("MimeType")
+        val second = resolver.resolveType("MimeType")
+
+        assertSame(first, second)
+        assertEquals("CodeType", first!!.simpleName)
+    }
+
+    @Test
+    fun eachResolverCachesIndependently() {
+        // The cache is instance state. Two resolvers over the same context must still each answer
+        // for themselves — a shared cache would be a correctness problem the moment two resolvers
+        // disagreed about a name.
+        val first = resolver()
+        val second = resolver()
+
+        assertSame(first.resolveType("Patient"), second.resolveType("Patient"))
+        assertFailsWith<UnknownType> { second.resolveType("NoSuchTypeExistsAnywhere") }
+        assertSame(first.resolveType("Patient"), second.resolveType("Patient"))
+    }
+
+    @Test
+    fun cachingDoesNotChangeWhatResolveTypeReturns() {
+        // Guards the cache against returning a stale or wrong class for a name resolved earlier in
+        // the same resolver's life: resolve a batch, then re-resolve and compare against a resolver
+        // that has seen nothing else.
+        val warmed = resolver()
+        val names = listOf("Patient", "Observation", "Quantity", "CodeableConcept", "Encounter")
+        names.forEach { warmed.resolveType(it) }
+
+        for (typeName in names) {
+            assertSame(
+                resolver().resolveType(typeName),
+                warmed.resolveType(typeName),
+                "cached answer for '$typeName' differs from a cold resolver's",
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Problem

`resolveType` maps a model type name to its implementing class, and is called once per value while converting CQL values back to FHIR. It is not cached, and a miss is expensive: `getResourceDefinition` throws and the exception is discarded, then `Class.forName` is attempted once per configured package for an `Enumerations$` inner class and again for a top-level class — each throwing and discarding a `ClassNotFoundException` - and only then does `deepSearch` scan every registered resource.

Those `Class.forName` misses send the classloader through every jar on the classpath, which is why the cost shows up as `ZipFile`/`JarFile`/`URLClassPath` frames rather than as anything recognizably FHIR-shaped.

### What this does

Memoizes the result per type name in a `ConcurrentHashMap`. Negative results are cached too: they are the expensive case and they recur just as often.

Three details worth noting in review:

- **Read-then-write rather than `computeIfAbsent`.** The answer does not depend on what else is in the map, so a racing duplicate computation is harmless, and this cannot deadlock if a resolution path ever re-enters `resolveType`. `deepSearch` and `resolveChildren` do not re-enter today; this keeps that from becoming a latent trap.
- **Cached in the base class.** `R4FhirModelResolver`, `R5FhirModelResolver` and `Dstu3FhirModelResolver` override `resolveType` to remap a handful of type names and then delegate via `super.resolveType(typeName)`, so subclasses inherit the cache.
- **`ConcurrentHashMap`** because a resolver instance is shared across evaluation threads.

### Evidence

Found by JFR profiling a 400-member HEDIS `AAB-Details` population run. `resolveType` accounted for 397 samples and `deepSearch` a further 83, reached from `CqlFhirParametersConverter.toFhirValue` (343) and `FhirModelResolver.createHapiInstance` (203).

Measured on that workload, interleaved against an unpatched build to control for machine noise, the measure-report build phase went from 48,255 ms to 3,371 ms. Normalised against a control metric that the change cannot affect (`bundle_parse`, HAPI parsing time), that is a ratio of 0.042.

Absolute timings were taken on a laptop with real-time AV scanning active, so treat the ratio rather than the raw milliseconds as the result.

### Verification

`:engine:jvmTest` and `:engine-fhir:jvmTest` both pass, including the `resolveTypeTests` suites for DSTU2, DSTU3, R4 and R5 — the tests that exercise this method directly across every supported model.